### PR TITLE
Fixes on context reduction.

### DIFF
--- a/src/Solcore/Frontend/Pretty/SolcorePretty.hs
+++ b/src/Solcore/Frontend/Pretty/SolcorePretty.hs
@@ -298,8 +298,10 @@ instance Pretty Pred where
 instance Pretty Scheme where
   ppr (Forall vs ty) = ppr' (Forall vs ty) 
     where 
+      ppr' (Forall [] ([] :=> t)) = ppr t
       ppr' (Forall [] (ctx :=> t))
-        = pprContext ctx <+> ppr t
+        = text "forall"       <+>
+          pprContext ctx <+> ppr t
       ppr' (Forall vs (ctx :=> t)) 
         = text "forall"       <+> 
           hsep (map ppr vs)   <+>

--- a/src/Solcore/Pipeline/Options.hs
+++ b/src/Solcore/Pipeline/Options.hs
@@ -7,6 +7,7 @@ data Option
     { fileName :: FilePath
     , optNoSpec :: !Bool
     , optNoDesugarCalls :: !Bool
+    , optNoMatchCompiler :: !Bool
     -- Options controlling printing
     , optVerbose :: !Bool
     , optDumpDS :: !Bool
@@ -24,6 +25,7 @@ emptyOption path = Option
     { fileName          = path
     , optNoSpec         = False
     , optNoDesugarCalls = False
+    , optNoMatchCompiler = False 
     -- Options controlling printing
     , optVerbose        = False
     , optDumpDS         = False
@@ -49,6 +51,9 @@ options
            <*> switch ( long "no-desugar-calls"
                <> short 's'
                <> help "Skip indirect call desugaring")
+           <*> switch (long "no-match-compiler"
+               <> short 'm'
+               <> help "Skip match compilation")
            -- Options controlling printing
            <*> switch ( long "verbose"
                <> short 'v'

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -112,6 +112,7 @@ cases
               , runTestForFile "typedef.solc" caseFolder
               , expectFail $ runTestForFile "mainproxy.solc" caseFolder
               , expectFail $ runTestForFile "complexproxy.solc" caseFolder
+              , expectFail $ runTestForFile "reference-test.solc" caseFolder
               ]
     where 
       caseFolder = "./test/examples/cases"

--- a/test/examples/cases/reference-encoding.solc
+++ b/test/examples/cases/reference-encoding.solc
@@ -5,15 +5,6 @@ class abs:Typedef(rep) {
     function abs(x:rep) -> abs;
 }
 
-// isn't this builtin? What does () stand for?
-// I can't write instances for (),
-// and `unit` for instances seems to be taken as type variable,
-// unless I declare it.
-data unit = unit;
-// To be sure I'm not running into bugs,
-// I use a distinct xunit instead,
-// I'll try to reproduce issues with "unit" separately.
-data xunit = xunit;
 
 data uint = uint(word);
 
@@ -143,13 +134,8 @@ forall StructField(structType, fieldSelector):StructField(fieldType, offsetType)
     }
 }
 
-instance unit:MemorySize {
-    function size(x:Proxy(unit)) -> word {
-        return 0;
-    }
-}
-instance xunit:MemorySize {
-    function size(x:Proxy(xunit)) -> word {
+instance ():MemorySize {
+    function size(x:Proxy(())) -> word {
         return 0;
     }
 }
@@ -198,7 +184,7 @@ data x_sel = x_sel;
 data y_sel = y_sel;
 data z_sel = z_sel;
 
-instance StructField(S, x_sel):StructField(word, xunit) {}
+instance StructField(S, x_sel):StructField(word, ()) {}
 instance StructField(S, y_sel):StructField(uint, word) {}
 // BUG: This next one should really be the following, but that breaks weirdly:
 // (I get a patterson condition violation on an invoke instance for g)

--- a/test/examples/cases/reference-encoding.solc
+++ b/test/examples/cases/reference-encoding.solc
@@ -126,10 +126,9 @@ forall StructField(structType, fieldSelector):StructField(fieldType, offsetType)
     function memberAccess(x:MemberAccessProxy(memory(structType), fieldSelector)) -> memoryRef(fieldType) {
         let ptr:word = Typedef.rep(memberAccessD1(x));
         let size:word = MemorySize.size(Proxy:Proxy(offsetType));
-        // BUG: Something wrong here? Complains about ptr not being word...
-        /*assembly {
+        assembly {
             ptr := add(ptr, size)
-        };*/
+        };
         return memoryRef(Typedef.abs(ptr));
     }
 }

--- a/test/examples/cases/reference-test.solc
+++ b/test/examples/cases/reference-test.solc
@@ -1,0 +1,55 @@
+data memory(a) = memory(word);
+
+class abs:Typedef(rep) {
+    function abs(v:rep) -> abs;
+    function rep(v:abs) -> rep;
+}
+
+instance memory(a):Typedef(word) {
+    function abs(ptr:word) -> memory(a) {
+        return memory(ptr);
+    }
+    function rep(v:memory(a)) -> word {
+        match v {
+            | memory(ptr) => return ptr;
+        };
+    }
+}
+
+pragma no-patterson-condition Test;
+pragma no-bounded-variable-condition Test;
+class self:Test {
+    function test(x:self) -> word;
+}
+
+instance word:Test {
+    function test(x:word) -> word {
+        return x;
+    }
+}
+
+data test(a) = test(memory(a));
+
+instance test(a):Typedef(memory(a)) {
+    function rep(x:test(a)) -> memory(a) {
+        match x {
+            | test(m) => return m;
+        };
+    }
+    function abs(m:memory(a)) -> test(a) {
+        return test(m);
+    }
+}
+
+forall test(abs):Typedef(rep), rep:Test . instance test(abs):Test {
+    function test(x:test(abs)) -> word {
+        return Test.test(Typedef.rep(x));
+    }
+}
+
+contract C {
+    function main() {
+        let x:test(word) = test(memory(42));
+        let ptr:word = Test.test(x);
+    }
+}


### PR DESCRIPTION
This PR fixes a problem in context reduction. Now, the following code is correctly rejected by the type inference.

```
data memory(a) = memory(word);

class abs:Typedef(rep) {
    function abs(v:rep) -> abs;
    function rep(v:abs) -> rep;
}

instance memory(a):Typedef(word) {
    function abs(ptr:word) -> memory(a) {
        return memory(ptr);
    }
    function rep(v:memory(a)) -> word {
        match v {
            | memory(ptr) => return ptr;
        };
    }
}

pragma no-patterson-condition Test;
pragma no-bounded-variable-condition Test;
class self:Test {
    function test(x:self) -> word;
}

instance word:Test {
    function test(x:word) -> word {
        return x;
    }
}

data test(a) = test(memory(a));

instance test(a):Typedef(memory(a)) {
    function rep(x:test(a)) -> memory(a) {
        match x {
            | test(m) => return m;
        };
    }
    function abs(m:memory(a)) -> test(a) {
        return test(m);
    }
}

forall test(abs):Typedef(rep), rep:Test . instance test(abs):Test {
    function test(x:test(abs)) -> word {
        return Test.test(Typedef.rep(x));
    }
}

contract C {
    function main() {
        let x:test(word) = test(memory(42));
        let ptr:word = Test.test(x);
    }
}
```