### PR TITLE
no-desugar-calls option; make options available in the typechecker monad

### DIFF
--- a/sol-core.cabal
+++ b/sol-core.cabal
@@ -76,6 +76,7 @@ library
       Solcore.Frontend.TypeInference.TcStmt
       Solcore.Frontend.TypeInference.TcSubst
       Solcore.Frontend.TypeInference.TcUnify
+      Solcore.Pipeline.Options
       Solcore.Pipeline.SolcorePipeline
       Solcore.Primitives.Primitives
       Language.Core

--- a/src/Solcore/Frontend/TypeInference/TcEnv.hs
+++ b/src/Solcore/Frontend/TypeInference/TcEnv.hs
@@ -11,6 +11,7 @@ import Solcore.Frontend.TypeInference.Id
 import Solcore.Frontend.TypeInference.NameSupply
 import Solcore.Frontend.TypeInference.TcSubst
 import Solcore.Frontend.TypeInference.TcUnify
+import Solcore.Pipeline.Options
 import Solcore.Primitives.Primitives
 
 
@@ -58,7 +59,7 @@ type TypeTable = Table TypeInfo
 type Inst = Qual Pred 
 type InstTable = Table [Inst] 
 
-data TcEnv 
+data TcEnv
   = TcEnv {
       ctx :: Env               -- Variable environment
     , instEnv :: InstTable     -- Instance Environment
@@ -81,31 +82,34 @@ data TcEnv
     , boundVariable :: PragmaStatus -- Disable bound variable condition for names.
     , maxRecursionDepth :: Int -- max recursion depth in 
                                -- context reduction
+    , tcOptions :: Option
     }
 
-initTcEnv :: UniqueTyMap -> TcEnv 
-initTcEnv utm 
-  = TcEnv primCtx 
-          primInstEnv
-          primTypeEnv
-          primClassEnv 
-          Nothing 
-          mempty
-          namePool
-          (Map.union utm primDataType)
-          [ Name "primAddWord"
-          , Name "primEqWord"
-          ]
-          True
-          []
-          0
-          []
-          []
-          True 
-          Enabled 
-          Enabled
-          Enabled  
-          100
+initTcEnv :: Option -> UniqueTyMap -> TcEnv
+initTcEnv options utm
+  = TcEnv { ctx = primCtx
+          , instEnv = primInstEnv
+          , typeTable = primTypeEnv
+          , classTable = primClassEnv
+          , contract = Nothing
+          , subst = mempty
+          , nameSupply = namePool
+          , uniqueTypes = Map.union utm primDataType
+          , directCalls = [ Name "primAddWord"
+                          , Name "primEqWord"
+                          ]
+          , generateDefs = True
+          , generated = []
+          , counter = 0
+          , logs = []
+          , warnings = []
+          , enableLog = True
+          , coverage = Enabled
+          , patterson = Enabled
+          , boundVariable = Enabled
+          , maxRecursionDepth = 100
+          , tcOptions = options
+          }
 
 primCtx :: Env 
 primCtx 

--- a/src/Solcore/Frontend/TypeInference/TcMonad.hs
+++ b/src/Solcore/Frontend/TypeInference/TcMonad.hs
@@ -18,6 +18,7 @@ import Solcore.Frontend.TypeInference.NameSupply
 import Solcore.Frontend.TypeInference.TcEnv
 import Solcore.Frontend.TypeInference.TcSubst
 import Solcore.Frontend.TypeInference.TcUnify
+import Solcore.Pipeline.Options(Option(..))
 import Solcore.Primitives.Primitives
 
 
@@ -484,6 +485,14 @@ disableBoundVariableCondition m
 
 askMaxRecursionDepth :: TcM Int 
 askMaxRecursionDepth = gets maxRecursionDepth 
+
+-- other options
+
+getTcOpts :: TcM Option
+getTcOpts = gets tcOptions
+
+getNoDesugarCalls :: TcM Bool
+getNoDesugarCalls = gets (optNoDesugarCalls. tcOptions)
 
 -- logging utilities
 

