### PR TITLE
Fixes the typing for if statements

### DIFF
--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -93,18 +93,19 @@ tcStmt s@(If e blk1 blk2)
                            ]) `wrapError` s
       (blk1', ps1, t1) <- tcBody blk1
       (blk2', ps2, t2) <- tcBody blk2
-      let ps3 = ps ++ ps1 ++ ps2
+      -- here we check if "else" branch is present.
+      let t2' = if null blk2 then t1 else t2
+          ps3 = ps ++ ps1 ++ ps2
       -- we force that both blocks should return the same type.
-      unify t1 t2 `catchError` (\ _ ->
-        tcmError $ unlines ["If blocks should produce the same return type"
-                           , "but, block:"
+      unify t1 t2' `catchError` (\ _ ->
+        tcmError $ unlines ["If blocks should produce the same return type but, block:"
                            , pretty blk1
                            , "has return type:"
                            , pretty t1
                            , "while block:"
                            , pretty blk2
                            , "has return type:"
-                           , pretty t2
+                           , pretty t2'
                            ]) `wrapError` s
       withCurrentSubst (If e' blk1' blk2', ps3, t1)
 

--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -81,19 +81,32 @@ tcStmt (Asm yblk)
       let word' = monotype word
       mapM_ (flip extEnv word') newBinds
       pure (Asm yblk, [], t)
-tcStmt (If e blk1 blk2)
+tcStmt s@(If e blk1 blk2)
   = do
       (e', ps, t) <- tcExp e
-      unless (t == boolTy) $
-        throwError $ unlines ["Expression:", pretty e
-                             , "has type:", pretty t
-                             , "while it is expected to have type:"
-                             , pretty boolTy
-                             ]
-      (blk1', ps1, _) <- tcBody blk1
-      (blk2', ps2, _) <- tcBody blk2
+      -- condition should have the boolean type
+      unify t boolTy `catchError` (\ _ ->
+        tcmError $ unlines ["Expression:", pretty e
+                           , "has type:", pretty t
+                           , "while it is expected to have type:"
+                           , pretty boolTy
+                           ]) `wrapError` s
+      (blk1', ps1, t1) <- tcBody blk1
+      (blk2', ps2, t2) <- tcBody blk2
       let ps3 = ps ++ ps1 ++ ps2
-      withCurrentSubst (If e' blk1' blk2', ps3, unit)
+      -- we force that both blocks should return the same type.
+      unify t1 t2 `catchError` (\ _ ->
+        tcmError $ unlines ["If blocks should produce the same return type"
+                           , "but, block:"
+                           , pretty blk1
+                           , "has return type:"
+                           , pretty t1
+                           , "while block:"
+                           , pretty blk2
+                           , "has return type:"
+                           , pretty t2
+                           ]) `wrapError` s
+      withCurrentSubst (If e' blk1' blk2', ps3, t1)
 
 
 

--- a/test/examples/cases/notif.solc
+++ b/test/examples/cases/notif.solc
@@ -5,3 +5,10 @@ function not(x){
     return true ;
   }
 }
+
+function not2(x) {
+  if (x) {
+    return false ;
+  }
+  return true;
+}

--- a/test/examples/cases/notif.solc
+++ b/test/examples/cases/notif.solc
@@ -1,0 +1,7 @@
+function not(x){
+  if (x) {
+    return false ;
+  } else {
+    return true ;
+  }
+}


### PR DESCRIPTION
Fixes the typing of if's by:
* unifying the infered expression type with bool
* checks that both branches have the same return type.