### PR TITLE
Adding an option for disabling match compilation.

### DIFF
--- a/src/Solcore/Pipeline/Options.hs
+++ b/src/Solcore/Pipeline/Options.hs
@@ -7,6 +7,7 @@ data Option
     { fileName :: FilePath
     , optNoSpec :: !Bool
     , optNoDesugarCalls :: !Bool
+    , optNoMatchCompiler :: !Bool
     -- Options controlling printing
     , optVerbose :: !Bool
     , optDumpDS :: !Bool
@@ -24,6 +25,7 @@ emptyOption path = Option
     { fileName          = path
     , optNoSpec         = False
     , optNoDesugarCalls = False
+    , optNoMatchCompiler = False 
     -- Options controlling printing
     , optVerbose        = False
     , optDumpDS         = False
@@ -49,6 +51,9 @@ options
            <*> switch ( long "no-desugar-calls"
                <> short 's'
                <> help "Skip indirect call desugaring")
+           <*> switch (long "no-match-compiler"
+               <> short 'm'
+               <> help "Skip match compilation")
            -- Options controlling printing
            <*> switch ( long "verbose"
                <> short 'v'

--- a/test/examples/cases/reference-test.solc
+++ b/test/examples/cases/reference-test.solc
@@ -1,0 +1,55 @@
+data memory(a) = memory(word);
+
+class abs:Typedef(rep) {
+    function abs(v:rep) -> abs;
+    function rep(v:abs) -> rep;
+}
+
+instance memory(a):Typedef(word) {
+    function abs(ptr:word) -> memory(a) {
+        return memory(ptr);
+    }
+    function rep(v:memory(a)) -> word {
+        match v {
+            | memory(ptr) => return ptr;
+        };
+    }
+}
+
+pragma no-patterson-condition Test;
+pragma no-bounded-variable-condition Test;
+class self:Test {
+    function test(x:self) -> word;
+}
+
+instance word:Test {
+    function test(x:word) -> word {
+        return x;
+    }
+}
+
+data test(a) = test(memory(a));
+
+instance test(a):Typedef(memory(a)) {
+    function rep(x:test(a)) -> memory(a) {
+        match x {
+            | test(m) => return m;
+        };
+    }
+    function abs(m:memory(a)) -> test(a) {
+        return test(m);
+    }
+}
+
+forall test(abs):Typedef(rep), rep:Test . instance test(abs):Test {
+    function test(x:test(abs)) -> word {
+        return Test.test(Typedef.rep(x));
+    }
+}
+
+contract C {
+    function main() {
+        let x:test(word) = test(memory(42));
+        let ptr:word = Test.test(x);
+    }
+}


### PR DESCRIPTION
Adding an option to disable pattern match compilation. This is useful to reduce to output produced by the prototype.