### PR TITLE
Core and Yul for match on word values

### DIFF
--- a/src/Language/Core.hs
+++ b/src/Language/Core.hs
@@ -2,7 +2,7 @@
 {-# OPTIONS_GHC -Wincomplete-patterns #-}
 {-# LANGUAGE InstanceSigs #-}
 module Language.Core
-  ( Expr(..), Stmt(..), Arg(..), Alt(..), Con(..), Contract(..), Core(..)
+  ( Expr(..), Stmt(..), Arg(..), Alt(..), pattern ConAlt, Pat(..), Con(..), Contract(..), Core(..)
   , module Language.Core.Types
   ,  pattern SAV
   , Name
@@ -51,8 +51,13 @@ instance Show Arg where show = render . ppr
 instance Show Stmt where show :: Stmt -> String
                          show = render . ppr
 
-data Alt = Alt Con Name Stmt
-data Con = CInl | CInr | CInK Int
+data Alt = Alt Pat Name Stmt deriving Show
+pattern ConAlt :: Con -> Name -> Stmt -> Alt
+pattern ConAlt c n s = Alt (PCon c) n s
+
+data Pat = PVar Name | PCon Con | PWildcard | PIntLit Integer
+  deriving Show
+data Con = CInl | CInr | CInK Int deriving Show
 
 data Contract = Contract { ccName :: Name, ccStmts ::  [Stmt] }
 
@@ -110,6 +115,12 @@ instance Pretty Stmt where
         <+> text "->" <+> ppr ret
         <+> lbrace $$ nest 2 (vcat (map ppr stmts))  $$ rbrace
     ppr (SRevert s) = text "revert" <+> text (show s)
+
+instance Pretty Pat where
+    ppr (PVar x) = text x
+    ppr (PCon c) = ppr c
+    ppr PWildcard = text "_"
+    ppr (PIntLit i) = integer i
 
 instance Pretty Alt where
     ppr (Alt c n s) = ppr c <+> text n <+> text "=>" <+> ppr s

--- a/src/Solcore/Desugarer/EmitCore.hs
+++ b/src/Solcore/Desugarer/EmitCore.hs
@@ -379,8 +379,8 @@ emitSumMatch allCons scrutinee alts = do
         rightBranch t = error ("rightBranch: not a sum type: " ++ show t)
         left = altName False
         right = altName True
-        alt con n [stmt] = Core.Alt con n stmt
-        alt con n stmts = Core.Alt con n (Core.SBlock stmts)
+        alt con n [stmt] = Core.ConAlt con n stmt
+        alt con n stmts = Core.ConAlt con n (Core.SBlock stmts)
 
         body [stmt] = stmt
         body stmts = Core.SBlock stmts

--- a/yule/Compress.hs
+++ b/yule/Compress.hs
@@ -50,16 +50,17 @@ compressMatch cty@(TSumN ts) top@(SMatch ty e alts) = SMatch ty' e' (go 0 top) w
     ty' = compress ty
     e' = compress e
     arity = length ts
+    alt = ConAlt
     go k s@(SMatch t@(TNamed n ty) e alts) = go k (SMatch ty e alts)
-    go k s@(SMatch t@(TSum lty rty) e [Alt CInl ln left, Alt CInr rn right])
+    go k s@(SMatch t@(TSum lty rty) e [ConAlt CInl ln left, ConAlt CInr rn right])
        -- last two alternatives in the chain
-       | k == arity-2 = [Alt (CInK k )ln left', Alt (CInK (k+1)) rn right']
+       | k == arity-2 = [alt (CInK k )ln left', alt (CInK (k+1)) rn right']
        -- not reached the end of the chain yet
        | otherwise = firstAlt:rest
        where
         left' = compress left
         right' = compress right
-        firstAlt = Alt (CInK k) ln left'
+        firstAlt = alt (CInK k) ln left'
         rest = go (k+1) right
     go k (SBlock [s]) = go k s
     go k s = error $ concat["compressMatch unimplemented for k=",show k," stmt: ", show s]

--- a/yule/Translate.hs
+++ b/yule/Translate.hs
@@ -186,7 +186,7 @@ genNAlts :: Location -> [Alt] -> TM [(YLiteral, [YulStmt])]
 genNAlts payload alts = do mapM (genAlt payload) alts
 
 genAlt :: Location -> Alt -> TM (YLiteral, [YulStmt])
-genAlt payload (Alt con name stmt) = withLocalEnv do
+genAlt payload (Alt (PCon con) name stmt) = withLocalEnv do
     insertVar name payload
     yulStmts <- genStmt stmt
     pure (yulCon con, yulStmts)
@@ -194,6 +194,8 @@ genAlt payload (Alt con name stmt) = withLocalEnv do
         yulCon CInl = YulFalse
         yulCon CInr = YulTrue
         yulCon (CInK k) = YulNumber (fromIntegral k)
+genAlt _ alt = error ("genAlt unimplemented for: " ++ show alt)
+
 
 allocVar :: Core.Name -> Type -> TM [YulStmt]
 allocVar name TWord = do

--- a/yule/Translate.hs
+++ b/yule/Translate.hs
@@ -120,8 +120,8 @@ genStmt (SMatch sty e alts) = do
      where
         genSwitch :: Location -> Location -> [Alt] -> TM [YulStmt]
         genSwitch tag payload alts = do
-            yulAlts <- genNAlts payload alts
-            pure [YSwitch (loadLoc tag) yulAlts Nothing]
+            (yulAlts, yulDefault) <- genNAlts payload alts
+            pure [YSwitch (loadLoc tag) yulAlts yulDefault]
 
 genStmt (SFunction name args ret stmts) = withLocalEnv do
     debug ["> SFunction: ", name, " ", show args, " -> ", show ret]
@@ -182,18 +182,32 @@ genBinAlts payload [Alt lcon lname lstmt, Alt rcon rname rstmt] = do
 genBinAlts _ alts = error("genAlts: invalid number of alternatives:\n" 
                           ++ unlines(map (render . ppr) alts) )
 
-genNAlts :: Location -> [Alt] -> TM [(YLiteral, [YulStmt])]
-genNAlts payload alts = do mapM (genAlt payload) alts
+genNAlts :: Location -> [Alt] -> TM (YulCases, YulDefault)
+genNAlts payload alts = do
+    results <- mapM (genAlt payload) alts
+    return(gather results)
+    where
+      gather = foldr combine ([], Nothing)
+      combine (Left (tag, stmts)) (cases, def) = ((tag, stmts):cases, def)
+      combine (Right stmts) (cases, def) = (cases, Just stmts)      
 
-genAlt :: Location -> Alt -> TM (YLiteral, [YulStmt])
+
+genAlt :: Location -> Alt -> TM (Either YulCase YulBlock)
 genAlt payload (Alt (PCon con) name stmt) = withLocalEnv do
     insertVar name payload
     yulStmts <- genStmt stmt
-    pure (yulCon con, yulStmts)
+    pure (Left(yulCon con, yulStmts))
     where
         yulCon CInl = YulFalse
         yulCon CInr = YulTrue
         yulCon (CInK k) = YulNumber (fromIntegral k)
+genAlt payload (Alt (PIntLit k) _ stmt) = withLocalEnv do
+    yulStmts <- genStmt stmt
+    pure (Left(YulNumber (fromIntegral k), yulStmts))
+genAlt payload (Alt (PVar name) _ stmt) = do
+    insertVar name payload
+    yulStmts <- genStmt stmt
+    pure (Right yulStmts)
 genAlt _ alt = error ("genAlt unimplemented for: " ++ show alt)
 
 


### PR DESCRIPTION
this allows for example (see `test/examples/spec/025tobool.solc`)

```
function toBool(x: word) {
  match x {
    | 0 => return False;
    | _ => return True;
  };
}
```


