### PR TITLE
std: add instances for contract dispatch desugaring

### DIFF
--- a/std/dispatch.solc
+++ b/std/dispatch.solc
@@ -21,17 +21,85 @@ data Fallback(payability, args, rets, fn) = Fallback(payability, args, rets, fn)
 
 // --- Method Selectors ---
 
-// For each method in a contract the compiler generates a unique type and
-// produces a `Selector` instance for that type that returns the selector hash
-forall nm . class nm:Selector {
-  function hash(prx: Proxy(nm)) -> word;
+// The string representation of abi types used during selector computation
+forall ty . class ty:ABIString {
+    function append(head : word, tail : word, prx : Proxy(ty)) -> word;
 }
 
-// Method has a Selector if its name has a Selector
-forall name payability args rets fn . name:Selector => instance Method(name,payability,args,rets,fn):Selector {
-  function hash(prx: Proxy(Method(name,payability,args,rets,fn))) -> word {
-    return Selector.hash(Proxy : Proxy(name));
-  }
+instance uint256:ABIString {
+    function append(head : word, tail : word, prx : Proxy(uint256)) -> word {
+        let size : word = 7;
+        assembly {
+            mstore(head, add(mload(head), size))
+            mstore(tail, 0x75696e7432353600000000000000000000000000000000000000000000000000)
+        }
+        return Add.add(tail, size);
+    }
+}
+
+instance ():ABIString {
+    function append(head : word, tail : word, prx : Proxy(())) -> word {
+        return(tail);
+    }
+}
+
+function append_left_bracket(head : word, tail : word) -> word {
+    let size = 1;
+    assembly {
+        mstore(head, add(mload(head), size));
+        mstore(tail, 0x2800000000000000000000000000000000000000000000000000000000000000);
+    }
+    return Add.add(tail, size);
+}
+
+function append_right_bracket(head : word, tail : word) -> word {
+    let size = 1;
+    assembly {
+        mstore(head, add(mload(head), size));
+        mstore(tail, 0x2900000000000000000000000000000000000000000000000000000000000000);
+    }
+    return Add.add(tail, size);
+}
+
+function append_comma(head : word, tail : word) -> word {
+    let size = 1;
+    assembly {
+        mstore(head, add(mload(head), size));
+        mstore(tail, 0x2c00000000000000000000000000000000000000000000000000000000000000);
+    }
+    return Add.add(tail, size);
+}
+
+forall l r . l:ABIString, r:ABIString => instance (l,r):ABIString {
+    function append(head : word, tail : word, prx : Proxy((l,r))) -> word {
+        let with_l = ABIString.append(head, tail, Proxy : Proxy(l));
+        let with_comma = append_comma(head, with_l);
+        return ABIString.append(head, with_comma, Proxy : Proxy(r));
+    }
+}
+
+forall ty . class ty:Selector {
+    function compute(prx : Proxy(ty)) -> bytes4;
+}
+
+// Computes the selector hash for a given method
+// this is a class with a single instance since it made some of the downstream definitions a bit cleaner to define
+forall name payability args rets fn
+    . name:ABIString
+    , args:ABIString
+=> instance Method(name,payability,Proxy(args),Proxy(rets),fn):Selector {
+    function compute(prx : Proxy(Method(name,payability,Proxy(args),Proxy(rets),fn))) -> bytes4 {
+        let head = get_free_memory();
+        let tail = Add.add(head, 32);
+        tail = ABIString.append(head, tail, Proxy : Proxy(name));
+        tail = append_left_bracket(head, tail);
+        tail = ABIString.append(head, tail, Proxy : Proxy(args));
+        tail = append_right_bracket(head, tail);
+
+        let res : word;
+        assembly { res := shr(224, keccak256(add(head, 32), mload(head))) }
+        return bytes4(res);
+    }
 }
 
 // --- Method Execution ---
@@ -145,13 +213,13 @@ forall n m . n:ExecMethod, n:Selector, m:RunDispatch => instance (n,m):RunDispat
 }
 
 // TODO: we only wanna do the calldataload once
-// Given evidence of a name with a known selector, we can check if it matches the selector in the first four bytes of calldata
-forall name . name:Selector => function selector_matches(prx : Proxy(name)) -> Bool {
-  let hash = Selector.hash(prx);
+// Given evidence of a type with a known selector, we can check if it matches the selector in the first four bytes of calldata
+forall ty . ty:Selector => function selector_matches(prx : Proxy(ty)) -> Bool {
+  let candidate = Typedef.rep(Selector.compute(prx));
   let res : word;
   assembly {
     let sel := shr(224, calldataload(0));
-    res := eq(sel, hash);
+    res := eq(sel, candidate);
   }
   match res {
     | 0 => return False;
@@ -248,14 +316,17 @@ function revert_handler() -> () {
   assembly { revert(0,0) }
 }
 
-data C_Add2_Selector = C_Add2_Selector;
+data C_Add2_Name = C_Add2_Name;
 
-instance C_Add2_Selector:Selector {
-  function hash(prx: Proxy(C_Add2_Selector)) -> word {
-    // This would be keccak256("add2(uint256,uint256)") >> 224
-    // Compiler computes this at compile time
-    return 0x29fcda33;  // placeholder value
-  }
+instance C_Add2_Name:ABIString {
+    function append(head : word, tail : word, prx : Proxy(C_Add2_Name)) -> word {
+        let size = 4;
+        assembly {
+            mstore(head, add(mload(head), size));
+            mstore(tail, 0x6164643200000000000000000000000000000000000000000000000000000000);
+        }
+        return Add.add(tail, size);
+    }
 }
 
 // transform
@@ -265,13 +336,12 @@ contract C {
     return Add.add(x,y);
   }
 
-  function main() -> word {
+  function main() -> () {
     let c = Contract(
-      Method(C_Add2_Selector, Proxy : Proxy(NonPayable), Proxy : Proxy((uint256,uint256)), Proxy : Proxy(uint256), add2),
+      Method(C_Add2_Name, Proxy : Proxy(NonPayable), Proxy : Proxy((uint256,uint256)), Proxy : Proxy(uint256), add2),
       Fallback(Proxy : Proxy(NonPayable), Proxy : Proxy(()), Proxy : Proxy(()),revert_handler)
     );
 
     RunContract.exec(c);
-    return 0;
   }
 }

--- a/std/dispatch.solc
+++ b/std/dispatch.solc
@@ -9,10 +9,10 @@ pragma no-patterson-condition RunDispatch, ExecMethod;
 data Contract(methods, fallback) = Contract(methods,fallback);
 
 // A method contains an implementation (fn) as well as it's name and type signature
-data Method(name, payability, args, rets, fn) = Method(name, payability, args, rets, fn);
+data Method(name, payability, args, rets, fn) = Method(Proxy(name), Proxy(payability), Proxy(args), Proxy(rets), fn);
 
 // Contains the implementation for the fallback (fn) as well as it's type signature
-data Fallback(payability, args, rets, fn) = Fallback(payability, args, rets, fn);
+data Fallback(payability, args, rets, fn) = Fallback(Proxy(payability), Proxy(args), Proxy(rets), fn);
 
 // --- Method Selectors ---
 
@@ -82,8 +82,8 @@ forall ty . class ty:Selector {
 forall name payability args rets fn
     . name:ABIString
     , args:ABIString
-=> instance Method(name,payability,Proxy(args),Proxy(rets),fn):Selector {
-    function compute(prx : Proxy(Method(name,payability,Proxy(args),Proxy(rets),fn))) -> bytes4 {
+=> instance Method(name,payability,args,rets,fn):Selector {
+    function compute(prx : Proxy(Method(name,payability,args,rets,fn))) -> bytes4 {
         let head = get_free_memory();
         let tail = Add.add(head, 32);
         tail = ABIString.append(head, tail, Proxy : Proxy(name));
@@ -111,13 +111,13 @@ forall name payability args rets fn
   , rets:ABIAttribs
   , ABIDecoder(args,CalldataWordReader):ABIDecode(args)
   , rets:ABIEncode
-  , Method(name,payability,Proxy(args),Proxy(rets),fn):MethodLevelCallvalueCheck
-  => instance Method(name,payability,Proxy(args),Proxy(rets),fn):ExecMethod {
-  function exec(m : Method(name,payability,Proxy(args),Proxy(rets),fn)) -> () {
+  , Method(name,payability,args,rets,fn):MethodLevelCallvalueCheck
+  => instance Method(name,payability,args,rets,fn):ExecMethod {
+  function exec(m : Method(name,payability,args,rets,fn)) -> () {
     match m {
-      | Method(nm,payability,pargs,prets,fn) =>
+      | Method(pnm,ppayability,pargs,prets,fn) =>
         // check callvalue
-        MethodLevelCallvalueCheck.checkCallvalue(Proxy : Proxy(Method(name,payability,Proxy(args),Proxy(rets),fn)));
+        MethodLevelCallvalueCheck.checkCallvalue(Proxy : Proxy(Method(name,payability,args,rets,fn)));
 
         // check we have enough calldata for the head of args
         let hdsz = ABIAttribs.headSize(pargs);
@@ -158,13 +158,13 @@ forall payability args rets fn
   . fn:invokable(args,rets)
   , args:ABIAttribs
   , rets:ABIAttribs
-  , Fallback(payability,Proxy(args),Proxy(rets),fn):MethodLevelCallvalueCheck
-  => instance Fallback(payability,Proxy(args),Proxy(rets),fn):ExecMethod {
-  function exec(fb : Fallback(payability, Proxy(args),Proxy(rets),fn)) -> () {
+  , Fallback(payability,args,rets,fn):MethodLevelCallvalueCheck
+  => instance Fallback(payability,args,rets,fn):ExecMethod {
+  function exec(fb : Fallback(payability,args,rets,fn)) -> () {
     match fb {
-      | Fallback(payability, args, rets, fn) =>
+      | Fallback(ppayability, pargs, prets, fn) =>
         // check callvalue
-        MethodLevelCallvalueCheck.checkCallvalue(Proxy : Proxy(Fallback(payability, Proxy(args),Proxy(rets),fn)));
+        MethodLevelCallvalueCheck.checkCallvalue(Proxy : Proxy(Fallback(payability,args,rets,fn)));
 
         // check we have enough calldata for the head of args
         // abi decode args from calldata
@@ -232,22 +232,22 @@ forall ty . class ty:MethodLevelCallvalueCheck {
 }
 
 // no callvalue check for Payable methods
-forall name args ret fn . instance Method(name,Proxy(Payable),args,ret,fn):MethodLevelCallvalueCheck {
-  function checkCallvalue(prx : Proxy(Method(name,Proxy(Payable),args,ret,fn))) -> () { }
+forall name args ret fn . instance Method(name,Payable,args,ret,fn):MethodLevelCallvalueCheck {
+  function checkCallvalue(prx : Proxy(Method(name,Payable,args,ret,fn))) -> () { }
 }
-forall args ret fn . instance Fallback(Proxy(Payable),args,ret,fn):MethodLevelCallvalueCheck {
-  function checkCallvalue(prx : Proxy(Fallback(Proxy(Payable),args,ret,fn))) -> () { }
+forall args ret fn . instance Fallback(Payable,args,ret,fn):MethodLevelCallvalueCheck {
+  function checkCallvalue(prx : Proxy(Fallback(Payable,args,ret,fn))) -> () { }
 }
 
 // NonPayable methods revert if passed value
-forall name args ret fn . instance Method(name,Proxy(NonPayable),args,ret,fn):MethodLevelCallvalueCheck {
-  function checkCallvalue(prx : Proxy(Method(name,Proxy(NonPayable),args,ret,fn))) -> () {
+forall name args ret fn . instance Method(name,NonPayable,args,ret,fn):MethodLevelCallvalueCheck {
+  function checkCallvalue(prx : Proxy(Method(name,NonPayable,args,ret,fn))) -> () {
     ensureNoCallvalue();
   }
 }
 
-forall name args ret fn . instance Fallback(Proxy(NonPayable),args,ret,fn):MethodLevelCallvalueCheck {
-  function checkCallvalue(prx : Proxy(Fallback(Proxy(NonPayable),args,ret,fn))) -> () {
+forall name args ret fn . instance Fallback(NonPayable,args,ret,fn):MethodLevelCallvalueCheck {
+  function checkCallvalue(prx : Proxy(Fallback(NonPayable,args,ret,fn))) -> () {
     ensureNoCallvalue();
   }
 }
@@ -311,7 +311,7 @@ function revert_handler() -> () {
   assembly { revert(0,0) }
 }
 
-data C_Add2_Name = C_Add2_Name;
+data C_Add2_Name;
 
 instance C_Add2_Name:ABIString {
     function append(head : word, tail : word, prx : Proxy(C_Add2_Name)) -> word {
@@ -333,8 +333,8 @@ contract C {
 
   function main() -> () {
     let c = Contract(
-      Method(C_Add2_Name, Proxy : Proxy(NonPayable), Proxy : Proxy((uint256,uint256)), Proxy : Proxy(uint256), add2),
-      Fallback(Proxy : Proxy(NonPayable), Proxy : Proxy(()), Proxy : Proxy(()),revert_handler)
+      Method(Proxy: Proxy(C_Add2_Name), Proxy : Proxy(NonPayable), Proxy : Proxy((uint256,uint256)), Proxy : Proxy(uint256), add2),
+      Fallback(Proxy : Proxy(NonPayable), Proxy : Proxy(()), Proxy : Proxy(()), revert_handler)
     );
 
     RunContract.exec(c);

--- a/std/dispatch.solc
+++ b/std/dispatch.solc
@@ -79,20 +79,31 @@ forall ty . class ty:Selector {
 
 // Computes the selector hash for a given method
 // this is a class with a single instance since it made some of the downstream definitions a bit cleaner to define
+// NOTE: for efficiency purposes this leaves dirty data past the end of the free memory pointer
 forall name payability args rets fn
     . name:ABIString
     , args:ABIString
 => instance Method(name,payability,args,rets,fn):Selector {
     function compute(prx : Proxy(Method(name,payability,args,rets,fn))) -> bytes4 {
+        // setup memory pointers for the selector string
         let head = get_free_memory();
         let tail = Add.add(head, 32);
+
+        // ensure the size is zero
+        assembly { mstore(head, 0) }
+
+        // write the selector string
         tail = ABIString.append(head, tail, Proxy : Proxy(name));
         tail = append_left_bracket(head, tail);
         tail = ABIString.append(head, tail, Proxy : Proxy(args));
         tail = append_right_bracket(head, tail);
 
+        // hash it & get the first four bytes
         let res : word;
-        assembly { res := shr(224, keccak256(add(head, 32), mload(head))) }
+        assembly {
+            let hash := keccak256(add(head, 32), mload(head))
+            res := shr(224, hash)
+        }
         return bytes4(res);
     }
 }

--- a/std/dispatch.solc
+++ b/std/dispatch.solc
@@ -189,9 +189,12 @@ forall ty . class ty:RunDispatch {
 }
 
 // We can dispatch to a single executable method with a known selector
-forall m . m:ExecMethod, m:Selector => instance m:RunDispatch {
-  function go(method : m) -> () {
-    match selector_matches(Proxy : Proxy(m)) {
+forall name payability args rets fn
+  . Method(name,payability,args,rets,fn):ExecMethod
+  , Method(name,payability,args,rets,fn):Selector
+=> instance Method(name,payability,args,rets,fn):RunDispatch {
+  function go(method : Method(name,payability,args,rets,fn)) -> () {
+    match selector_matches(Proxy : Proxy(Method(name,payability,args,rets,fn))) {
       | true => ExecMethod.exec(method);
       | false => return ();
     }

--- a/std/dispatch.solc
+++ b/std/dispatch.solc
@@ -2,11 +2,6 @@ import std;
 
 pragma no-patterson-condition RunDispatch, ExecMethod;
 
-// --- Preliminaries ---
-
-data Bool = True | False;
-data Proxy(a) = Proxy;
-
 // --- Core Data Types ---
 
 // A contract contains a tuple of methods and a single fallback
@@ -193,8 +188,8 @@ forall ty callvalueCheckStatus . class ty:RunDispatch {
 forall m . m:ExecMethod, m:Selector => instance m:RunDispatch {
   function go(method : m) -> () {
     match selector_matches(Proxy : Proxy(m)) {
-      | True => ExecMethod.exec(method);
-      | False => return ();
+      | true => ExecMethod.exec(method);
+      | false => return ();
     }
   }
 }
@@ -205,8 +200,8 @@ forall n m . n:ExecMethod, n:Selector, m:RunDispatch => instance (n,m):RunDispat
     match methods {
       | (method_n, rest) =>
         match selector_matches(Proxy : Proxy(n)) {
-          | True => ExecMethod.exec(method_n);
-          | False => RunDispatch.go(rest);
+          | true => ExecMethod.exec(method_n);
+          | false => RunDispatch.go(rest);
         }
     }
   }
@@ -214,7 +209,7 @@ forall n m . n:ExecMethod, n:Selector, m:RunDispatch => instance (n,m):RunDispat
 
 // TODO: we only wanna do the calldataload once
 // Given evidence of a type with a known selector, we can check if it matches the selector in the first four bytes of calldata
-forall ty . ty:Selector => function selector_matches(prx : Proxy(ty)) -> Bool {
+forall ty . ty:Selector => function selector_matches(prx : Proxy(ty)) -> bool {
   let candidate = Typedef.rep(Selector.compute(prx));
   let res : word;
   assembly {
@@ -222,8 +217,8 @@ forall ty . ty:Selector => function selector_matches(prx : Proxy(ty)) -> Bool {
     res := eq(sel, candidate);
   }
   match res {
-    | 0 => return False;
-    | _ => return True;
+    | 0 => return false;
+    | _ => return true;
   }
 }
 

--- a/std/dispatch.solc
+++ b/std/dispatch.solc
@@ -1,0 +1,277 @@
+import std;
+
+pragma no-patterson-condition RunDispatch, ExecMethod;
+
+// --- Preliminaries ---
+
+data Bool = True | False;
+data Proxy(a) = Proxy;
+
+// --- Core Data Types ---
+
+// A contract contains a tuple of methods and a single fallback
+// TODO: implement receive()
+data Contract(methods, fallback) = Contract(methods,fallback);
+
+// A method contains an implementation (fn) as well as it's name and type signature
+data Method(name, payability, args, rets, fn) = Method(name, payability, args, rets, fn);
+
+// Contains the implementation for the fallback (fn) as well as it's type signature
+data Fallback(payability, args, rets, fn) = Fallback(payability, args, rets, fn);
+
+// --- Method Selectors ---
+
+// For each method in a contract the compiler generates a unique type and
+// produces a `Selector` instance for that type that returns the selector hash
+forall nm . class nm:Selector {
+  function hash(prx: Proxy(nm)) -> word;
+}
+
+// Method has a Selector if its name has a Selector
+forall name payability args rets fn . name:Selector => instance Method(name,payability,args,rets,fn):Selector {
+  function hash(prx: Proxy(Method(name,payability,args,rets,fn))) -> word {
+    return Selector.hash(Proxy : Proxy(name));
+  }
+}
+
+// --- Method Execution ---
+
+// Describes how to execute a given method / fallback
+forall ty . class ty:ExecMethod {
+  function exec(x: ty);
+}
+
+// If fn matches the provided args/ret types, then we can execute any method
+forall name payability args rets fn
+  . fn:invokable(args,rets)
+  , args:ABIAttribs
+  , rets:ABIAttribs
+  , ABIDecoder(args,CalldataWordReader):ABIDecode(args)
+  , rets:ABIEncode
+  , Method(name,payability,Proxy(args),Proxy(rets),fn):MethodLevelCallvalueCheck
+  => instance Method(name,payability,Proxy(args),Proxy(rets),fn):ExecMethod {
+  function exec(m : Method(name,payability,Proxy(args),Proxy(rets),fn)) -> () {
+    match m {
+      | Method(nm,payability,pargs,prets,fn) =>
+        // check callvalue
+        MethodLevelCallvalueCheck.checkCallvalue(Proxy : Proxy(Method(name,payability,Proxy(args),Proxy(rets),fn)));
+
+        // check we have enough calldata for the head of args
+        let hdsz = ABIAttribs.headSize(pargs);
+        assembly {
+          if lt(sub(calldatasize(), 4), hdsz) {
+            revert(0,0);
+          };
+        }
+
+        // TODO: calldatasize checks for dynamic types
+
+        // abi decode args from calldata
+        let ptr : calldata(bytes) = calldata(4);
+
+        // TODO: this needs entirely too many type annotations
+        let args : args = abi_decode(ptr, pargs, Proxy : Proxy(CalldataWordReader));
+
+        // call fn with args
+        // TODO: why are type annotations needed here?
+        let rets : rets = fn(args);
+
+        // abi encode rets to memory
+        let ptr = abi_encode(rets);
+
+        // TODO: this is broken for dynamically sized types...
+        let retSz : word = ABIAttribs.headSize(prets);
+        let start : word = Typedef.rep(ptr);
+
+        assembly {
+          return(start,retSz)
+        }
+    }
+  }
+}
+
+// If fn matches the provided args/ret types, then we can execute any fallback
+forall payability args rets fn
+  . fn:invokable(args,rets)
+  , args:ABIAttribs
+  , rets:ABIAttribs
+  , Fallback(payability,Proxy(args),Proxy(rets),fn):MethodLevelCallvalueCheck
+  => instance Fallback(payability,Proxy(args),Proxy(rets),fn):ExecMethod {
+  function exec(fb : Fallback(payability, Proxy(args),Proxy(rets),fn)) -> () {
+    match fb {
+      | Fallback(payability, args, rets, fn) =>
+        // check callvalue
+        MethodLevelCallvalueCheck.checkCallvalue(Proxy : Proxy(Fallback(payability, Proxy(args),Proxy(rets),fn)));
+
+        // check we have enough calldata for the head of args
+        // abi decode args from calldata
+        // call fn with args
+        // abi encode rets to memory
+        // returndata copy encoded returns
+        // evm return
+        return ();
+    }
+  }
+}
+
+// --- Method Dispatch ---
+
+// For a given tuple of methods this executes the method specified by the first four bytes of calldata
+forall ty callvalueCheckStatus . class ty:RunDispatch {
+  function go(methods : ty) -> ();
+}
+
+// We can dispatch to a single executable method with a known selector
+forall m . m:ExecMethod, m:Selector => instance m:RunDispatch {
+  function go(method : m) -> () {
+    match selector_matches(Proxy : Proxy(m)) {
+      | True => ExecMethod.exec(method);
+      | False => return ();
+    }
+  }
+}
+
+// Recursive instance
+forall n m . n:ExecMethod, n:Selector, m:RunDispatch => instance (n,m):RunDispatch {
+  function go(methods : (n,m)) -> () {
+    match methods {
+      | (method_n, rest) =>
+        match selector_matches(Proxy : Proxy(n)) {
+          | True => ExecMethod.exec(method_n);
+          | False => RunDispatch.go(rest);
+        }
+    }
+  }
+}
+
+// TODO: we only wanna do the calldataload once
+// Given evidence of a name with a known selector, we can check if it matches the selector in the first four bytes of calldata
+forall name . name:Selector => function selector_matches(prx : Proxy(name)) -> Bool {
+  let hash = Selector.hash(prx);
+  let res : word;
+  assembly {
+    let sel := shr(224, calldataload(0));
+    res := eq(sel, hash);
+  }
+  match res {
+    | 0 => return False;
+    | _ => return True;
+  }
+}
+
+// --- Callvalue Checks ---
+
+data Payable;
+data NonPayable;
+
+forall ty . class ty:MethodLevelCallvalueCheck {
+  function checkCallvalue(pty : Proxy(ty));
+}
+
+// no callvalue check for Payable methods
+forall name args ret fn . instance Method(name,Proxy(Payable),args,ret,fn):MethodLevelCallvalueCheck {
+  function checkCallvalue(prx : Proxy(Method(name,Proxy(Payable),args,ret,fn))) -> () { }
+}
+forall args ret fn . instance Fallback(Proxy(Payable),args,ret,fn):MethodLevelCallvalueCheck {
+  function checkCallvalue(prx : Proxy(Fallback(Proxy(Payable),args,ret,fn))) -> () { }
+}
+
+// NonPayable methods revert if passed value
+forall name args ret fn . instance Method(name,Proxy(NonPayable),args,ret,fn):MethodLevelCallvalueCheck {
+  function checkCallvalue(prx : Proxy(Method(name,Proxy(NonPayable),args,ret,fn))) -> () {
+    ensureNoCallvalue();
+  }
+}
+
+forall name args ret fn . instance Fallback(Proxy(NonPayable),args,ret,fn):MethodLevelCallvalueCheck {
+  function checkCallvalue(prx : Proxy(Fallback(Proxy(NonPayable),args,ret,fn))) -> () {
+    ensureNoCallvalue();
+  }
+}
+
+function ensureNoCallvalue() -> () {
+  assembly {
+    if gt(callvalue(), 0) {
+      mstore(0, 0x1);
+      revert(0, 32);
+    }
+  }
+}
+
+// --- Contract Execution ---
+
+// Describes how to execute a given contract
+forall c . class c:RunContract {
+  function exec(v : c) -> ();
+}
+
+// If we have a dispatch for the contracts methods, and we know how to execute it's fallback, then we can define an entrypoint
+forall methods fallback . methods:RunDispatch, fallback:ExecMethod => instance Contract(methods, fallback):RunContract {
+  function exec(c : Contract(methods, fallback)) -> () {
+    match c {
+      | Contract(ms, fb) =>
+
+        // TODO: if all methods are non payable then we should life the callvalue check here
+
+        // check that we have at least 4 bytes of calldata
+        let haveSelector : word;
+        assembly {
+          haveSelector := lt(3, calldatasize());
+        }
+
+        match haveSelector {
+          | 0 =>
+              assembly {
+                  mstore(0,0xff)
+                  revert(0,1)
+              }
+          | _ =>
+            // set free memory pointer to the output of memoryguard
+            // https://docs.soliditylang.org/en/v0.8.30/yul.html#memoryguard
+            // TODO: we will need to consider immutables here at some point...
+            assembly { mstore(0x40, memoryguard(128)); }
+
+            // dispatch to method based on selector
+            RunDispatch.go(ms);
+            // run fallback if no methods matched
+            ExecMethod.exec(fb);
+        }
+    }
+  }
+}
+
+// --- Manually Desugared Example ---
+
+// compiler generated
+
+function revert_handler() -> () {
+  assembly { revert(0,0) }
+}
+
+data C_Add2_Selector = C_Add2_Selector;
+
+instance C_Add2_Selector:Selector {
+  function hash(prx: Proxy(C_Add2_Selector)) -> word {
+    // This would be keccak256("add2(uint256,uint256)") >> 224
+    // Compiler computes this at compile time
+    return 0x29fcda33;  // placeholder value
+  }
+}
+
+// transform
+
+contract C {
+  function add2(x : uint256, y : uint256) -> uint256 {
+    return Add.add(x,y);
+  }
+
+  function main() -> word {
+    let c = Contract(
+      Method(C_Add2_Selector, Proxy : Proxy(NonPayable), Proxy : Proxy((uint256,uint256)), Proxy : Proxy(uint256), add2),
+      Fallback(Proxy : Proxy(NonPayable), Proxy : Proxy(()), Proxy : Proxy(()),revert_handler)
+    );
+
+    RunContract.exec(c);
+    return 0;
+  }
+}

--- a/std/dispatch.solc
+++ b/std/dispatch.solc
@@ -111,44 +111,12 @@ forall name payability args rets fn
   , rets:ABIAttribs
   , ABIDecoder(args,CalldataWordReader):ABIDecode(args)
   , rets:ABIEncode
-  , Method(name,payability,args,rets,fn):MethodLevelCallvalueCheck
-  => instance Method(name,payability,args,rets,fn):ExecMethod {
+  , payability:MethodLevelCallvalueCheck
+=> instance Method(name,payability,args,rets,fn):ExecMethod {
   function exec(m : Method(name,payability,args,rets,fn)) -> () {
     match m {
       | Method(pnm,ppayability,pargs,prets,fn) =>
-        // check callvalue
-        MethodLevelCallvalueCheck.checkCallvalue(Proxy : Proxy(Method(name,payability,args,rets,fn)));
-
-        // check we have enough calldata for the head of args
-        let hdsz = ABIAttribs.headSize(pargs);
-        assembly {
-          if lt(sub(calldatasize(), 4), hdsz) {
-            revert(0,0);
-          };
-        }
-
-        // TODO: calldatasize checks for dynamic types
-
-        // abi decode args from calldata
-        let ptr : calldata(bytes) = calldata(4);
-
-        // TODO: this needs entirely too many type annotations
-        let args : args = abi_decode(ptr, pargs, Proxy : Proxy(CalldataWordReader));
-
-        // call fn with args
-        // TODO: why are type annotations needed here?
-        let rets : rets = fn(args);
-
-        // abi encode rets to memory
-        let ptr = abi_encode(rets);
-
-        // TODO: this is broken for dynamically sized types...
-        let retSz : word = ABIAttribs.headSize(prets);
-        let start : word = Typedef.rep(ptr);
-
-        assembly {
-          return(start,retSz)
-        }
+        do_exec(ppayability, pargs, prets, fn);
     }
   }
 }
@@ -158,29 +126,65 @@ forall payability args rets fn
   . fn:invokable(args,rets)
   , args:ABIAttribs
   , rets:ABIAttribs
-  , Fallback(payability,args,rets,fn):MethodLevelCallvalueCheck
-  => instance Fallback(payability,args,rets,fn):ExecMethod {
+  , ABIDecoder(args,CalldataWordReader):ABIDecode(args)
+  , rets:ABIEncode
+  , payability:MethodLevelCallvalueCheck
+=> instance Fallback(payability,args,rets,fn):ExecMethod {
   function exec(fb : Fallback(payability,args,rets,fn)) -> () {
     match fb {
       | Fallback(ppayability, pargs, prets, fn) =>
-        // check callvalue
-        MethodLevelCallvalueCheck.checkCallvalue(Proxy : Proxy(Fallback(payability,args,rets,fn)));
-
-        // check we have enough calldata for the head of args
-        // abi decode args from calldata
-        // call fn with args
-        // abi encode rets to memory
-        // returndata copy encoded returns
-        // evm return
-        return ();
+        do_exec(ppayability, pargs, prets, fn);
     }
   }
+}
+
+forall payability args rets fn
+  . fn:invokable(args,rets)
+  , args:ABIAttribs
+  , rets:ABIAttribs
+  , ABIDecoder(args,CalldataWordReader):ABIDecode(args)
+  , rets:ABIEncode
+  , payability:MethodLevelCallvalueCheck
+=> function do_exec(ppayability : Proxy(payability), pargs : Proxy(args), prets : Proxy(rets), fn : fn) -> () {
+    // check callvalue
+    MethodLevelCallvalueCheck.checkCallvalue(Proxy : Proxy(payability));
+
+    // check we have enough calldata for the head of args
+    let hdsz = ABIAttribs.headSize(pargs);
+    assembly {
+        if lt(sub(calldatasize(), 4), hdsz) {
+            revert(0,0);
+        };
+    }
+
+    // TODO: calldatasize checks for dynamic types
+
+    // abi decode args from calldata
+    let ptr : calldata(bytes) = calldata(4);
+
+    // TODO: this needs entirely too many type annotations
+    let args : args = abi_decode(ptr, pargs, Proxy : Proxy(CalldataWordReader));
+
+    // call fn with args
+    // TODO: why are type annotations needed here?
+    let rets : rets = fn(args);
+
+    // abi encode rets to memory
+    let ptr = abi_encode(rets);
+
+    // TODO: this is broken for dynamically sized types...
+    let retSz : word = ABIAttribs.headSize(prets);
+    let start : word = Typedef.rep(ptr);
+
+    assembly {
+        return(start,retSz)
+    }
 }
 
 // --- Method Dispatch ---
 
 // For a given tuple of methods this executes the method specified by the first four bytes of calldata
-forall ty callvalueCheckStatus . class ty:RunDispatch {
+forall ty . class ty:RunDispatch {
   function go(methods : ty) -> ();
 }
 
@@ -228,37 +232,23 @@ data Payable;
 data NonPayable;
 
 forall ty . class ty:MethodLevelCallvalueCheck {
-  function checkCallvalue(pty : Proxy(ty));
+    function checkCallvalue(pty : Proxy(ty));
 }
 
 // no callvalue check for Payable methods
-forall name args ret fn . instance Method(name,Payable,args,ret,fn):MethodLevelCallvalueCheck {
-  function checkCallvalue(prx : Proxy(Method(name,Payable,args,ret,fn))) -> () { }
+instance Payable:MethodLevelCallvalueCheck {
+    function checkCallvalue(prx : Proxy(Payable)) -> () { }
 }
-forall args ret fn . instance Fallback(Payable,args,ret,fn):MethodLevelCallvalueCheck {
-  function checkCallvalue(prx : Proxy(Fallback(Payable,args,ret,fn))) -> () { }
-}
-
 // NonPayable methods revert if passed value
-forall name args ret fn . instance Method(name,NonPayable,args,ret,fn):MethodLevelCallvalueCheck {
-  function checkCallvalue(prx : Proxy(Method(name,NonPayable,args,ret,fn))) -> () {
-    ensureNoCallvalue();
-  }
-}
-
-forall name args ret fn . instance Fallback(NonPayable,args,ret,fn):MethodLevelCallvalueCheck {
-  function checkCallvalue(prx : Proxy(Fallback(NonPayable,args,ret,fn))) -> () {
-    ensureNoCallvalue();
-  }
-}
-
-function ensureNoCallvalue() -> () {
-  assembly {
-    if gt(callvalue(), 0) {
-      mstore(0, 0x1);
-      revert(0, 32);
-    }
-  }
+instance NonPayable:MethodLevelCallvalueCheck {
+   function checkCallvalue(prx : Proxy(NonPayable)) -> () {
+       assembly {
+         if gt(callvalue(), 0) {
+           mstore(0, 0x1);
+           revert(0, 32);
+         }
+       }
+   }
 }
 
 // --- Contract Execution ---

--- a/std/std.solc
+++ b/std/std.solc
@@ -38,8 +38,6 @@ pragma no-coverage-condition ABIDecode, MemoryType;
 
 // --- booleans ---
 
-data bool = true | false;
-
 // TODO: this should short circuit. probably needs some compiler magic to do so.
 function and(x: bool, y: bool) -> bool {
     match x, y {
@@ -156,6 +154,11 @@ instance uint256:Typedef(word) {
         | uint256(w) => return w;
         }
     }
+}
+instance uint256:Add {
+  function add(x : uint256, y : uint256) -> uint256 {
+    return Typedef.abs(Add.add(Typedef.rep(x), Typedef.rep(y)));
+  }
 }
 
 data byte = byte(word);
@@ -360,7 +363,10 @@ instance CalldataWordReader:WordReader {
     function read(reader:CalldataWordReader) -> word {
         let result : word;
         match reader {
-        | CalldataWordReader(ptr) => assembly { result := calldataload(ptr) }
+          | CalldataWordReader(ptr) =>
+            // https://github.com/argotorg/solcore/issues/188
+            let ptr2 = ptr;
+            assembly { result := calldataload(ptr2) }
         }
         return result;
     }
@@ -467,6 +473,10 @@ forall self . class self:ABIAttribs {
     function isStatic(ty:Proxy(self)) -> bool;
 }
 
+instance ():ABIAttribs {
+    function headSize(ty : Proxy(())) -> word { return 0; }
+    function isStatic(ty : Proxy(())) -> bool { return true; }
+}
 instance uint256:ABIAttribs {
     function headSize(ty : Proxy(uint256)) -> word { return 32; }
     function isStatic(ty : Proxy(uint256)) -> bool { return true; }
@@ -714,69 +724,14 @@ function getReader(d:ABIDecoder(ty, reader)) -> reader {
     }
 }
 
- forall baseType baseType_decoded reader . ABIDecoder(baseType, CalldataWordReader):ABIDecode(baseType_decoded),
-     baseType : WordReader =>
-     instance ABIDecoder(calldata(DynArray(baseType)), CalldataWordReader):ABIDecode(calldata(DynArray(baseType_decoded)))
- {
-     function decode(ptr:ABIDecoder(calldata(DynArray(baseType)), reader), currentHeadOffset:word) -> calldata(DynArray(baseType)) {
-          let newptr = WordReader.advance(ptr, currentHeadOffset);
-	  let reader: CalldataWordReader = getReader(newptr);
-          let addr: word = Typedef.rep(reader);
-          return Typedef.abs(addr);
-     }
- }
-
-//
-// --- Contract Entrypoint ---
-
-forall nm . class nm:Selector {}
-
-forall ty f . f : invokable((),()) => class ty:GenerateDispatch {
-    function dispatch_if_selector_match(x: ty) -> f;
-}
-
-data Dispatch(name, args, retvals, f) = Dispatch(name, args, rets, f);
-
-forall name . name:Selector => function selector_matches(nm : name) -> bool {
-    return true;
-}
-
-forall nm args rets f g . nm:Selector, args:ABIDecode, rets:ABIEncode, f:invokable(args, rets) => instance Dispatch(nm,args,rets,f):GenerateDispatch {
-    function dispatch_if_selector_match(d:Dispatch(nm,args,rets,f)) -> g {
-        return lam() {
-            match d {
-            | Dispatch(name, args, rets, fn) => match selector_matches(name) {
-                | false => return ();
-                | true => return ();
-            }}
-        };
+forall baseType baseType_decoded reader . ABIDecoder(baseType, CalldataWordReader):ABIDecode(baseType_decoded),
+    baseType : WordReader =>
+    instance ABIDecoder(calldata(DynArray(baseType)), CalldataWordReader):ABIDecode(calldata(DynArray(baseType_decoded)))
+{
+    function decode(ptr:ABIDecoder(calldata(DynArray(baseType)), reader), currentHeadOffset:word) -> calldata(DynArray(baseType)) {
+        let newptr = WordReader.advance(ptr, currentHeadOffset);
+        let reader: CalldataWordReader = getReader(newptr);
+        let addr: word = Typedef.rep(reader);
+        return Typedef.abs(addr);
     }
 }
-
-//// /// Translation of the above contract
-//// struct StorageContext {
-////     x:uint;
-////     y:bool;
-//// }
-////
-//// function C_f(ctxt:StorageContext) public {
-////     ctxt.x = 42;
-//// }
-////
-////
-//// function entry_C() {
-////     GenerateDispatch.dispatch_if_selector_match(DispatchFunction("f()", C_f)); // could also be (nested) pairs of dispatch functions, if the contract had more functions
-////     revert("unknown selector");
-//// }
-////
-//// // init code for contract creation
-//// function init_C() {
-////     // constructor code
-////     let code_start := allocate_unbounded() // fetch some free memory
-////     let code_length := __builtin_fetch_code(entry_C, code_start) // sounds weirder than it is - this will just add the code for entry_C to a Yul subobject and use some Yul builtins for fetching the code to be deployed
-////     assembly {
-////         return(code_start, code_length)
-////     }
-//// }
-////
-////

--- a/std/std.solc
+++ b/std/std.solc
@@ -174,6 +174,21 @@ instance byte:Typedef(word) {
     }
 }
 
+// --- Bytes4 ---
+
+data bytes4 = bytes4(word);
+
+instance bytes4:Typedef(word) {
+    function rep(b : bytes4) -> word {
+        match b {
+            | bytes4(w) => return w;
+        }
+    }
+    function abs(w : word) -> bytes4 {
+        return bytes4(w);
+    }
+}
+
 // --- Pointers ---
 
 data memory(t) = memory(word);
@@ -245,6 +260,12 @@ function set_free_memory(loc : word) {
     assembly { mstore(0x40, loc) }
 }
 
+function allocate_memory(size : word) -> word {
+    let ptr = get_free_memory();
+    set_free_memory(Add.add(ptr,size));
+    return ptr;
+}
+
 // --- Indexable Types ---
 
 // types that can be written to and read from at a uint256 index
@@ -312,6 +333,11 @@ forall t . function allocateDynamicArray(prx : Proxy(t), length : word) -> memor
 // TODO: IndexAccess for calldata(bytes)
 // TODO: IndexAccess for storage(bytes)
 data bytes;
+
+// --- strings ---
+
+// TODO: should this be a typedef over `bytes`?
+data string;
 
 // --- slices (sized pointers) ---
 

--- a/std/std.solc
+++ b/std/std.solc
@@ -595,6 +595,13 @@ instance uint256:ABIEncode {
     }
 }
 
+instance ():ABIEncode {
+    // a unit256 is written directly into the head
+    function encodeInto(x:(), basePtr:word, offset:word, tail:word) -> word {
+        return tail;
+    }
+}
+
 // abi encoding for a pair of two encodable types
 forall a b . a:ABIAttribs, a:ABIEncode, b:ABIEncode => instance (a,b):ABIEncode {
     function encodeInto(x: (a,b), basePtr: word, offset: word, tail: word) -> word {
@@ -669,6 +676,12 @@ forall ty reader . reader:WordReader => instance ABIDecoder(ty, reader):WordRead
 forall reader . reader:WordReader => instance ABIDecoder(uint256, reader):ABIDecode(uint256) {
     function decode(ptr:ABIDecoder(uint256, reader), currentHeadOffset:word) -> uint256 {
         return Typedef.abs(WordReader.read(WordReader.advance(ptr, currentHeadOffset))) : uint256;
+    }
+}
+
+forall reader . reader:WordReader => instance ABIDecoder((), reader):ABIDecode(()) {
+    function decode(ptr:ABIDecoder((), reader), currentHeadOffset:word) -> () {
+        return ();
     }
 }
 

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -11,6 +11,7 @@ std =
   testGroup
     "Standard library"
     [ runTestForFile "std.solc" stdFolder
+    , runTestForFile "dispatch.solc" stdFolder
     ]
  where
   stdFolder = "./std"


### PR DESCRIPTION
This adds the core datatype definitions and class / instance definitions that allow us to desugar a surface level `contract` definition into a single entrypoint that dispatches to the contracts methods based on it's function selector hash.

An example desugaring can be seen at the end of the file. At a high level each surface level `contract` object will have a `main` generated that calls `RunContract.exec` on an instance of the `Contract` datatype reflecting the structure of the given contract. The defined typeclass instances will handle the dispatch generation and abi encoding/decoding.

Still to do:

- receive()
- move callvalue check to the top level if all methods are not payable
- `public` / `external`

Pending a decision on our implementation of compile time eval it also relies on the desugaring stage to precompute the selector hash and insert that directly into the bytecode.

You can test the desugaring logic as follows. This will call the `add2` method with `2` and `3` abi encoded, and then display the result:

```
$ ./runsol.sh std/dispatch.solc --calldata "add2(uint256,uint256)" 2 3
Processing: std/dispatch.solc
Compiling to core...
Emitting core for contract C
Writing to output1.core
Generating Yul...
found main
writing output to dispatch.yul
Compiling to bytecode...
Hex output: dispatch.hex
Executing...
"Return: 0x0000000000000000000000000000000000000000000000000000000000000005"
Decoded: 5
```