--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -210,8 +210,11 @@ tcExp e@(Lam args bd _)
            t1 = apply s (unskol t')
            vs = fv ps1 `union` fv t1 `union` fv ts1
            ty = funtype ts1 t1
-       (e, t) <- closureConversion vs (apply s args') (apply s bd') ps1 ty 
-       pure (e, ps1, t)
+       noDesugarCalls <- getNoDesugarCalls
+       if noDesugarCalls then pure (Lam args' bd' (Just t1), ps1, ty)
+       else do
+         (e, t) <- closureConversion vs (apply s args') (apply s bd') ps1 ty
+         pure (e, ps1, t)
 tcExp e1@(TyExp e ty)
   = do
       kindCheck ty `wrapError` e1

--- a/src/Solcore/Pipeline/Options.hs
+++ b/src/Solcore/Pipeline/Options.hs
@@ -1,0 +1,58 @@
+module Solcore.Pipeline.Options where
+import Options.Applicative
+
+
+data Option
+  = Option
+    { fileName :: FilePath
+    , optNoSpec :: !Bool
+    , optNoDesugarCalls :: !Bool
+    -- Options controlling printing
+    , optVerbose :: !Bool
+    , optDumpDS :: !Bool
+    , optDumpDF :: !Bool
+    , optDumpSpec :: !Bool
+    , optDumpCore :: !Bool
+    -- Options controlling diagnostic output
+    , optDebugSpec :: !Bool
+    , optDebugCore :: !Bool
+    } deriving (Eq, Show)
+
+options :: Parser Option
+options
+  = Option <$> strOption (
+                  long "file"
+               <> short 'f'
+               <> metavar "FILE"
+               <> help "Input file name")
+           <*> switch ( long "no-specialise"
+               <> short 'n'
+               <> help "Skip specialisation and core emission phases")
+           <*> switch ( long "no-desugar-calls"
+               <> short 's'
+               <> help "Skip indirect call desugaring")
+           -- Options controlling printing
+           <*> switch ( long "verbose"
+               <> short 'v'
+               <> help "Verbose output")
+           <*> switch ( long "dump-ds"
+               <> help "Dump desugared contract")
+           <*> switch ( long "dump-df"
+               <> help "Dump defunctionalised contract")
+           <*> switch ( long "dump-spec"
+               <> help "Dump specialised contract")
+           <*> switch ( long "dump-core"
+               <> help "Dump low-level core")
+           -- Options controlling diagnostic output
+           <*> switch ( long "debug-spec"
+               <> help "Debug specialisation")
+           <*> switch ( long "debug-core"
+               <> help "Debug core emission")
+
+-- parsing command line arguments           
+argumentsParser :: IO Option
+argumentsParser = do
+  let opts = info (options <**> helper)
+                  (fullDesc <>
+                   header "Solcore - solidity core language")
+  execParser opts

--- a/src/Solcore/Pipeline/SolcorePipeline.hs
+++ b/src/Solcore/Pipeline/SolcorePipeline.hs
@@ -4,8 +4,6 @@ import Control.Monad
 
 import qualified Data.Map as Map
 
-import Options.Applicative
-
 import Solcore.Desugarer.IndirectCall (indirectCall)
 import Solcore.Desugarer.LambdaLifting (lambdaLifting)
 import Solcore.Desugarer.MatchCompiler
@@ -14,14 +12,14 @@ import Solcore.Frontend.Lexer.SolcoreLexer
 import Solcore.Frontend.Parser.SolcoreParser
 import Solcore.Frontend.Pretty.SolcorePretty
 import Solcore.Frontend.Syntax.ElabTree
-import Solcore.Frontend.Syntax.Contract 
+import Solcore.Frontend.Syntax.Contract
 import Solcore.Frontend.Syntax
 import Solcore.Frontend.TypeInference.SccAnalysis
 import Solcore.Frontend.TypeInference.TcContract
 import Solcore.Frontend.TypeInference.TcEnv
 import Solcore.Desugarer.Specialise(specialiseCompUnit)
 import Solcore.Desugarer.EmitCore(emitCore)
-
+import Solcore.Pipeline.Options(Option(..), argumentsParser)
 import System.Exit
 
 -- main compiler driver function
@@ -30,32 +28,42 @@ pipeline :: IO ()
 pipeline = do
   opts <- argumentsParser
   let verbose = optVerbose opts
+  let noDesugarCalls = optNoDesugarCalls opts
   content <- readFile (fileName opts)
-  t' <- runParser content 
+  t' <- runParser content
   withErr t' $ \ ast@(CompUnit imps ds) -> do
-    when verbose $ do 
+    when verbose $ do
       putStrLn "> AST after name resolution"
       putStrLn $ pretty ast
-    (ast0, mdt) <- uniqueTypeGen ast 
-    when verbose $ do 
-      putStrLn "> Unique type generation"
-      putStrLn $ pretty ast0 
-    r2 <- sccAnalysis ast0
-    withErr r2 $ \ ast' -> do
-      when verbose $ do 
-        putStrLn "> SCC Analysis:"
-        putStrLn $ pretty ast'
-      ast3 <- indirectCall mdt ast'
-      when verbose $ do 
-        putStrLn "> Indirect call desugaring:"
-        putStrLn $ pretty ast3
-      r5 <- typeInfer mdt ast3
-      withErr r5 $ \ (c', env) -> do
+    r5 <- if noDesugarCalls
+      then do
+        r2 <- sccAnalysis ast
+        withErr r2 $ \ ast' -> do
+          when verbose $ do
+            putStrLn "> SCC Analysis:"
+            putStrLn $ pretty ast'
+          typeInfer opts Map.empty ast'
+      else do
+        (ast0, mdt) <- uniqueTypeGen ast
+        when verbose $ do
+          putStrLn "> Unique type generation"
+          putStrLn $ pretty ast0
+        r2 <- sccAnalysis ast0
+        withErr r2 $ \ ast' -> do
+          when verbose $ do
+            putStrLn "> SCC Analysis:"
+            putStrLn $ pretty ast'
+          ast3 <- indirectCall mdt ast'
+          when verbose $ do
+            putStrLn "> Indirect call desugaring:"
+            putStrLn $ pretty ast3
+          typeInfer opts mdt ast3
+    withErr r5 $ \ (c', env) -> do
         let warns = warnings env
             logsInfo = logs env
-            tyctx = ctx env 
-            ts = generated env 
-        when verbose $ do  
+            tyctx = ctx env
+            ts = generated env
+        when verbose $ do
           putStrLn "> Type inference logs:"
           mapM_ putStrLn (reverse $ logsInfo)
           putStrLn "> Elaborated tree:"
@@ -76,97 +84,45 @@ pipeline = do
               forM_ r10 (putStrLn . pretty)
 
 runParser :: String -> IO (Either String (CompUnit Name))
-runParser content = do 
-  let r1 = runAlex content parser 
-  case r1 of 
-    Left err -> pure $ Left err 
-    Right t -> do 
+runParser content = do
+  let r1 = runAlex content parser
+  case r1 of
+    Left err -> pure $ Left err
+    Right t -> do
       buildAST t
 
-withErr :: Either String a -> (a -> IO ()) -> IO ()
-withErr r f 
+withErr :: Either String a -> (a -> IO b) -> IO b
+withErr r f
   = either err f r
-    where 
-      err s = do 
-                putStrLn s 
+    where
+      err s = do
+                putStrLn s
                 exitWith (ExitFailure 1)
 
--- add declarations generated in the previous step 
--- and moving data types inside contracts to the 
--- global scope. 
+-- add declarations generated in the previous step
+-- and moving data types inside contracts to the
+-- global scope.
 
-moveData :: CompUnit Name -> CompUnit Name 
-moveData (CompUnit imps decls) 
+moveData :: CompUnit Name -> CompUnit Name
+moveData (CompUnit imps decls)
   = CompUnit imps (foldr step [] decls)
-    where 
-      step (TContr c) ac 
-        = let (dts, c') = extractData c 
-              dts' = map TDataDef dts 
-          in (TContr c') : dts' ++ ac  
-      step d ac = d : ac 
+    where
+      step (TContr c) ac
+        = let (dts, c') = extractData c
+              dts' = map TDataDef dts
+          in (TContr c') : dts' ++ ac
+      step d ac = d : ac
 
 extractData :: Contract Name -> ([DataTy], Contract Name)
 extractData (Contract n ts ds)
-  = (ds1, Contract n ts ds0) 
-    where 
-      (ds1, ds0) = foldr step ([], []) ds 
+  = (ds1, Contract n ts ds0)
+    where
+      (ds1, ds0) = foldr step ([], []) ds
       step (CDataDecl dt) (dts, cs) = (dt : dts, cs)
       step c (dts, cs) = (dts, c : cs)
 
-addGenerated :: CompUnit Name -> 
-                [TopDecl Name] -> 
-                CompUnit Name 
+addGenerated :: CompUnit Name ->
+                [TopDecl Name] ->
+                CompUnit Name
 addGenerated (CompUnit imps ds) ts
-  = CompUnit imps (ds ++ ts) 
-
--- parsing command line arguments
-
-data Option
-  = Option
-    { fileName :: FilePath
-    , optNoSpec :: !Bool
-    -- Options controlling printing
-    , optVerbose :: !Bool
-    , optDumpDS :: !Bool
-    , optDumpDF :: !Bool
-    , optDumpSpec :: !Bool
-    , optDumpCore :: !Bool
-    -- Options controlling diagnostic output
-    , optDebugSpec :: !Bool
-    , optDebugCore :: !Bool
-    } deriving (Eq, Show)
-
-options :: Parser Option
-options
-  = Option <$> strOption (
-                  long "file"
-               <> short 'f'
-               <> metavar "FILE"
-               <> help "Input file name")
-           <*> switch ( long "no-specialise"
-               <> short 'n'
-               <> help "Skip specialisation and core emission phases")
-           -- Options controlling printing
-           <*> switch ( long "verbose"
-               <> short 'v'
-               <> help "Verbose output")
-           <*> switch ( long "dump-ds"
-               <> help "Dump desugared contract")
-           <*> switch ( long "dump-df"
-               <> help "Dump defunctionalised contract")
-           <*> switch ( long "dump-spec"
-               <> help "Dump specialised contract")
-           <*> switch ( long "dump-core"
-               <> help "Dump low-level core")
-           -- Options controlling diagnostic output
-           <*> switch ( long "debug-spec"
-               <> help "Debug specialisation")
-           <*> switch ( long "debug-core"
-               <> help "Debug core emission")
-argumentsParser :: IO Option
-argumentsParser = do
-  let opts = info (options <**> helper)
-                  (fullDesc <>
-                   header "Solcore - solidity core language")
-  opt <- execParser opts
-  return opt
+  = CompUnit imps (ds ++ ts)


### PR DESCRIPTION
Adds the option `--no-desugar-calls` that disables indirect call desugaring.
It also makes program options available in the typechecking monad (TcM) via `getTcOpts`
Options aremoved to a separate `Solcore.Pipeline.Options` module.