### PR TITLE
spec: nixify builds and upload in CI

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -1,0 +1,25 @@
+name: Spec PDF
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v31
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - run: nix build .#spec
+    - name: Upload spec PDF
+      uses: actions/upload-artifact@v4
+      with:
+        name: spec-pdf
+        path: result/spec.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,11 @@ output.core
 # claude
 /CLAUDE.md
 /.claude/
+
+# latex
+/spec/*.bbl
+/spec/*.blg
+/spec/*.log
+/spec/*.out
+/spec/*.pdfsync
+/spec/*.pdf

--- a/flake.nix
+++ b/flake.nix
@@ -14,8 +14,7 @@
     };
   };
 
-  outputs =
-    inputs:
+  outputs = inputs:
     inputs.flake-utils.lib.eachDefaultSystem (
       system:
       let
@@ -27,9 +26,11 @@
 
         gitignore = pkgs.nix-gitignore.gitignoreSourcePure [ ./.gitignore ];
         sol-core = (hspkgs.callCabal2nix "sol-core" (gitignore ./.) { });
+        texlive = pkgs.texlive.combine { inherit (pkgs.texlive) scheme-small thmtools pdfsync lkproof cm-super; };
       in
       rec {
         packages.sol-core = sol-core;
+        packages.spec = pkgs.callPackage ./spec { solcoreTexlive = texlive; };
         packages.default = packages.sol-core;
 
         apps.sol-core = inputs.flake-utils.lib.mkApp { drv = packages.sol-core; };
@@ -43,6 +44,7 @@
             hspkgs.haskell-language-server
             pkgs.foundry-bin
             pkgs.solc
+            texlive
           ];
         };
       }

--- a/spec/default.nix
+++ b/spec/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, solcoreTexlive }:
+stdenv.mkDerivation {
+  src = ./.;
+  pname = "sol-core-spec";
+  version = "0.0.0";
+  phases = ["unpackPhase" "buildPhase" "installPhase"];
+  buildInputs = [ solcoreTexlive ];
+  buildPhase = ''
+    mkdir -p .cache/texmf-var
+    # make some writable tempdirs
+    export TEXMFHOME=.cache
+    export TEXMFVAR=.cache/texmf-var
+    make
+  '';
+  installPhase = ''
+    mkdir -p $out
+    cp new-solidity-spec.pdf $out/spec.pdf
+  '';
+}


### PR DESCRIPTION
- Adds a texlive to the development shell that can be used to build the spec
- Adds a nix package for the spec and exposes it as a flake output
- Builds the spec in CI and uploads the resulting pdf as an artifact (unfortunately zipped due to github actions limitations).