### PR TITLE
Support Cyclic Function Definitions

### DIFF
--- a/src/Solcore/Desugarer/Specialise.hs
+++ b/src/Solcore/Desugarer/Specialise.hs
@@ -159,6 +159,7 @@ addDeclResolutions :: TopDecl Id -> SM ()
 addDeclResolutions (TInstDef inst) = addInstResolutions (flexAll inst)
 addDeclResolutions (TFunDef fd) = addFunDefResolution (flexAll fd)
 addDeclResolutions (TDataDef dt) = addData dt
+addDeclResolutions (TMutualDef decls) = forM_ decls addDeclResolutions
 addDeclResolutions _ = return ()
 
 

--- a/src/Solcore/Desugarer/Specialise.hs
+++ b/src/Solcore/Desugarer/Specialise.hs
@@ -200,6 +200,7 @@ addContractResolutions (Contract name args decls) = do
 addCDeclResolution :: ContractDecl Id -> SM ()
 addCDeclResolution (CFunDecl fd) = addFunDefResolution (flexAll fd)
 addCDeclResolution (CDataDecl dt) = addData dt
+addCDeclResolution (CMutualDecl decls) = forM_ decls addCDeclResolution
 addCDeclResolution _ = return ()
 
 addFunDefResolution fd = do

--- a/src/Solcore/Frontend/TypeInference/SccAnalysis.hs
+++ b/src/Solcore/Frontend/TypeInference/SccAnalysis.hs
@@ -79,8 +79,6 @@ analysis fn ds
 
 -- building the dependency graph
 
--- building the dependency graph
-
 mkGraph :: (Ord a, Names a, Decl a) => [a] -> AdjacencyMap a
 mkGraph ds = stars $ mkEdges (mkNameEnv ds) ds
 

--- a/src/Solcore/Frontend/TypeInference/SccAnalysis.hs
+++ b/src/Solcore/Frontend/TypeInference/SccAnalysis.hs
@@ -38,18 +38,10 @@ sccAnalysis' :: CompUnit Name -> SCC (CompUnit Name)
 sccAnalysis' (CompUnit imps ds)
   = do
       cs' <- mapM sccContract cs
-      CompUnit imps <$> analysis group (cs' ++ ds')
+      CompUnit imps <$> analysis (cs' ++ ds')
     where
       isContract (TContr _) = True
       isContract _ = False
-
-      isFunDef (TFunDef _) = True
-      isFunDef _ = False
-
-      group xs =
-        if (all isFunDef xs && length xs > 1)
-        then singleton (TMutualDef xs)
-        else xs
 
       (cs, ds') = partition isContract ds
 
@@ -57,25 +49,17 @@ sccAnalysis' (CompUnit imps ds)
 
 sccContract :: TopDecl Name -> SCC (TopDecl Name)
 sccContract (TContr (Contract n vs ds))
-  = (TContr . Contract n vs) <$> analysis group ds
-    where
-      group xs =
-        if (all isFunDef xs && length xs > 1)
-        then singleton (CMutualDecl xs)
-        else xs
-
-      isFunDef (CFunDecl _) = True
-      isFunDef _ = False
+  = (TContr . Contract n vs) <$> analysis ds
 sccContract d = pure d
 
-analysis :: (Ord a, Names a, Decl a, Show a) => ([a] -> [a]) -> [a] -> SCC [a]
-analysis fn ds
+analysis :: (Ord a, Names a, Decl a, Show a, Groupable a) => [a] -> SCC [a]
+analysis ds
   = do
       let grph = mkGraph ds
           cmps = scc grph
       case topSort cmps of
         Left _ -> pure []
-        Right ds' -> pure $ reverse $ concatMap (fn . toList . N.vertexList1) ds'
+        Right ds' -> pure $ reverse $ concatMap (groupMutualDefs . toList . N.vertexList1) ds'
 
 -- building the dependency graph
 
@@ -271,6 +255,28 @@ instance Names (TopDecl Name) where
 
 instance Names (CompUnit Name) where
   names (CompUnit _ decls) = names decls
+
+-- Groupable class for handling mutual definitions
+
+class Groupable a where
+  isFunctionDef :: a -> Bool
+  wrapMutualDefs :: [a] -> [a]
+
+instance Groupable (TopDecl Name) where
+  isFunctionDef (TFunDef _) = True
+  isFunctionDef _ = False
+  wrapMutualDefs xs = [TMutualDef xs]
+
+instance Groupable (ContractDecl Name) where
+  isFunctionDef (CFunDecl _) = True
+  isFunctionDef _ = False
+  wrapMutualDefs xs = [CMutualDecl xs]
+
+groupMutualDefs :: Groupable a => [a] -> [a]
+groupMutualDefs xs =
+  if (all isFunctionDef xs && length xs > 1)
+  then wrapMutualDefs xs
+  else xs
 
 -- monad definition
 

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -122,6 +122,7 @@ cases =
     , runTestExpectingFailure "Uncurry.solc" caseFolder
     , runTestForFile "unit.solc" caseFolder
     , runTestForFile "memory.solc" caseFolder
+    , runTestForFile "cyclical-defs.solc" caseFolder
     , runTestForFile "closure.solc" caseFolder
     , runTestForFile "noclosure.solc" caseFolder
     , runTestForFile "constructor-weak-args.solc" caseFolder

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -123,6 +123,7 @@ cases =
     , runTestForFile "unit.solc" caseFolder
     , runTestForFile "memory.solc" caseFolder
     , runTestForFile "cyclical-defs.solc" caseFolder
+    , runTestForFile "cyclical-defs-inferred.solc" caseFolder
     , runTestForFile "closure.solc" caseFolder
     , runTestForFile "noclosure.solc" caseFolder
     , runTestForFile "constructor-weak-args.solc" caseFolder

--- a/test/examples/cases/cyclical-defs-inferred.solc
+++ b/test/examples/cases/cyclical-defs-inferred.solc
@@ -1,0 +1,12 @@
+function foo(x) {
+  return bar(x);
+}
+function bar(x) {
+  return foo(x);
+}
+
+contract C {
+  function main() -> word {
+    return foo(1);
+  }
+}

--- a/test/examples/cases/cyclical-defs.solc
+++ b/test/examples/cases/cyclical-defs.solc
@@ -1,0 +1,18 @@
+function foo(x : word) -> word {
+  return bar(x);
+}
+function bar(x : word) -> word {
+  return foo(x);
+}
+
+contract C {
+  function m(x : word) -> word {
+    return n(x);
+  }
+  function n(x : word) -> word {
+    return m(x);
+  }
+  function main() -> word {
+    return m(1);
+  }
+}


### PR DESCRIPTION
This PR includes two changes that fix compilation of mutually recursive functions:

1. The strongly connected component analysis was not wrapping connected binding groups in the `TMutualDef` and `CMutualDecl` constructors, meaning that they were not being passed into `tcBindGroup` and were being checked individually.
2. `tcBindGroup` was not adding the other functions in the bind group to the environment when typechecking.

For now we scoped the fix to work for strongly connected definition groups composed only of functions. Expanding support to include classes and instances will need a bit more work (since tcBindGroup currently only supports typechecking function definitions).