### PR TITLE
TcContract: Allow definition of multiple pragmas

### DIFF
--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -167,6 +167,12 @@ cases =
     , runTestForFile "bal.solc" caseFolder
     , runTestForFile "ixa.solc" caseFolder
     , runTestForFile "tuva.solc" caseFolder
+    -- Pragma merging tests
+    , runTestForFile "pragma_merge_base.solc" caseFolder
+    , runTestForFile "pragma_merge_import.solc" caseFolder
+    , runTestForFile "pragma_merge_verify.solc" caseFolder
+    , runTestExpectingFailure "pragma_merge_fail_patterson.solc" caseFolder
+    , runTestExpectingFailure "pragma_merge_fail_coverage.solc" caseFolder
     ]
  where
   caseFolder = "./test/examples/cases"

--- a/test/examples/cases/pragma_merge_base.solc
+++ b/test/examples/cases/pragma_merge_base.solc
@@ -1,0 +1,48 @@
+// Test base file for pragma merging functionality
+// This file contains violations of all three condition types with pragmas to disable checks
+
+// Pragmas to disable checks for specific classes
+pragma no-patterson-condition TestClassP1, TestClassB1;
+pragma no-coverage-condition TestClassC1;
+pragma no-bounded-variable-condition TestClassB1;
+
+// --- Test Classes ---
+
+forall a . class a:TestClassP1 {}
+forall a . class a:TestClassP2 {}
+forall a . class a:TestClassP3 {}
+
+forall a b . class a:TestClassC1(b) {}
+forall a b c . class a:TestClassC2(b,c) {}
+
+forall a . class a:TestClassB1 {}
+forall a b . class a:TestClassB2(b) {}
+
+// --- Data Types ---
+
+data TestType1(x) = TestType1;
+data TestType2 = TestType2;
+
+// --- Patterson Condition ---
+
+// Fails Patterson: Context measure (3 predicates) > conclusion measure (TestType1(U):TestClassP1)
+forall U . U:TestClassP1, U:TestClassP2, U:TestClassP3 => instance U:TestClassP1 {}
+
+// Patterson OK: No context predicates
+instance TestType2:TestClassP2 {}
+
+// --- Coverage Condition ---
+
+// Fails Coverage: Variable 'a' only appears in weak position (parameter to TestClassC1)
+forall a b . instance TestType1(b):TestClassC1(a) {}
+
+// Coverage OK: All variables in strong positions
+instance TestType2:TestClassC2(TestType2, TestType2) {}
+
+// === Bound Variable Violations ===
+
+// Fails Bound Variable & Patterson: Variable 'c' appears in context but not in instance head
+forall a . c:TestClassB2(a) => instance TestType1(a):TestClassB1 {}
+
+// Bound Variable OK: Simple instance without context
+instance TestType1(TestType2):TestClassB2(TestType2) {}

--- a/test/examples/cases/pragma_merge_fail_coverage.solc
+++ b/test/examples/cases/pragma_merge_fail_coverage.solc
@@ -1,0 +1,10 @@
+// Negative test for pragma merging - should fail
+import pragma_merge_base;
+
+forall a . class a:TestFailClass {}
+
+data FailType(x) = FailType;
+
+// should fail because TestFailCoverage doesn't have no-coverage-condition
+forall a b . class a:TestFailCoverage(b) {}
+forall x y . instance FailType(x):TestFailCoverage(y) {}

--- a/test/examples/cases/pragma_merge_fail_patterson.solc
+++ b/test/examples/cases/pragma_merge_fail_patterson.solc
@@ -1,0 +1,11 @@
+// This file should FAIL compilation to demonstrate that checks are working when the imported file contains violations
+
+import pragma_merge_base;
+
+
+// --- Patterson Violation ---
+
+forall a . class a:TestFailClass {}
+
+// Should fail because TestFailClass doesn't have no-patterson-condition
+forall U . U:TestClassP1, U:TestClassP2, U:TestClassP3 => instance U:TestFailClass {}

