### PR TITLE
Add missing case in instance Apply Stmt

### DIFF
--- a/src/Solcore/Desugarer/MatchCompiler.hs
+++ b/src/Solcore/Desugarer/MatchCompiler.hs
@@ -373,7 +373,8 @@ instance Apply (Stmt Id) where
   apply s (Return e)
     = Return (apply s e)
   apply s (Match es eqns)
-    = Match (apply s es) (apply s eqns) 
+    = Match (apply s es) (apply s eqns)
+  apply s stmt@Asm{} = stmt
 
   ids (e1 := e2) = ids [e1, e2]
   ids (Let n _ me) = [x | x <- ids me, n /= x]


### PR DESCRIPTION
Fixes crash on the @clonker's array example