### PR TITLE
Make testrunner buildable on Ubuntu noble LTS

### DIFF
--- a/test/testrunner/CMakeLists.txt
+++ b/test/testrunner/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.23)
+project(TestRunner)
 
 ## use multithreaded boost libraries, with -mt suffix
 set(Boost_USE_MULTITHREADED ON)
@@ -10,9 +12,9 @@ set(BOOST_COMPONENTS "filesystem;unit_test_framework;program_options;system")
 
 find_package(Boost CONFIG REQUIRED)
 
-
+include_directories(AFTER SYSTEM .)
 add_subdirectory(evmc)
-
+set_property(TARGET evmc PROPERTY CXX_STANDARD 20)
 add_executable(
         testrunner
         common.h
@@ -30,6 +32,14 @@ add_executable(
         picosha2.h
         testrunner.cpp
 )
+set_property(TARGET testrunner PROPERTY CXX_STANDARD 20)
+
+
+include(FetchContent)
+
+FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz)
+FetchContent_MakeAvailable(json)
+
 target_link_libraries(testrunner evmc Boost::headers nlohmann_json::nlohmann_json)
 
 


### PR DESCRIPTION
Building testrunner with cmake ran into several problems on Ubuntu 24.04 LTS.
This PR is an attempt to fix these problems. Needs thorough review though.

We should also think how to integrate building the testrunner in our CI (Nix?)