### PR TITLE
Generate Yul objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
 # Experimental compiler for the new Solidity language
 
+# Usage
+## Compiling
 
+    $ cabal exec -- sol-core -f test/examples/spec/022add.solc
+
+(writes to output.core)
+
+## Running
+
+### Using HEVM
+
+    $ cabal run yule -- output.core -o Input.yul
+    $ solc --strict-assembly --bin --optimize Input.yul | tail -1 > Output.hex
+    $ hevm exec --code $(cat Output.hex) | awk -f parse_hevm_output.awk
+    Return: 42
+    hex: 0x000000000000000000000000000000000000000000000000000000000000002a
+
+The file `testsol.sh` defines bash functions `hevmcore` and `hevmsol` that perform these steps from core and solc source respectively.
+
+### Using Foundry
+
+    $ cabal run yule -- output.core -w -o Output.sol
+      found main
+      writing output to Output.sol
+    $ forge script Output.sol
+    Script ran successfully.
+    Gas used: 24910
+
+    == Logs ==
+    RESULT -->  42
+
+
+The file `testsol.sh` defines bash functions `testcore` and `testsol` that perform these steps from core and solc source respectively.

--- a/src/Language/Yul.hs
+++ b/src/Language/Yul.hs
@@ -18,13 +18,6 @@ newtype Yul = Yul { yulStmts :: [YulStmt] }
 newtype YulCode = YulCode YulBlock
 
 instance {-# OVERLAPPABLE #-} Pretty a => Show a where show = render . ppr
-{-
-instance Show Yul where show = render . ppr
-instance Show YulStmt where show = render . ppr
-instance Show YulExp where show = render . ppr
-instance Show YLiteral where show = render . ppr
-instance Show YulData where show = render . ppr
--}
 
 instance Semigroup Yul where
   Yul a <> Yul b = Yul (a <> b)
@@ -163,31 +156,3 @@ instance Pretty HexOrString where
   ppr (DHex s) = text "hex" <> doubleQuotes (text s)
   ppr (DString s) = doubleQuotes (text s)
 
-
--- sample code
-fnUsrAdd :: YulStmt
-fnUsrAdd = YFun "usr$add" ["x", "y"] (YReturns ["result"])
-        [ YAssign ["result"] (YCall "add" [YIdent "x", YIdent "y"])]
-
-fnUsrMain :: YulStmt
-fnUsrMain = YFun "usr$main" [] (YReturns ["result"])
-        [ YAssign1 "result" (YCall "usr$add" [yulInt 40, yulInt 2])]
-
-sampleCode :: YulCode
-sampleCode = YulCode
-            [ fnUsrAdd
-            , fnUsrMain
-            , YulAlloc "z"
-            , YAssign1 "z" (YCall "usr$main" [])
-            , YExp $ YCall "mstore" [yulInt 0, YIdent "z"]
-            , YExp $ YCall "return" [yulInt 0, yulInt 32]
-            ]
-
-sampleObject :: YulObject
-sampleObject = YulObject "Add" sampleCode []
-
-
-sampleNestedObject :: YulObject
-sampleNestedObject = YulObject "Nested" sampleCode
-                        [  InnerObject sampleObject
-                        , InnerData $ YulData "Table1" (DHex "4123")]

--- a/src/Language/Yul.hs
+++ b/src/Language/Yul.hs
@@ -166,34 +166,6 @@ instance Pretty HexOrString where
 -- commaSepList :: Pretty a => [a] -> Doc
 -- commaSepList = hsep . punctuate comma . map ppr
 
-{- | wrap a Yul chunk in a Solidity function with the given name
-   assumes result is in a variable named "_result"
--}
-wrapInSolFunction :: Pretty a => Name -> a -> Doc
-wrapInSolFunction name yul = text "function" <+> ppr name <+> prettyargs <+> text " public pure returns (uint256 _wrapresult)" <+> lbrace
-  $$ nest 2 assembly
-  $$ rbrace
-  where
-    assembly = text "assembly" <+> lbrace
-      $$ nest 2 (ppr yul)
-      $$ rbrace
-    prettyargs = parens empty
-
-wrapInContract :: Name -> Name -> Doc -> Doc
-wrapInContract name entry body = empty
-  $$ text "// SPDX-License-Identifier: UNLICENSED"
-  $$ text "pragma solidity ^0.8.23;"
-  $$ text "import {console,Script} from \"lib/stdlib.sol\";"
-  $$ text "contract" <+> ppr name <+> text "is Script"<+> lbrace
-  $$ nest 2 run
-  $$ nest 2 body
-  $$ rbrace
-
-  where
-    run = text "function run() public view" <+> lbrace
-      $$ nest 2 (text "console.log(\"RESULT --> \","<+> ppr entry >< text ");")
-      $$ rbrace $$ text ""
-
 -- sample code
 fnUsrAdd :: YulStmt
 fnUsrAdd = YFun "usr$add" ["x", "y"] (YReturns ["result"])

--- a/src/Language/Yul.hs
+++ b/src/Language/Yul.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE UndecidableInstances #-} -- for generic Pretty a => Show a
+
+
 module Language.Yul where
 import Data.Generics (Data, Typeable)
 
@@ -6,13 +9,22 @@ import Common.Pretty
 import Solcore.Frontend.Syntax.Name
 
 import Solcore.Frontend.Pretty.Name
-
+data YulObject = YulObject String YulCode [YulInner]
+data YulInner = InnerObject YulObject | InnerData YulData
+data YulData =  YulData String HexOrString
+data HexOrString = DHex String | DString String
 
 newtype Yul = Yul { yulStmts :: [YulStmt] }
+newtype YulCode = YulCode YulBlock
+
+instance {-# OVERLAPPABLE #-} Pretty a => Show a where show = render . ppr
+{-
 instance Show Yul where show = render . ppr
 instance Show YulStmt where show = render . ppr
 instance Show YulExp where show = render . ppr
 instance Show YLiteral where show = render . ppr
+instance Show YulData where show = render . ppr
+-}
 
 instance Semigroup Yul where
   Yul a <> Yul b = Yul (a <> b)
@@ -74,13 +86,31 @@ yulBool False = YLit YulFalse
 
 
 -- auxilliary functions
+
+hlist, vlist, nvlist :: Pretty a => [a] -> Doc
 hlist = hsep . map ppr
 vlist = vcat . map ppr
 nvlist = nest 2 . vlist
 pprBlock stmts = lbrace $$ nvlist stmts $$ rbrace
 
+
+instance Pretty YulObject where
+  ppr (YulObject name code inners) = vcat
+    [ text "object" <+> doubleQuotes(text name) <+> lbrace
+    , nest 2 $ ppr code
+    , nvlist inners
+    , rbrace
+    ]
+
+instance Pretty YulInner where
+  ppr (InnerObject obj) = ppr obj
+  ppr (InnerData dat) = ppr dat
+
 instance Pretty Yul where
   ppr (Yul stmts) = vcat (map ppr stmts)
+
+instance Pretty YulCode where
+  ppr (YulCode block) = (text "code" <+> lbrace) $$ nvlist block $$ rbrace
 
 instance Pretty YulStmt where
   ppr (YBlock stmts) = pprBlock stmts
@@ -126,6 +156,13 @@ instance Pretty YLiteral where
   ppr YulTrue = text "true"
   ppr YulFalse = text "false"
 
+instance Pretty YulData where
+  ppr (YulData name val) = hsep [text "data", doubleQuotes $ text name , ppr val]
+
+instance Pretty HexOrString where
+  ppr (DHex s) = text "hex" <> doubleQuotes (text s)
+  ppr (DString s) = doubleQuotes (text s)
+
 -- commaSepList :: Pretty a => [a] -> Doc
 -- commaSepList = hsep . punctuate comma . map ppr
 
@@ -156,3 +193,31 @@ wrapInContract name entry body = empty
     run = text "function run() public view" <+> lbrace
       $$ nest 2 (text "console.log(\"RESULT --> \","<+> ppr entry >< text ");")
       $$ rbrace $$ text ""
+
+-- sample code
+fnUsrAdd :: YulStmt
+fnUsrAdd = YFun "usr$add" ["x", "y"] (YReturns ["result"])
+        [ YAssign ["result"] (YCall "add" [YIdent "x", YIdent "y"])]
+
+fnUsrMain :: YulStmt
+fnUsrMain = YFun "usr$main" [] (YReturns ["result"])
+        [ YAssign1 "result" (YCall "usr$add" [yulInt 40, yulInt 2])]
+
+sampleCode :: YulCode
+sampleCode = YulCode
+            [ fnUsrAdd
+            , fnUsrMain
+            , YulAlloc "z"
+            , YAssign1 "z" (YCall "usr$main" [])
+            , YExp $ YCall "mstore" [yulInt 0, YIdent "z"]
+            , YExp $ YCall "return" [yulInt 0, yulInt 32]
+            ]
+
+sampleObject :: YulObject
+sampleObject = YulObject "Add" sampleCode []
+
+
+sampleNestedObject :: YulObject
+sampleNestedObject = YulObject "Nested" sampleCode
+                        [  InnerObject sampleObject
+                        , InnerData $ YulData "Table1" (DHex "4123")]

--- a/src/Language/Yul.hs
+++ b/src/Language/Yul.hs
@@ -163,8 +163,6 @@ instance Pretty HexOrString where
   ppr (DHex s) = text "hex" <> doubleQuotes (text s)
   ppr (DString s) = doubleQuotes (text s)
 
--- commaSepList :: Pretty a => [a] -> Doc
--- commaSepList = hsep . punctuate comma . map ppr
 
 -- sample code
 fnUsrAdd :: YulStmt

--- a/test/examples/cases/undefined.solc
+++ b/test/examples/cases/undefined.solc
@@ -1,7 +1,7 @@
 forall any.function undefined() -> any {
   assembly {
     revert(0,0)
-  };
+  }
 }
 
 function useWord(w:word) {}

--- a/testsol.sh
+++ b/testsol.sh
@@ -1,0 +1,56 @@
+function esolc() {
+    file=$1
+    echo $file
+    shift
+    cabal run sol-core -- -f $file $*
+}
+
+function testsol() {
+    file=$1
+    echo $file
+    shift
+    cabal run sol-core -- -f $file $* && \
+	cabal exec yule -- output.core -w -O > /dev/null && \
+    forge script Output.sol | grep RESULT
+}
+
+function testspec() {
+    file=$1
+    echo $file
+    shift
+    cabal exec sol-core -- -f $file --debug-spec --dump-spec $*
+#    cabal run yule -- output.core -O && \
+#    forge script Output.sol
+}
+
+
+function testcore() {
+    echo $1
+    cabal exec yule -- $1 -w -O && forge script Output.sol | grep RESULT
+}
+
+function hevmcore() {
+     local base=$(basename $1 .core)
+     local yulfile=$base.yul
+     echo $yulfile
+     cabal exec yule -- $1 -o $yulfile
+     local hexfile=$base.hex
+     solc --strict-assembly --bin --optimize $yulfile | tail -1 > $hexfile
+     hevm exec --code $(cat $hexfile) | awk -f parse_hevm_output.awk
+}
+
+function hevmsol() {
+    file=$1
+    echo $file
+    local base=$(basename $1 .solc)
+    local core=output.core
+    local hexfile=$base.hex
+    local yulfile=$base.yul
+    echo Hex: $hexfile
+    shift
+    cabal exec sol-core -- -f $file $* && \
+	cabal exec yule -- $core -O -o $yulfile && \
+        solc --strict-assembly --bin --optimize $yulfile | tail -1 > $hexfile && \
+        hevm exec --code $(cat $hexfile) | awk -f parse_hevm_output.awk
+
+}

--- a/yule/Main.hs
+++ b/yule/Main.hs
@@ -37,9 +37,9 @@ main = do
     generatedYul <- runTM options (translateStmts source)
     let name = fromString (ccName coreContract)
 
-    let doc = if Options.wrap options
-        then wrapInSol name generatedYul
-        else wrapInObject name generatedYul
+    let doc = if Options.yof options
+        then wrapInObject name generatedYul
+        else wrapInSol name generatedYul
     putStrLn (render doc)
     putStrLn ("writing output to " ++ Options.output options)
     writeFile (Options.output options) (render doc)

--- a/yule/Main.hs
+++ b/yule/Main.hs
@@ -40,7 +40,6 @@ main = do
     let doc = if Options.yof options
         then wrapInObject name generatedYul
         else wrapInSol name generatedYul
-    putStrLn (render doc)
     putStrLn ("writing output to " ++ Options.output options)
     writeFile (Options.output options) (render doc)
 

--- a/yule/Main.hs
+++ b/yule/Main.hs
@@ -1,13 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 import Language.Core(Contract(..))
-import Language.Core.Parser
-import Common.Pretty(Pretty(..), nest, render)
+import Language.Core.Parser(parseContract)
+import Solcore.Frontend.Syntax.Name  -- FIXME: move Name to Common
+import Solcore.Frontend.Pretty.Name
+import Common.Pretty -- (Doc, Pretty(..), nest, render)
+import qualified Common.Pretty as Pretty
 import Builtins(yulBuiltins)
 import Compress
 import TM
 import Translate
-import Language.Yul(wrapInSolFunction, wrapInContract)
+import Language.Yul
 import qualified Options
 import Options(parseOptions)
 import Control.Monad(when)
@@ -32,8 +35,56 @@ main = do
         putStrLn "Compressing sums"
         putStrLn (render (nest 2 (ppr source)))
     generatedYul <- runTM options (translateStmts source)
-    let fooFun = wrapInSolFunction "wrapper" (yulBuiltins <> generatedYul)
-    let doc = wrapInContract (fromString (ccName coreContract)) "wrapper()" fooFun
-    -- putStrLn (render doc)
+    let name = fromString (ccName coreContract)
+
+    let doc = if Options.wrap options
+        then wrapInSol name generatedYul
+        else wrapInObject name generatedYul
+    putStrLn (render doc)
     putStrLn ("writing output to " ++ Options.output options)
     writeFile (Options.output options) (render doc)
+
+-- wrap in a Yul object with the given name
+wrapInObject :: Name -> Yul -> Doc
+wrapInObject name yul = ppr object where
+    object = YulObject (show name) (YulCode stmts) []
+    stmts = yulStmts yul ++ retcode
+    retcode =
+      [ call "mstore" [yulInt 0, YIdent "_mainresult"]
+      , call "return" [yulInt 0, yulInt 32]
+      ]
+    call f args = YExp (YCall f args)
+
+{- | wrap a Yul chunk in a Solidity function with the given name
+   assumes result is in a variable named "_result"
+-}
+
+wrapInSol name yul = wrapInContract name "wrapper()" wrapper
+    where
+        wrapper = wrapInSolFunction "wrapper" (yulBuiltins <> yul)
+
+wrapInSolFunction :: Name -> Yul -> Doc
+wrapInSolFunction name yul =
+  text "function" <+> ppr name <+> prettyargs <+> text " public pure returns (uint256 _wrapresult)" <+> lbrace
+  $$ nest 2 assembly
+  $$ rbrace
+  where
+    yul' = yul <> Yul [YAssign1 "_wrapresult" (YIdent "_mainresult")]
+    assembly = text "assembly" <+> lbrace
+      $$ nest 2 (ppr yul')
+      $$ rbrace
+    prettyargs = parens empty
+
+wrapInContract ::  Name -> Name -> Doc -> Doc
+wrapInContract name entry body = empty
+  $$ text "// SPDX-License-Identifier: UNLICENSED"
+  $$ text "pragma solidity ^0.8.23;"
+  $$ text "import {console,Script} from \"lib/stdlib.sol\";"
+  $$ text "contract" <+> ppr name <+> text "is Script"<+> lbrace
+  $$ nest 2 run
+  $$ nest 2 body
+  $$ rbrace
+  where
+    run = text "function run() public view" <+> lbrace
+      $$ nest 2 (text "console.log(\"RESULT --> \","<+> ppr entry >< text ");")
+      $$ rbrace $$ text ""

--- a/yule/Main.hs
+++ b/yule/Main.hs
@@ -37,9 +37,10 @@ main = do
     generatedYul <- runTM options (translateStmts source)
     let name = fromString (ccName coreContract)
 
-    let doc = if Options.yof options
-        then wrapInObject name generatedYul
-        else wrapInSol name generatedYul
+    let doc = if Options.wrap options
+        then wrapInSol name generatedYul
+        else wrapInObject name generatedYul
+    putStrLn (render doc)
     putStrLn ("writing output to " ++ Options.output options)
     writeFile (Options.output options) (render doc)
 

--- a/yule/Main.hs
+++ b/yule/Main.hs
@@ -33,14 +33,12 @@ main = do
     let source = if oCompress then compress core else core
     when oCompress $ do
         putStrLn "Compressing sums"
-        putStrLn (render (nest 2 (ppr source)))
     generatedYul <- runTM options (translateStmts source)
     let name = fromString (ccName coreContract)
 
     let doc = if Options.wrap options
         then wrapInSol name generatedYul
         else wrapInObject name generatedYul
-    putStrLn (render doc)
     putStrLn ("writing output to " ++ Options.output options)
     writeFile (Options.output options) (render doc)
 

--- a/yule/Options.hs
+++ b/yule/Options.hs
@@ -9,7 +9,7 @@ data Options = Options
     , verbose :: Bool
     , debug :: Bool
     , compress :: Bool
-    , yof :: Bool
+    , wrap :: Bool
     } deriving Show
 
 optionsParser :: Parser Options
@@ -49,9 +49,9 @@ optionsParser = Options
         <> help "Compress sums (experimental)"
         )
     <*> switch
