### PR TITLE
Sail objects

### DIFF
--- a/src/Language/Core.hs
+++ b/src/Language/Core.hs
@@ -2,7 +2,7 @@
 {-# OPTIONS_GHC -Wincomplete-patterns #-}
 {-# LANGUAGE InstanceSigs #-}
 module Language.Core
-  ( Expr(..), Stmt(..), Arg(..), Alt(..), pattern ConAlt, Pat(..), Con(..), Contract(..), Core(..), Body
+  ( Expr(..), Stmt(..), Arg(..), Alt(..), pattern ConAlt, Pat(..), Con(..), Contract(..), Object(..), Body
   , module Language.Core.Types
   ,  pattern SAV
   , Name
@@ -13,6 +13,8 @@ import Language.Core.Types
 import Language.Yul
 
 
+data Object = Object { objName :: Name, objCode :: Body, objInners :: [Object] }
+type Body = [Stmt]
 type Name = String
 
 data Expr
@@ -47,7 +49,6 @@ data Stmt
     | SRevert String
     -- deriving Show
 
-type Body = [Stmt]
 data Arg = TArg Name Type
 instance Show Arg where show = render . ppr
 instance Show Stmt where show :: Stmt -> String
@@ -66,6 +67,19 @@ data Contract = Contract { ccName :: Name, ccStmts ::  [Stmt] }
 newtype Core = Core [Stmt]
 instance Show Core where show = render . ppr
 instance Show Contract where show = render . ppr
+
+
+instance Pretty Object where
+  ppr (Object name code inners) = vcat
+    [ text "object" <+> ppr name <+> lbrace
+    , nest 2 $ vcat
+      [ text "code" <+> lbrace
+      , nest 2 $ ppr code
+      , rbrace
+      ]
+    , nvlist inners
+    , rbrace
+    ]
 
 instance Pretty Contract where
     ppr (Contract n stmts) = text "contract" <+> text n <+> lbrace $$ nest 4 (vcat (map ppr stmts)) $$ rbrace
@@ -139,6 +153,8 @@ instance Pretty Arg where
 instance Pretty Core where
     ppr (Core stmts) = vcat (map ppr stmts)
 
+pprBody :: Body -> Doc
+pprBody stmts = braces $ nest 2 (vcat (map ppr stmts))
 
 instance Pretty [Stmt] where
     ppr stmts = vcat (map ppr stmts)

--- a/src/Language/Core/Parser.hs
+++ b/src/Language/Core/Parser.hs
@@ -1,6 +1,7 @@
 module Language.Core.Parser where
 import Language.Core
-    ( Core(..), Contract(..), Body,
+    ( Object(..),
+      Body,
       Alt(..),
       Pat(..),
       Arg(..),
@@ -14,11 +15,9 @@ import Text.Megaparsec.Char.Lexer qualified as L
 import Control.Monad.Combinators.Expr
 import Language.Yul.Parser(yulBlock)
 
-parseCore :: String -> Core
-parseCore = runMyParser "core" coreProgram
 
-parseContract :: String -> String -> Contract
-parseContract filename = runMyParser filename coreContract
+parseObject :: String -> String -> Object
+parseObject filename = runMyParser filename coreObject
 
 -- Note: this module repeats some definitions from YulParser.Name
 -- This is intentional as we may want to make different syntax choices
@@ -158,9 +157,9 @@ corePat = choice
     , PWildcard <$ pKeyword "_"
     ]
 
-coreProgram :: Parser Core
-coreProgram = sc *> (Core <$> many coreStmt) <* eof
+coreObject :: Parser Object
+coreObject = sc *> (Object <$> (pKeyword "object" *> identifier  <* symbol "{")
+               <*> coreCode <*> many coreObject) <* symbol "}"
 
-coreContract :: Parser Contract
-coreContract = sc *> (Contract <$> (pKeyword "contract" *> identifier )
-                  <*> braces (many coreStmt)) <* eof
+coreCode :: Parser Body
+coreCode = sc *> (Object <$> pKeyword "code" *> coreBody)

--- a/src/Language/Yul.hs
+++ b/src/Language/Yul.hs
@@ -70,13 +70,18 @@ data YLiteral
   | YulFalse
   deriving (Eq, Ord, Data, Typeable)
 
-yulInt :: Integral i => i -> YulExp
-yulInt = YLit . YulNumber . fromIntegral
+yulIntegral :: Integral i => i -> YulExp
+yulIntegral = YLit . YulNumber . fromIntegral
+
+yulInt :: Integer -> YulExp
+yulInt = YLit . YulNumber
 
 yulBool :: Bool -> YulExp
 yulBool True = YLit YulTrue
 yulBool False = YLit YulFalse
 
+yulString :: String -> YulExp
+yulString = YLit . YulString
 
 -- auxilliary functions
 

--- a/src/Language/Yul.hs
+++ b/src/Language/Yul.hs
@@ -85,7 +85,7 @@ yulString = YLit . YulString
 
 -- auxilliary functions
 
-hlist, vlist, nvlist :: Pretty a => [a] -> Doc
+hlist, vlist, nvlist, pprBlock :: Pretty a => [a] -> Doc
 hlist = hsep . map ppr
 vlist = vcat . map ppr
 nvlist = nest 2 . vlist

--- a/src/Solcore/Pipeline/SolcorePipeline.hs
+++ b/src/Solcore/Pipeline/SolcorePipeline.hs
@@ -47,7 +47,7 @@ pipeline = do
         writeFile filename (show c)
 
 -- Version that returns Either for testing
-compile :: Option -> IO (Either String [Core.Contract])
+compile :: Option -> IO (Either String [Core.Object])
 compile opts = runExceptT $ do
   let verbose = optVerbose opts
       noDesugarCalls = optNoDesugarCalls opts

--- a/yule/Builtins.hs
+++ b/yule/Builtins.hs
@@ -3,8 +3,8 @@ module Builtins(yulBuiltins, revertStmt) where
 import Data.String
 import Language.Yul
 
-yulBuiltins :: Yul
-yulBuiltins = Yul []
+yulBuiltins :: [YulStmt]
+yulBuiltins = []
 
 revertStmt :: String -> [YulStmt]
 revertStmt s =  [ YExp $ YCall "mstore" [yulInt 0, YLit (YulString s)]

--- a/yule/Builtins.hs
+++ b/yule/Builtins.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Builtins(yulBuiltins) where
+module Builtins(yulBuiltins, revertStmt) where
 import Data.String
 import Language.Yul
 
@@ -8,7 +8,7 @@ yulBuiltins = Yul []
 
 revertStmt :: String -> [YulStmt]
 revertStmt s =  [ YExp $ YCall "mstore" [yulInt 0, YLit (YulString s)]
-                , YExp $ YCall "revert" [yulInt 0, yulInt (length s)]
+                , YExp $ YCall "revert" [yulInt 0, yulIntegral (length s)]
                 ]
 
 {-

--- a/yule/Main.hs
+++ b/yule/Main.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
-import Language.Core(Contract(..))
-import Language.Core.Parser(parseContract)
+import Language.Core(Object(..))
+import Language.Core.Parser(parseObject)
 import Solcore.Frontend.Syntax.Name  -- FIXME: move Name to Common
 import Common.Pretty -- (Doc, Pretty(..), nest, render)
 import Builtins(yulBuiltins)
@@ -21,27 +21,21 @@ main = do
     -- print options
     let filename = Options.input options
     src <- readFile filename
-    let coreContract = parseContract filename src
-    let core = ccStmts coreContract
-    when (Options.verbose options) $ do
-        putStrLn "/* Core:"
-        putStrLn (render (nest 2 (ppr coreContract)))
-        putStrLn "*/"
+    let (Object name code inners) = parseObject filename src
     let oCompress = Options.compress options
-    let source = if oCompress then compress core else core
     when oCompress $ do
         putStrLn "Compressing sums"
+    let source = if oCompress then compress code else code
     generatedYul <- runTM options (translateStmts source)
-    let name = fromString (ccName coreContract)
     let withDeployment = not (Options.runOnce options)
     let doc = if Options.wrap options
-        then wrapInSol name generatedYul
-        else wrapInObject name withDeployment generatedYul
+        then wrapInSol (Name name) generatedYul
+        else wrapInObject (Name name) withDeployment generatedYul
     putStrLn ("writing output to " ++ Options.output options)
     writeFile (Options.output options) (render doc)
 
 -- wrap in a Yul object with the given name
-wrapInObject :: Name -> Bool -> Yul -> Doc
+wrapInObject :: Name -> Bool -> [YulStmt] -> Doc
 wrapInObject name deploy yul
   | deploy    = ppr nested
   | otherwise = ppr runtime
@@ -49,37 +43,40 @@ wrapInObject name deploy yul
     nested = YulObject "Deployable" deploycode [InnerObject runtime]
     runtime = YulObject (show name) (YulCode stmts) []
     cname = yulString (show name)
-    stmts = yulStmts yul ++ retcode
+    stmts = yul ++ retcode
     retcode =
       [ calls "mstore" [yulInt 0, YIdent "_mainresult"]
       , calls "return" [yulInt 0, yulInt 32]
       ]
     deploycode = YulCode
-      [ calls "datacopy" [yulInt 0, dataoffset, datasize]
+      [ calls "mstore" [yulInt 64, YCall "memoryguard" [yulInt 128]]
+      , ylva "memPtr" (YCall "mload" [yulInt 64])
+      -- call constructor here
+      , calls "datacopy" [yulInt 0, dataoffset, datasize]
       , calls "return" [yulInt 0, datasize]
       ]
     calls f args = YExp (YCall f args)
+    ylva x e = YLet [Name x] (Just e)
     datasize = YCall "datasize"[cname]
     dataoffset = YCall "dataoffset"[cname]
 
 {- | wrap a Yul chunk in a Solidity function with the given name
    assumes result is in a variable named "_result"
 -}
-wrapInSol :: Name -> Yul -> Doc
+wrapInSol :: Name -> [YulStmt] -> Doc
 wrapInSol name yul = wrapInContract name "wrapper()" wrapper
     where
         wrapper = wrapInSolFunction "wrapper" (yulBuiltins <> yul)
 
-wrapInSolFunction :: Name -> Yul -> Doc
+wrapInSolFunction :: Name -> [YulStmt] -> Doc
 wrapInSolFunction name yul =
   text "function" <+> ppr name <+> prettyargs <+> text " public returns (uint256 _wrapresult)" <+> lbrace
   $$ nest 2 assembly
   $$ rbrace
   where
-    yul' = yul <> Yul [YAssign1 "_wrapresult" (YIdent "_mainresult")]
-    assembly = text "assembly" <+> lbrace
-      $$ nest 2 (ppr yul')
-      $$ rbrace
+    yul' = yul <> [YAssign1 "_wrapresult" (YIdent "_mainresult")]
+    assembly = text "assembly" <+> braces (nest 2 prettybody)
+    prettybody = vcat (map ppr yul')
     prettyargs = parens empty
 
 wrapInContract ::  Name -> Name -> Doc -> Doc

--- a/yule/Options.hs
+++ b/yule/Options.hs
@@ -10,6 +10,7 @@ data Options = Options
     , debug :: Bool
     , compress :: Bool
     , wrap :: Bool
+    , runOnce :: Bool
     } deriving Show
 
 optionsParser :: Parser Options
@@ -52,6 +53,10 @@ optionsParser = Options
         ( long "wrap"
         <> short 'w'
         <> help "Wrap Yul in a Solidity contract"
+        )
+    <*> switch
+        ( long "nodeploy"
+        <> help "Output code to be run once, without the deployment code"
         )
 
 parseOptions :: IO Options

--- a/yule/Translate.hs
+++ b/yule/Translate.hs
@@ -1,16 +1,21 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Translate where
+
+
 import Data.List(nub, union)
 import GHC.Stack
 import Language.Core hiding(Name)
 import qualified Language.Core as Core
-import TM
 import Language.Yul
 import Solcore.Frontend.Syntax.Name
 import Data.String
 
 import Common.Monad
 import Common.Pretty
+
+import Builtins
+import TM
+
 
 genExpr :: Expr -> TM ([YulStmt], Location)
 genExpr (EWord n) = pure ([], LocWord n)
@@ -179,10 +184,7 @@ genStmt (SFunction name args ret stmts) = withLocalEnv do
             return (flattenLhs loc)
 
 genStmt (SExpr e) = fst <$> genExpr e
-genStmt (SRevert s) = pure
-  [ YExp $ YCall "mstore" [yulInt 0, YLit (YulString s)]
-  , YExp $ YCall "revert" [yulInt 0, yulInt (length s)]
-  ]
+genStmt (SRevert s) = pure (revertStmt s)
 
 genStmt e = error $ "genStmt unimplemented for: " ++ show e
 


### PR DESCRIPTION
Add objects in SAIL (aka core) to reflect Yul objects, in preparation for adding constructor/deployer code.

Should be behaviour-neutral, except of the new output format:

```
object Answer {
  code {
    function main () -> word {
      return 42
    }
  }
}
```