### PR TITLE
Parser: handle yul return

### DIFF
--- a/src/Solcore/Frontend/Parser/SolcoreParser.y
+++ b/src/Solcore/Frontend/Parser/SolcoreParser.y
@@ -16,7 +16,7 @@ import System.FilePath
 
 
 %name parser CompilationUnit
-%monad {Alex}{(>>=)}{return}
+%monad {Alex}{(>>=)}{pure}
 %tokentype { Token }
 %error     { parseError }
 %lexer {lexer}{Token _ TEOF}
@@ -469,9 +469,10 @@ IdentifierList : Name                              {[$1]}
 
 
 YulExp :: {YulExp}
-YulExp : YulLiteral                                   {YLit $1}
+YulExp : YulLiteral                                {YLit $1}
        | Name                                      {YIdent $1}
        | Name YulFunArgs                           {YCall $1 $2}
+       | 'return' YulFunArgs                       {YCall (Name "return") $2}
 
 YulFunArgs :: {[YulExp]}
 YulFunArgs : '(' YulExpCommaList ')'               {$2}

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -166,7 +166,7 @@ cases =
     , runTestForFile "bal.solc" caseFolder
     , runTestForFile "ixa.solc" caseFolder
     , runTestForFile "tuva.solc" caseFolder
-    -- Pragma merging tests
+    , runTestForFile "yul-return.solc" caseFolder
     , runTestForFile "pragma_merge_base.solc" caseFolder
     , runTestForFile "pragma_merge_import.solc" caseFolder
     , runTestForFile "pragma_merge_verify.solc" caseFolder

--- a/test/examples/cases/yul-return.solc
+++ b/test/examples/cases/yul-return.solc
@@ -1,0 +1,7 @@
+contract C {
+  function main() -> () {
+    assembly {
+      return(0,0);
+    }
+  }
+}


### PR DESCRIPTION
return is used as both a surface level keyword and a yul level function. This modifies the surface level parser to correctly handle `return` in yul blocks.