-        ( long "yof"
-        <> short 'y'
-        <> help "Output a bare Yul object"
+        ( long "wrap"
+        <> short 'w'
+        <> help "Wrap Yul in a Solidity contract"
         )
 
 parseOptions :: IO Options

--- a/yule/Options.hs
+++ b/yule/Options.hs
@@ -9,7 +9,7 @@ data Options = Options
     , verbose :: Bool
     , debug :: Bool
     , compress :: Bool
-    , wrap :: Bool
+    , yof :: Bool
     } deriving Show
 
 optionsParser :: Parser Options
@@ -49,9 +49,9 @@ optionsParser = Options
         <> help "Compress sums (experimental)"
         )
     <*> switch
-        ( long "wrap"
-        <> short 'w'
-        <> help "Wrap Yul in a Solidity contract"
+        ( long "yof"
+        <> short 'y'
+        <> help "Output a bare Yul object"
         )
 
 parseOptions :: IO Options

--- a/yule/Options.hs
+++ b/yule/Options.hs
@@ -9,6 +9,7 @@ data Options = Options
     , verbose :: Bool
     , debug :: Bool
     , compress :: Bool
+    , wrap :: Bool
     } deriving Show
 
 optionsParser :: Parser Options
@@ -46,6 +47,11 @@ optionsParser = Options
         ( long "compress"
         <> short 'O'
         <> help "Compress sums (experimental)"
+        )
+    <*> switch
+        ( long "wrap"
+        <> short 'w'
+        <> help "Wrap Yul in a Solidity contract"
         )
 
 parseOptions :: IO Options