--- a/test/examples/cases/pragma_merge_import.solc
+++ b/test/examples/cases/pragma_merge_import.solc
@@ -1,0 +1,54 @@
+// Test import file for pragma merging functionality
+// This file imports pragma_merge_base and adds its own violations with pragmas
+// Testing that pragmas from both files are properly merged
+
+import pragma_merge_base;
+
+// Add more pragmas - these should merge with imported ones
+// After merging:
+// - Patterson: TestClassP1 (from base) + TestClassP4 (from here)
+// - Coverage: TestClassC1 (from base) + TestClassC3 (from here)  
+// - Bound: TestClassB1 (from base) + TestClassB3 (from here)
+pragma no-patterson-condition TestClassP4, TestClassB3, TestClassB1;
+pragma no-coverage-condition TestClassC3;
+pragma no-bounded-variable-condition TestClassB3, TestClassB1;
+
+// === Additional Classes ===
+forall a . class a:TestClassP4 {}
+forall a b . class a:TestClassC3(b) {}
+forall a . class a:TestClassB3 {}
+
+// === Additional Data Types ===
+data ImportType1(x) = ImportType1;
+data ImportType2 = ImportType2;
+
+// === New Patterson Violations ===
+
+// VIOLATION: Needs pragma for TestClassP4 (provided above)
+forall W . W:TestClassP1, W:TestClassP2, W:TestClassP3 => instance ImportType1(W):TestClassP4 {}
+
+// Using base class that already has pragma from import
+forall X . X:TestClassP2, X:TestClassP3, X:TestClassP4 => instance ImportType2:TestClassP1 {}
+
+// === New Coverage Violations ===
+
+// VIOLATION: Needs pragma for TestClassC3 (provided above)
+forall x y . instance ImportType1(x):TestClassC3(y) {}
+
+// Using base class that already has pragma from import
+forall m n . instance ImportType2:TestClassC1(n) {}
+
+// === New Bound Variable Violations ===
+
+// VIOLATION: Needs pragma for TestClassB3 (provided above)
+forall d . e:TestClassB2(d) => instance ImportType1(d):TestClassB3 {}
+
+// Using base class that already has pragma from import
+forall f . g:TestClassB3 => instance ImportType2:TestClassB1 {}
+
+// === Cross-file Tests ===
+
+// Mix types from both files - tests that all pragmas are active
+instance ImportType1(ImportType2):TestClassP2 {}
+instance ImportType1(TestType2):TestClassC1(TestType2) {}
+forall h . instance ImportType2:TestClassB3 {}

--- a/test/examples/cases/pragma_merge_verify.solc
+++ b/test/examples/cases/pragma_merge_verify.solc
@@ -1,0 +1,13 @@
+// Verification file for pragma merging
+// This file imports pragma_merge_base but has no pragmas of its own
+// Tests that pragmas from imported files are properly inherited
+
+import pragma_merge_base;
+
+data VerifyType(x) = VerifyType;
+
+// Would fail without imported pragma no-patterson-condition TestClassP1
+forall A . A:TestClassP1, A:TestClassP2, A:TestClassP3 => instance A:TestClassP1 {}
+
+// Would fail without imported pragma no-coverage-condition TestClassC1
+forall p q . instance VerifyType(p):TestClassC1(q) {}

--- a/test/examples/cases/pragma_test_patterson.solc
+++ b/test/examples/cases/pragma_test_patterson.solc
@@ -1,0 +1,9 @@
+// Simple Patterson test - should fail without pragma
+
+forall a . class a:C1 {}
+forall a . class a:C2 {}
+
+data T(x) = T;
+
+// This violates Patterson: context measure (2) >= conclusion measure (2)
+forall U . U:C1, U:C2 => instance T(U):C1 {}


### PR DESCRIPTION
This is needed when importing a file that contains pragma definitions into another one. Pragmas are merged additively, with a catch all pragma defintion taking precendence and forcing the check to be disabled for all instances