### PR TITLE
Better error messages on type list length mismatch

### DIFF
--- a/src/Common/Pretty.hs
+++ b/src/Common/Pretty.hs
@@ -20,6 +20,9 @@ infixl 6 ><
 class Pretty a where
   ppr :: a -> Doc
 
+instance Pretty String where
+  ppr = text
+
 dotSep :: [Doc] -> Doc
 dotSep = hcat . punctuate dot
          where

--- a/src/Solcore/Frontend/Pretty/ShortName.hs
+++ b/src/Solcore/Frontend/Pretty/ShortName.hs
@@ -28,13 +28,12 @@ instance HasShortName a => HasShortName (FunDef a) where
     shortName fd = "function " ++shortName (funSignature fd)
 
 instance HasShortName a => HasShortName (Instance a) where
-  shortName is = unwords
-    [ "instance"
-    , pretty (mainTy is)
-    , ":"
-    , pretty (instName is)
-    , prettys (paramsTy is)
-    ]
+  shortName idef@(Instance _d _vs _ctx n ts t _funs) = do
+      unwords [ "instance", pretty (InCls n t ts) ]
+
+instance HasShortName Pred where
+    shortName p = unwords ["constraint", pretty p]
+
 instance HasShortName a => HasShortName (TopDecl a) where
   shortName (TContr c) = shortName c
   shortName (TFunDef fd) = shortName fd

--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -9,6 +9,7 @@ import Data.List
 import qualified Data.Map as Map
 import Data.Maybe
 
+import Solcore.Frontend.Pretty.ShortName
 import Solcore.Frontend.Pretty.SolcorePretty
 import Solcore.Frontend.Syntax
 import Solcore.Frontend.TypeInference.Id
@@ -635,7 +636,7 @@ checkInstance idef@(Instance d vs ctx n ts t funs)
       bound <- askBoundVariableCondition n
       unless bound (checkBoundVariable ctx (fv (t : ts)) `wrapError` idef)
       -- checking instance methods
-      mapM_ (checkMethod ipred) funs
+      mapM_ (checkMethod ipred) funs `wrapError` idef
       let ninst = anfInstance $ ctx :=> InCls n t ts
       -- add to the environment
       if d then addDefaultInstance n ninst

--- a/src/Solcore/Frontend/TypeInference/TcUnify.hs
+++ b/src/Solcore/Frontend/TypeInference/TcUnify.hs
@@ -7,6 +7,7 @@ import Control.Monad.Reader
 import Data.List
 
 import Common.Pretty
+import Solcore.Frontend.Pretty.ShortName
 import Solcore.Frontend.Pretty.SolcorePretty hiding ((<>))
 import Solcore.Frontend.Syntax
 import Solcore.Frontend.TypeInference.TcSubst
@@ -174,12 +175,13 @@ typesNotMatch t1 t2 =
 
 typesMatchListErr :: (MonadError String m) => [String] -> [String] -> m a
 typesMatchListErr ts ts' =
-  throwError (errMsg (zip ts ts'))
+  throwError (errMsg ts ts')
  where
-  errMsg ps =
-    unwords ["Types do not match:"]
-      ++ concatMap tyList ps
-  tyList (t1, t2) = t1 <> " and " <> t2
+  errMsg ts ts' =
+    unwords ["Type lists do not match: (typesMatchListErr)\n"
+            , prettys ts, "and", prettys ts'
+            ]
+
 
 typesDoNotUnify :: (MonadError String m) => Ty -> Ty -> m a
 typesDoNotUnify t1 t2 =


### PR DESCRIPTION
Currently, the error reported by `typesMatchListErr` is not very useful if one of the lists is empty
(due to zip) - this should be caught elsewhere, but sometimes isn't. This PR attempts to fix that.

Additionally it adds another `wrapError` in checkInstance to make locating the error a bit easier.
