### PR TITLE
Single fix on a test case for instance typing

### DIFF
--- a/test/examples/cases/instance-wrong-sig.solc
+++ b/test/examples/cases/instance-wrong-sig.solc
@@ -1,5 +1,6 @@
 data uint256 = uint256(word);
-forall self . class self:ABIAttribs {`
+data Proxy(a) = Proxy;
+forall self . class self:ABIAttribs {
     function headSize(ty:Proxy(self)) -> word;
     function isStatic(ty:Proxy(self)) -> bool;
 }


### PR DESCRIPTION
* This test checks if type inference correctly rejects an instance member function which has not a type that is an instance of the class annotated most general function.