### PR TITLE
Fixes on type synonym expansion

### DIFF
--- a/src/Solcore/Frontend/TypeInference/TcContract.hs
+++ b/src/Solcore/Frontend/TypeInference/TcContract.hs
@@ -41,16 +41,25 @@ buildSynTable :: [TySym] -> SynTable
 buildSynTable syns =
   Map.fromList [(symName s, SynInfo (length (symVars s)) (symVars s) (symType s)) | s <- syns]
 
--- Pure recursive expansion of a single Ty using a SynTable
-expandTyPure :: SynTable -> Ty -> Ty
-expandTyPure st (TyCon n ts) =
-  let ts' = map (expandTyPure st) ts
-   in case Map.lookup n st of
-        Just (SynInfo _ params body)
-          | length params == length ts' -> expandTyPure st (insts (zip params ts') body)
-        _ -> TyCon n ts'
-expandTyPure st (t1 :-> t2) = expandTyPure st t1 :-> expandTyPure st t2
-expandTyPure _ t = t
+-- Monadic recursive expansion of a single Ty using a SynTable.
+-- Reports an error when a synonym is applied to the wrong number of arguments.
+expandTyM :: SynTable -> Ty -> TcM Ty
+expandTyM st (TyCon n ts) = do
+  ts' <- mapM (expandTyM st) ts
+  case Map.lookup n st of
+    Just (SynInfo _ params body)
+      | length params == length ts' ->
+          expandTyM st (insts (zip params ts') body)
+      | otherwise ->
+          throwError $
+            unlines
+              [ "Type synonym arity mismatch for '" ++ pretty n ++ "':",
+                "  expected " ++ show (length params) ++ " argument(s)",
+                "  but got  " ++ show (length ts')
+              ]
+    Nothing -> pure (TyCon n ts')
+expandTyM st (t1 :-> t2) = (:->) <$> expandTyM st t1 <*> expandTyM st t2
+expandTyM _ t = pure t
 
 tcCompUnit :: CompUnit Name -> TcM (CompUnit Id)
 tcCompUnit (CompUnit imps cs) =
@@ -58,7 +67,7 @@ tcCompUnit (CompUnit imps cs) =
     setupPragmas ps
     checkSynonymCycles syns
     let st = buildSynTable syns
-        cs' = everywhere (mkT (expandTyPure st)) cs
+    cs' <- everywhereM (mkM (expandTyM st)) cs
     mapM_ checkTopDecl (filter isClass cs')
     mapM_ checkTopDecl (filter (not . isClass) cs')
     typedDecls <- mapM tcTopDecl' cs'

--- a/src/Solcore/Frontend/TypeInference/TcContract.hs
+++ b/src/Solcore/Frontend/TypeInference/TcContract.hs
@@ -36,20 +36,37 @@ typeInfer opts (CompUnit imps topDecls) =
 
 -- type inference for a compilation unit
 
+-- Build a pure synonym table from parsed synonym declarations
+buildSynTable :: [TySym] -> SynTable
+buildSynTable syns =
+  Map.fromList [(symName s, SynInfo (length (symVars s)) (symVars s) (symType s)) | s <- syns]
+
+-- Pure recursive expansion of a single Ty using a SynTable
+expandTyPure :: SynTable -> Ty -> Ty
+expandTyPure st (TyCon n ts) =
+  let ts' = map (expandTyPure st) ts
+   in case Map.lookup n st of
+        Just (SynInfo _ params body)
+          | length params == length ts' -> expandTyPure st (insts (zip params ts') body)
+        _ -> TyCon n ts'
+expandTyPure st (t1 :-> t2) = expandTyPure st t1 :-> expandTyPure st t2
+expandTyPure _ t = t
+
 tcCompUnit :: CompUnit Name -> TcM (CompUnit Id)
 tcCompUnit (CompUnit imps cs) =
   do
     setupPragmas ps
     checkSynonymCycles syns
-    mapM_ checkTopDecl cls
-    mapM_ checkTopDecl nonClassDecls
-    typedDecls <- mapM tcTopDecl' cs
+    let st = buildSynTable syns
+        cs' = everywhere (mkT (expandTyPure st)) cs
+    mapM_ checkTopDecl (filter isClass cs')
+    mapM_ checkTopDecl (filter (not . isClass) cs')
+    typedDecls <- mapM tcTopDecl' cs'
     pure (CompUnit imps typedDecls)
   where
     ps = foldr step [] cs
     step (TPragmaDecl p) ac = p : ac
     step _ ac = ac
-    (cls, nonClassDecls) = partition isClass cs
     isClass (TClassDef _) = True
     isClass _ = False
     syns = [s | TSym s <- cs]
@@ -237,15 +254,15 @@ tcField :: Field Name -> TcM (Field Id)
 tcField d@(Field n t (Just e)) =
   do
     (e', _, t') <- tcExp e
-    _ <- kindCheck t `wrapError` d
+    t1 <- kindCheck t `wrapError` d
     _ <- mgu t t' `wrapError` d
-    extEnv n (monotype t)
-    return (Field n t (Just e'))
+    extEnv n (monotype t1)
+    return (Field n t1 (Just e'))
 tcField d@(Field n t _) =
   do
-    _ <- kindCheck t `wrapError` d
-    extEnv n (monotype t)
-    pure (Field n t Nothing)
+    t1 <- kindCheck t `wrapError` d
+    extEnv n (monotype t1)
+    pure (Field n t1 Nothing)
 
 tcClass :: Class Name -> TcM (Class Id)
 tcClass iclass@(Class bvs classCtx n vs v sigs) =
@@ -264,11 +281,11 @@ tcClass iclass@(Class bvs classCtx n vs v sigs) =
 tcSig :: (Signature Name, Scheme) -> TcM (Signature Id)
 tcSig (sig, (Forall _ (_ :=> t))) =
   do
-    let (ts, r) = splitTy t
-        param (Typed n _) t1 = Typed (Id n t1) t1
-        param (Untyped n) t1 = Typed (Id n t1) t1
+    t1 <- kindCheck t `wrapError` sig
+    let (ts, r) = splitTy t1
+        param (Typed n _) t2 = Typed (Id n t2) t2
+        param (Untyped n) t2 = Typed (Id n t2) t2
         params' = zipWith param (sigParams sig) ts
-    _ <- kindCheck t `wrapError` sig
     pure
       ( Signature
           (sigVars sig)

--- a/src/Solcore/Frontend/TypeInference/TcMonad.hs
+++ b/src/Solcore/Frontend/TypeInference/TcMonad.hs
@@ -141,19 +141,7 @@ matchTy t t' =
     extSubst s
 
 tcmMatch :: Ty -> Ty -> TcM Subst
-tcmMatch t u = do
-  result <- tryMatch t u
-  case result of
-    Right s -> pure s
-    Left err -> do
-      t' <- maybeExpandSynonym t
-      u' <- maybeExpandSynonym u
-      if t' == t && u' == u
-        then throwError err
-        else tcmMatch t' u'
-  where
-    tryMatch :: Ty -> Ty -> TcM (Either String Subst)
-    tryMatch t1 t2 = catchError (Right <$> match t1 t2) (pure . Left)
+tcmMatch t u = catchError (match t u) throwError
 
 addFunctionName :: Name -> TcM ()
 addFunctionName n =
@@ -191,44 +179,24 @@ kindCheck (t1 :-> t2) =
   (:->) <$> kindCheck t1 <*> kindCheck t2
 kindCheck t@(TyCon n ts) =
   do
-    mSyn <- maybeAskSynInfo n
-    case mSyn of
-      Just (SynInfo ar _ _) -> do
-        unless (ar == length ts) $
-          throwError $
-            unlines
-              [ "Invalid number of type arguments!",
-                "Type synonym "
-                  ++ pretty n
-                  ++ " expects "
-                  ++ show ar
-                  ++ " type arguments",
-                "but, type "
-                  ++ pretty t
-                  ++ " has "
-                  ++ (show $ length ts)
-                  ++ " arguments"
-              ]
-        maybeExpandSynonym t
-      Nothing -> do
-        ti <- askTypeInfo n `wrapError` t
-        unless (n == Name "pair" || arity ti == length ts) $
-          throwError $
-            unlines
-              [ "Invalid number of type arguments!",
-                "Type "
-                  ++ pretty n
-                  ++ " is expected to have "
-                  ++ show (arity ti)
-                  ++ " type arguments",
-                "but, type "
-                  ++ pretty t
-                  ++ " has "
-                  ++ (show $ length ts)
-                  ++ " arguments"
-              ]
-        ts' <- mapM kindCheck ts
-        pure (TyCon n ts')
+    ti <- askTypeInfo n `wrapError` t
+    unless (n == Name "pair" || arity ti == length ts) $
+      throwError $
+        unlines
+          [ "Invalid number of type arguments!",
+            "Type "
+              ++ pretty n
+              ++ " is expected to have "
+              ++ show (arity ti)
+              ++ " type arguments",
+            "but, type "
+              ++ pretty t
+              ++ " has "
+              ++ (show $ length ts)
+              ++ " arguments"
+          ]
+    ts' <- mapM kindCheck ts
+    pure (TyCon n ts')
 kindCheck t = pure t
 
 -- Skolemization
@@ -511,38 +479,6 @@ duplicatedSynonymDecl :: Name -> TcM a
 duplicatedSynonymDecl n =
   throwError $ unwords ["Duplicated type synonym definition:", pretty n]
 
--- type synonym expansion
-
-expandSynonym :: Name -> [Ty] -> TcM Ty
-expandSynonym n ts =
-  do
-    SynInfo ar params body <- askSynInfo n
-    unless (ar == length ts) $
-      throwError $
-        unlines
-          [ "Type synonym " ++ pretty n ++ " expects " ++ show ar ++ " arguments",
-            "but was given " ++ show (length ts)
-          ]
-    let env = zip params ts
-    pure (insts env body)
-
-maybeExpandSynonym :: Ty -> TcM Ty
-maybeExpandSynonym (TyCon n ts) =
-  do
-    isSyn <- isSynonym n
-    if isSyn
-      then expandSynonym n ts >>= maybeExpandSynonym -- recursively expand nested synonyms
-      else do
-        -- Recursively expand synonyms in type arguments
-        ts' <- mapM maybeExpandSynonym ts
-        pure (TyCon n ts')
-maybeExpandSynonym (t1 :-> t2) =
-  do
-    t1' <- maybeExpandSynonym t1
-    t2' <- maybeExpandSynonym t2
-    pure (t1' :-> t2')
-maybeExpandSynonym t = pure t
-
 -- manipulating the instance environment
 
 getClassEnv :: TcM ClassTable
@@ -698,19 +634,7 @@ wrapError m e =
     decorate msg = msg ++ "\n - in:" ++ pretty e
 
 tcmMgu :: Ty -> Ty -> TcM Subst
-tcmMgu t u = do
-  result <- tryMgu t u
-  case result of
-    Right s -> pure s
-    Left err -> do
-      t' <- maybeExpandSynonym t
-      u' <- maybeExpandSynonym u
-      if t' == t && u' == u
-        then tcmError err
-        else tcmMgu t' u'
-  where
-    tryMgu :: Ty -> Ty -> TcM (Either String Subst)
-    tryMgu t1 t2 = catchError (Right <$> mgu t1 t2) (pure . Left)
+tcmMgu t u = catchError (mgu t u) tcmError
 
 -- error messages
 

--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -40,10 +40,10 @@ tcStmt e@(Let n mt me) =
     (me', psf, tf) <- case (mt, me) of
       (Just t, Just e1) -> do
         (e', ps1, t1) <- tcExp e1
-        _ <- kindCheck t1 `wrapError` e
-        let bvs = bv t
+        t2 <- kindCheck t `wrapError` e
+        let bvs = bv t2
         sks <- mapM (const freshTyVar) bvs
-        let t' = insts (zip bvs sks) t
+        let t' = insts (zip bvs sks) t2
         s <- tcmMatch t1 t' `wrapError` e
         _ <- extSubst s
         withCurrentSubst (Just e', ps1, t')
@@ -160,9 +160,7 @@ tcPat t p@(PCon n ps) =
     -- unifying the infered pattern type with constructor type
     s <- unify tc (funtype ts t) `wrapError` p
     let t' = apply s t
-    -- expand synonyms before extracting type name
-    t'' <- maybeExpandSynonym t'
-    tn <- typeName t''
+    tn <- typeName t'
     -- checking if it is a defined constructor
     checkConstr tn n
     -- building typing assumptions for introduced names
@@ -218,8 +216,7 @@ tcExp e@(Con n es) =
     -- unifying inferred parameter types
     t' <- freshTyVar
     s <- unify (funtype ts t') t `wrapError` e
-    -- expand synonyms before extracting type name
-    t'' <- maybeExpandSynonym (apply s t')
+    let t'' = apply s t'
     tn <- typeName t''
     -- checking if the constructor belongs to type tn
     checkConstr tn n
@@ -233,9 +230,7 @@ tcExp (FieldAccess (Just e) n) =
   do
     -- inferring expression type
     (e', ps, t) <- tcExp e
-    -- expand synonyms before extracting type name
-    tExp <- maybeExpandSynonym t
-    tn <- typeName tExp
+    tn <- typeName t
     -- getting field type
     s <- askField tn n
     (ps' :=> t') <- freshInst s
@@ -261,11 +256,11 @@ tcExp (Lam args bd _) =
         withCurrentSubst (exp1, ps1, t)
 tcExp e1@(TyExp e ty) =
   do
-    _ <- kindCheck ty `wrapError` e1
+    ty1 <- kindCheck ty `wrapError` e1
     (e', ps, ty') <- tcExp e
-    s <- tcmMatch ty' ty
+    s <- tcmMatch ty' ty1
     _ <- extSubst s
-    withCurrentSubst (TyExp e' ty, ps, ty)
+    withCurrentSubst (TyExp e' ty1, ps, ty1)
 tcExp e@(Cond e1 e2 e3) =
   do
     (e1', ps1, t1) <- tcExp e1 `wrapError` e
@@ -530,7 +525,7 @@ argumentAnnotation :: Param Name -> TcM Ty
 argumentAnnotation (Untyped _) =
   freshTyVar
 argumentAnnotation (Typed _ t) =
-  maybeExpandSynonym t
+  pure t
 
 checkAllTypeVarsBound :: (Pretty a) => a -> [Tyvar] -> [Tyvar] -> TcM ()
 checkAllTypeVarsBound context used declared =
@@ -541,7 +536,7 @@ annotatedScheme :: [Tyvar] -> [Pred] -> Signature Name -> TcM Scheme
 annotatedScheme vs' qs (Signature vs ps _ args rt) =
   do
     ts <- mapM argumentAnnotation args
-    t <- maybe freshTyVar maybeExpandSynonym rt
+    t <- maybe freshTyVar pure rt
     let vs1 = vs ++ vs' ++ fv qs
     pure (Forall vs1 ((qs ++ ps) :=> (funtype ts t)))
 
@@ -776,22 +771,26 @@ extSignature sig@(Signature _ _ n _ _) =
 -- typing instance
 
 tcInstance :: Instance Name -> TcM (Instance Id)
-tcInstance idecl@(Instance _ _ predCtx _ ts t _) =
+tcInstance idecl@(Instance d vs predCtx n ts t funs) =
   do
     -- checking instance type parameters
-    mapM_ kindCheck (t : ts) `wrapError` idecl
+    t' <- kindCheck t `wrapError` idecl
+    ts' <- mapM kindCheck ts `wrapError` idecl
     -- checking constraints
-    mapM_ checkConstraint predCtx `wrapError` idecl
-    tcInstance' idecl
+    qs' <- mapM checkConstraint predCtx `wrapError` idecl
+    tcInstance' (Instance d vs qs' n ts' t' funs)
 
-checkConstraint :: Pred -> TcM ()
+checkConstraint :: Pred -> TcM Pred
 checkConstraint p@(InCls n t ts) =
   do
     cinfo <- askClassInfo n
     unless (length ts == classArity cinfo) $
       classArityError n cinfo p
-    mapM_ kindCheck (t : ts) `wrapError` p
-checkConstraint (t :~: t') = mapM_ kindCheck [t, t']
+    t' <- kindCheck t `wrapError` p
+    ts' <- mapM kindCheck ts `wrapError` p
+    pure (InCls n t' ts')
+checkConstraint (t :~: t') =
+  (:~:) <$> kindCheck t <*> kindCheck t'
 
 tcInstance' :: Instance Name -> TcM (Instance Id)
 tcInstance' idecl@(Instance d vs predCtx n ts t funs) =
@@ -972,11 +971,7 @@ checkInstance idef@(Instance d vs predCtx n ts t funs) =
       classArityError n cinfo idef
     -- check if all the types and classes in the context are valid
     checkConstraints predCtx
-    -- expand type synonyms in instance head (affects overlap check and stored instance)
-    tExp <- maybeExpandSynonym t
-    tsExp <- mapM maybeExpandSynonym ts
-    predCtxExp <- mapM expandPredSynonyms predCtx
-    let ipred = InCls n tExp tsExp
+    let ipred = InCls n t ts
     -- checking the coverage condition
     insts' <- askInstEnv n `wrapError` ipred
     -- check overlapping only for non-default instances
@@ -986,29 +981,22 @@ checkInstance idef@(Instance d vs predCtx n ts t funs) =
         ipred' = insts env ipred
     unless d (checkOverlap ipred' insts' `wrapError` idef)
     -- check if default instance has a type variable as main argument.
-    when d (checkDefaultInst (predCtxExp :=> ipred) `wrapError` idef)
+    when d (checkDefaultInst (predCtx :=> ipred) `wrapError` idef)
     coverageEnabled <- askCoverage n
-    unless coverageEnabled (checkCoverage n tsExp tExp `wrapError` idef)
+    unless coverageEnabled (checkCoverage n ts t `wrapError` idef)
     -- checking Patterson condition
     pattersonEnabled <- askPattersonCondition n
-    unless pattersonEnabled (checkMeasure predCtxExp ipred `wrapError` idef)
+    unless pattersonEnabled (checkMeasure predCtx ipred `wrapError` idef)
     -- checking bound variable condition
     boundEnabled <- askBoundVariableCondition n
-    unless boundEnabled (checkBoundVariable predCtxExp (bv (tExp : tsExp)) `wrapError` idef)
+    unless boundEnabled (checkBoundVariable predCtx (bv (t : ts)) `wrapError` idef)
     -- checking instance methods
     mapM_ (checkMethod ipred) funs `wrapError` idef
-    let ninst = anfInstance $ predCtxExp :=> ipred
+    let ninst = anfInstance $ predCtx :=> ipred
     -- add to the environment
     if d
       then addDefaultInstance n ninst
       else addInstance n ninst
-
-expandPredSynonyms :: Pred -> TcM Pred
-expandPredSynonyms (InCls n t ts) = do
-  t' <- maybeExpandSynonym t
-  ts' <- mapM maybeExpandSynonym ts
-  pure (InCls n t' ts')
-expandPredSynonyms p = pure p
 
 -- checking a default instance
 

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -307,6 +307,7 @@ cases =
       runTestForFile "strange-unbound.solc" caseFolder,
       runTestForFile "type-synonym-arg.solc" caseFolder,
       runTestForFile "instance-synonym.solc" caseFolder,
+      runTestForFile "instance-synonym-int.solc" caseFolder,
       runTestExpectingFailure "overlap-synonym-detected.solc" caseFolder,
       runTestExpectingFailure "overlap-synonym-missed-order.solc" caseFolder,
       runTestExpectingFailure "overlap-synonym-missed-two-synonyms.solc" caseFolder,

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -242,6 +242,7 @@ cases =
       runTestExpectingFailure "synonym-recursive.solc" caseFolder,
       runTestExpectingFailure "synonym-self-recursive.solc" caseFolder,
       runTestExpectingFailure "synonym-long-cycle.solc" caseFolder,
+      runTestExpectingFailure "synonym-arity-mismatch.solc" caseFolder,
       runTestExpectingFailure "signature.solc" caseFolder,
       runTestExpectingFailure "SillyReturn.solc" caseFolder,
       runTestExpectingFailure "SimpleInvoke.solc" caseFolder,

--- a/test/examples/cases/instance-synonym-int.solc
+++ b/test/examples/cases/instance-synonym-int.solc
@@ -1,0 +1,18 @@
+type W = word;
+
+forall i.
+class i : Int {
+  function fromWord(x:word) ->  i;
+}
+
+instance word : Int {
+  function fromWord(x:word) -> word { x }
+}
+
+contract C {
+
+  function main () -> W {
+    let r : W = Int.fromWord(42);
+    return r;
+  }
+}

--- a/test/examples/cases/synonym-arity-mismatch.solc
+++ b/test/examples/cases/synonym-arity-mismatch.solc
@@ -1,0 +1,5 @@
+type F(a) = pair(a, word);
+
+function main() -> F(word, word) {
+    return pair(42, 0);
+}


### PR DESCRIPTION
* This PR changes the implementation of type synonym expansion to use SYB and expand every synonym before start type inference.
* Adds a test case suggested by mbenke.
*  Fixes #344.