### PR TITLE
Update pretty-printing of type schemes to current syntax

### DIFF
--- a/src/Solcore/Frontend/Pretty/SolcorePretty.hs
+++ b/src/Solcore/Frontend/Pretty/SolcorePretty.hs
@@ -298,8 +298,10 @@ instance Pretty Pred where
 instance Pretty Scheme where
   ppr (Forall vs ty) = ppr' (Forall vs ty) 
     where 
+      ppr' (Forall [] ([] :=> t)) = ppr t
       ppr' (Forall [] (ctx :=> t))
-        = pprContext ctx <+> ppr t
+        = text "forall"       <+>
+          pprContext ctx <+> ppr t
       ppr' (Forall vs (ctx :=> t)) 
         = text "forall"       <+> 
           hsep (map ppr vs)   <+>


### PR DESCRIPTION
Print type schemes with nontrivial context and no variables as

```
forall context . t
```
e.g.

```
forall memory(structType) : Typedef (o10) . word
```

rather than

```
memory(structType) : Typedef (o10) . word
```


which is more consistent with the current syntax (e.g. `forall constraints . instance ...`)