--- a/yule/Translate.hs
+++ b/yule/Translate.hs
@@ -305,7 +305,7 @@ normalizeLoc loc = loc
 genStmts :: [Stmt] -> TM [YulStmt]
 genStmts stmts = do
     mapM_ scanStmt stmts   -- scan for functions and record their types
-    concat <$> mapM genStmtWithComment stmts
+    concat <$> mapM genStmt stmts
 
 translateCore :: Core -> TM Yul
 translateCore (Core stmts) = translateStmts stmts

--- a/yule/Translate.hs
+++ b/yule/Translate.hs
@@ -312,7 +312,7 @@ translateCore (Core stmts) = translateStmts stmts
 
 translateStmts :: [Stmt] -> TM Yul
 translateStmts stmts = do
-    -- assuming the result goes into `_wrapresult`
+    -- assuming the result goes into `_mainresult`
     let hasMain = any isMain stmts
     if hasMain
       then writeln "found main"
@@ -320,7 +320,8 @@ translateStmts stmts = do
     let stmts' = if hasMain then stmts else addMain stmts
     payload <- genStmts stmts'
     let resultExp = YCall (yulFunName "main") []
-    let epilog = [YAssign1 "_wrapresult" resultExp]
+    let epilog = [ YLet ["_mainresult"] (Just resultExp)
+                 ]
     return $ Yul ( payload ++ epilog )
 
 


### PR DESCRIPTION
First stab at generating Yul objects (no dispatch/deploy, everything in init code as we discussed)

# Usage
## Compiling

    $ cabal exec -- sol-core -f test/examples/spec/022add.solc

(writes to output.core)

## Running 

### Using HEVM

    $ cabal run yule -- output.core -o Input.yul
    $ solc --strict-assembly --bin --optimize Input.yul | tail -1 > Output.hex
    $ hevm exec --code $(cat Output.hex) | awk -f parse_hevm_output.awk
    Return: 42
    hex: 0x000000000000000000000000000000000000000000000000000000000000002a

The file `testsol.sh` defines bash functions `hevmcore` and `hevmsol` that perform these steps from core and solc source respectively

### Using Foundry

    $ cabal run yule -- output.core -w -o Output.sol
      found main
      writing output to Output.sol
    $ forge script Output.sol
    Script ran successfully.
    Gas used: 24910

    == Logs ==
    RESULT -->  42

