### PR TITLE
Fixes on bound variable condition test

### DIFF
--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -747,7 +747,7 @@ checkInstance idef@(Instance d vs ctx n ts t funs)
       unless patterson (checkMeasure ctx ipred `wrapError` idef)
       -- checking bound variable condition
       bound <- askBoundVariableCondition n
-      unless bound (checkBoundVariable ctx (fv (t : ts)) `wrapError` idef)
+      unless bound (checkBoundVariable ctx (bv (t : ts)) `wrapError` idef)
       -- checking instance methods
       mapM_ (checkMethod ipred) funs `wrapError` idef
       let ninst = anfInstance $ ctx :=> InCls n t ts
@@ -769,7 +769,7 @@ isTyVar _ = False
 
 checkBoundVariable :: [Pred] -> [Tyvar] -> TcM ()
 checkBoundVariable ps vs
-  = unless (all (\ v -> v `elem` vs) (fv ps)) $ do
+  = unless (all (\ v -> v `elem` vs) (bv ps)) $ do
       throwError "Bounded variable condition fails!"
 
 

--- a/std/std.solc
+++ b/std/std.solc
@@ -1,4 +1,4 @@
-pragma no-bounded-variable-condition ABIEncode;
+pragma no-bounded-variable-condition ABIEncode, GenerateDispatch;
 pragma no-patterson-condition ABIEncode;
 pragma no-coverage-condition ABIDecode, MemoryType;
 

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -164,6 +164,8 @@ cases =
     , runTestExpectingFailure "bound-minimal.solc" caseFolder
     , runTestExpectingFailure "bound-only-test.solc" caseFolder
     , runTestForFile "bound-with-pragma.solc" caseFolder
+    , runTestExpectingFailure "pragma-merge-import.solc" caseFolder
+    , runTestExpectingFailure "pragma-merge-test.solc" caseFolder
     ]
  where
   caseFolder = "./test/examples/cases"

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -161,6 +161,9 @@ cases =
     , runTestForFile "word-match.solc" caseFolder
     , runTestForFile "if-examples.solc" caseFolder
     , runTestForFile "import-std.solc" caseFolder
+    , runTestExpectingFailure "bound-minimal.solc" caseFolder
+    , runTestExpectingFailure "bound-only-test.solc" caseFolder
+    , runTestForFile "bound-with-pragma.solc" caseFolder
     ]
  where
   caseFolder = "./test/examples/cases"

--- a/test/examples/cases/bound-merge-case.solc
+++ b/test/examples/cases/bound-merge-case.solc
@@ -1,0 +1,8 @@
+// Pragmas to disable checks for specific classes
+pragma no-patterson-condition TestClassP1, TestClassB1;
+pragma no-coverage-condition TestClassC1;
+//pragma no-bounded-variable-condition TestClassB1;
+pragma no-bounded-variable-condition TestClassB1;
+
+// === Test Classes ===
+forall a . class a:TestClassP1 {}

--- a/test/examples/cases/bound-minimal.solc
+++ b/test/examples/cases/bound-minimal.solc
@@ -1,0 +1,13 @@
+// Minimal test for bound variable condition
+// This SHOULD FAIL - variable 'bad' in context but not in instance head
+
+pragma no-patterson-condition TestBound;
+
+forall a . class a:TestBound {}
+forall a b . class a:TestHelper(b) {}
+
+data TestType(x) = TestType;
+
+// Variable 'bad' appears in context but not in instance head
+// Should fail bound variable check
+forall x . bad:TestHelper(x) => instance TestType(x):TestBound {}

--- a/test/examples/cases/bound-only-test.solc
+++ b/test/examples/cases/bound-only-test.solc
@@ -1,0 +1,11 @@
+// Test only bound variable check, disable Patterson
+pragma no-patterson-condition TestBound;
+
+forall a . class a:TestBound {}
+forall a b . class a:TestHelper(b) {}
+
+data TestType(x) = TestType;
+
+// Variable 'bad' appears in context but not in instance head
+// Should fail bound variable check
+forall x . bad:TestHelper(x) => instance TestType(x):TestBound {}

--- a/test/examples/cases/bound-with-pragma.solc
+++ b/test/examples/cases/bound-with-pragma.solc
@@ -1,0 +1,14 @@
+// Same test but with pragma to disable bound variable check
+// This SHOULD PASS
+
+pragma no-bounded-variable-condition TestBound;
+pragma no-patterson-condition TestBound; // Also disable Patterson to avoid that error
+
+forall a . class a:TestBound {}
+forall a b . class a:TestHelper(b) {}
+
+data TestType(x) = TestType;
+
+// Variable 'bad' appears in context but not in instance head
+// But pragma disables the check, so should pass
+forall x . bad:TestHelper(x) => instance TestType(x):TestBound {}

--- a/test/examples/cases/pragma-merge-import.solc
+++ b/test/examples/cases/pragma-merge-import.solc
@@ -1,0 +1,10 @@
+data ImportType1(A) = Import1(A);
+data ImportType2(A) = ImportType2(A);
+
+forall W . W:TestClassP1, W:TestClassP2, W:TestClassP3 => instance ImportType1(W):TestClassP4 {}
+
+// Using base class that already has pragma from import
+forall X . X:TestClassP2, X:TestClassP3, X:TestClassP4 => instance ImportType2:TestClassP1 {}
+forall X . X:TestClassP2, X:TestClassP3, X:TestClassP4 => instance ImportType1(X):TestClassP1 {}
+
+// === New Coverage Violations ===

--- a/test/examples/cases/pragma-merge-test.solc
+++ b/test/examples/cases/pragma-merge-test.solc
@@ -1,0 +1,15 @@
+// Test that multiple pragmas of same type are merged
+pragma no-patterson-condition TestClass1, TestClass2;
+pragma no-patterson-condition TestClass3;
+pragma no-bounded-variable-condition TestClass1, TestClass2, TestClass3;
+
+forall a . class a:TestClass1 {}
+forall a . class a:TestClass2 {}
+forall a . class a:TestClass3 {}
+
+data TestType = TestType;
+
+// All three should pass due to merged pragmas
+forall U . U:TestClass1, U:TestClass2 => instance TestType:TestClass1 {}
+forall U . U:TestClass2, U:TestClass3 => instance TestType:TestClass2 {}
+forall U . U:TestClass1, U:TestClass3 => instance TestType:TestClass3 {}


### PR DESCRIPTION
This PR provides the following fixes:

- Fix the bound variable condition test for class and instance definitions.
- Adds checks for kinds in instance definitions.
- Check if a class is defined in instance definitions.
- Adds a pragma in std.solc
- Adds some test cases proposed by @dxo.