### PR TITLE
Contract deployment - stage 1

### DIFF
--- a/src/Language/Yul.hs
+++ b/src/Language/Yul.hs
@@ -70,13 +70,18 @@ data YLiteral
   | YulFalse
   deriving (Eq, Ord, Data, Typeable)
 
-yulInt :: Integral i => i -> YulExp
-yulInt = YLit . YulNumber . fromIntegral
+yulIntegral :: Integral i => i -> YulExp
+yulIntegral = YLit . YulNumber . fromIntegral
+
+yulInt :: Integer -> YulExp
+yulInt = YLit . YulNumber
 
 yulBool :: Bool -> YulExp
 yulBool True = YLit YulTrue
 yulBool False = YLit YulFalse
 
+yulString :: String -> YulExp
+yulString = YLit . YulString
 
 -- auxilliary functions
 

--- a/yule/Builtins.hs
+++ b/yule/Builtins.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Builtins(yulBuiltins) where
+module Builtins(yulBuiltins, revertStmt) where
 import Data.String
 import Language.Yul
 
@@ -8,7 +8,7 @@ yulBuiltins = Yul []
 
 revertStmt :: String -> [YulStmt]
 revertStmt s =  [ YExp $ YCall "mstore" [yulInt 0, YLit (YulString s)]
-                , YExp $ YCall "revert" [yulInt 0, yulInt (length s)]
+                , YExp $ YCall "revert" [yulInt 0, yulIntegral (length s)]
                 ]
 
 {-

--- a/yule/Options.hs
+++ b/yule/Options.hs
@@ -10,6 +10,7 @@ data Options = Options
     , debug :: Bool
     , compress :: Bool
     , wrap :: Bool
+    , runOnce :: Bool
     } deriving Show
 
 optionsParser :: Parser Options
@@ -52,6 +53,10 @@ optionsParser = Options
         ( long "wrap"
         <> short 'w'
         <> help "Wrap Yul in a Solidity contract"
+        )
+    <*> switch
+        ( long "nodeploy"
+        <> help "Output code to be run once, without the deployment code"
         )
 
 parseOptions :: IO Options

--- a/yule/Translate.hs
+++ b/yule/Translate.hs
@@ -1,16 +1,21 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Translate where
+
+
 import Data.List(nub, union)
 import GHC.Stack
 import Language.Core hiding(Name)
 import qualified Language.Core as Core
-import TM
 import Language.Yul
 import Solcore.Frontend.Syntax.Name
 import Data.String
 
 import Common.Monad
 import Common.Pretty
+
+import Builtins
+import TM
+
 
 genExpr :: Expr -> TM ([YulStmt], Location)
 genExpr (EWord n) = pure ([], LocWord n)
@@ -179,10 +184,7 @@ genStmt (SFunction name args ret stmts) = withLocalEnv do
             return (flattenLhs loc)
 
 genStmt (SExpr e) = fst <$> genExpr e
-genStmt (SRevert s) = pure
-  [ YExp $ YCall "mstore" [yulInt 0, YLit (YulString s)]
-  , YExp $ YCall "revert" [yulInt 0, yulInt (length s)]
-  ]
+genStmt (SRevert s) = pure (revertStmt s)
 
 genStmt e = error $ "genStmt unimplemented for: " ++ show e
 


### PR DESCRIPTION
Adds basic contract deployment code (no constructors or dispatch yet).

Testing example
Assuming running node & PRIVATE_KEY set:

```
$ cabal exec sol-core -- -f test/examples/spec/00answer.solc 
Emitting core for contract Answer
Writing to output1.core

$ cabal exec yule -- output1.core -o Answer.yul
found main
writing output to Answer.yul

$ hex=$(solc --strict-assembly --bin --optimize --optimize-yul Answer.yul | tail -1)

$ rawtx=$(cast mktx --private-key=$PRIVATE_KEY --create $hex)

$ cast publish $rawtx | jq .contractAddress
"0x5fc8d32690cc91d4c39d9d3abcbd16989f875707"

ben@grab:~/work/solcore$ cast call 0x5fc8d32690cc91d4c39d9d3abcbd16989f875707
0x000000000000000000000000000000000000000000000000000000000000002a
```
