### PR TITLE
parser: allow Rust-style short returns

### DIFF
--- a/src/Solcore/Frontend/Parser/SolcoreParser.y
+++ b/src/Solcore/Frontend/Parser/SolcoreParser.y
@@ -270,6 +270,8 @@ InstBody : '{' Functions '}'                       {$2}
 
 Function :: { FunDef }
 Function : Signature Body {FunDef $1 $2}
+-- Proposed Rust-style short return, e.g `function d(x) { 2*x }`
+         | Signature '{' Expr '}' {FunDef $1 [Return $3]}
 
 OptRetTy :: { Maybe Ty }
 OptRetTy : '->' Type                               {Just $2}


### PR DESCRIPTION
Allow shorthand syntax for simple functions:
- e.g. `function d(x) { 2*x }`
- If a function body consists of a single expression, return its value.