### PR TITLE
Fix pattern matching

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,7 +69,7 @@
             src = gitignore ./.;
           } ''
             cd $src
-            ormolu --mode check $(find . -name '*.hs')
+            ormolu --mode check $(find app src yule test -name '*.hs')
             touch $out
           '';
 

--- a/src/Solcore/Backend/Specialise.hs
+++ b/src/Solcore/Backend/Specialise.hs
@@ -405,7 +405,17 @@ specFunDef fd0 = withLocalState do
       return name'
 
 specBody :: [Stmt Id] -> SM [Stmt Id]
-specBody = mapM specStmt
+specBody = fmap concat . mapM specStmtBody
+  where
+    specStmtBody stmt = do
+      stmt' <- specStmt stmt
+      pure (flattenSyntheticBlock stmt')
+
+    -- The match compiler uses `Match [] [([], body)]` as an internal block
+    -- wrapper for multi-statement leaves. Flatten it before converting to MAST,
+    -- where zero-scrutinee matches are not representable.
+    flattenSyntheticBlock (Match [] [([], body)]) = body
+    flattenSyntheticBlock stmt = [stmt]
 
 {-
 ensureSimple ty' stmt subst = case ty' of

--- a/src/Solcore/Backend/Specialise.hs
+++ b/src/Solcore/Backend/Specialise.hs
@@ -405,17 +405,7 @@ specFunDef fd0 = withLocalState do
       return name'
 
 specBody :: [Stmt Id] -> SM [Stmt Id]
-specBody = fmap concat . mapM specStmtBody
-  where
-    specStmtBody stmt = do
-      stmt' <- specStmt stmt
-      pure (flattenSyntheticBlock stmt')
-
-    -- The match compiler uses `Match [] [([], body)]` as an internal block
-    -- wrapper for multi-statement leaves. Flatten it before converting to MAST,
-    -- where zero-scrutinee matches are not representable.
-    flattenSyntheticBlock (Match [] [([], body)]) = body
-    flattenSyntheticBlock stmt = [stmt]
+specBody = mapM specStmt
 
 {-
 ensureSimple ty' stmt subst = case ty' of
@@ -489,6 +479,8 @@ specStmt stmt@(Let i mty mexp) = do
   case mexp of
     Nothing -> return $ Let i' mty' Nothing
     Just e -> Let i' mty' . Just <$> specExp e ty'
+specStmt (Block body) =
+  Block <$> specBody body
 specStmt (StmtExp e) = do
   ty <- atCurrentSubst (typeOfTcExp e)
   e' <- specExp e ty
@@ -816,7 +808,7 @@ toMastFunDef (FunDef sig body) =
       mastFunReturn = case sigReturn sig of
         Just t -> toMastTy t
         Nothing -> error $ "toMastFunDef: no return type for " ++ show (sigName sig),
-      mastFunBody = map toMastStmt body
+      mastFunBody = toMastBody body
     }
 
 toMastParam :: Param Id -> MastParam
@@ -844,8 +836,14 @@ toMastStmt (Match es _) = error $ "toMastStmt: multi-scrutinee match should have
 toMastStmt (Asm ys) = MastAsm ys
 toMastStmt s = error $ "toMastStmt: unexpected " ++ show s
 
+toMastBody :: [Stmt Id] -> [MastStmt]
+toMastBody = concatMap go
+  where
+    go (Block body) = toMastBody body
+    go stmt = [toMastStmt stmt]
+
 toMastAlt :: ([Pat Id], [Stmt Id]) -> MastAlt
-toMastAlt ([p], body) = (toMastPat p, map toMastStmt body)
+toMastAlt ([p], body) = (toMastPat p, toMastBody body)
 toMastAlt (ps, _) = error $ "toMastAlt: multi-pattern alt should have been desugared: " ++ show ps
 
 toMastExp :: Exp Id -> MastExp

--- a/src/Solcore/Desugarer/DecisionTreeCompiler.hs
+++ b/src/Solcore/Desugarer/DecisionTreeCompiler.hs
@@ -580,8 +580,8 @@ defaultMatrix = concatMap defaultRow
 specializedBoundActs :: Id -> Occurrence -> PatternMatrix -> [BoundAction] -> [BoundAction]
 specializedBoundActs k testOcc rows bacts =
   [ (addVarBinding row binds, a)
-  | (row, (binds, a)) <- zip rows bacts,
-    rowMatchesCon row
+    | (row, (binds, a)) <- zip rows bacts,
+      rowMatchesCon row
   ]
   where
     rowMatchesCon [] = False
@@ -596,10 +596,10 @@ specializedBoundActs k testOcc rows bacts =
 defaultBoundActs :: Occurrence -> PatternMatrix -> [BoundAction] -> [BoundAction]
 defaultBoundActs testOcc rows bacts =
   [ (addVarBinding row binds, a)
-  | (row, (binds, a)) <- zip rows bacts,
-    case row of
-      (p : _) -> isVarPat p
-      [] -> False
+    | (row, (binds, a)) <- zip rows bacts,
+      case row of
+        (p : _) -> isVarPat p
+        [] -> False
   ]
   where
     addVarBinding (PVar v : _) binds = binds ++ [(v, testOcc)]
@@ -608,8 +608,8 @@ defaultBoundActs testOcc rows bacts =
 litSpecializedBoundActs :: Literal -> Occurrence -> PatternMatrix -> [BoundAction] -> [BoundAction]
 litSpecializedBoundActs lit testOcc rows bacts =
   [ (addVarBinding row binds, a)
-  | (row, (binds, a)) <- zip rows bacts,
-    rowMatchesLit row
+    | (row, (binds, a)) <- zip rows bacts,
+      rowMatchesLit row
   ]
   where
     rowMatchesLit [] = False

--- a/src/Solcore/Desugarer/DecisionTreeCompiler.hs
+++ b/src/Solcore/Desugarer/DecisionTreeCompiler.hs
@@ -102,17 +102,30 @@ instance Compile (Stmt Id) where
     es' <- compile es
     eqns' <- mapM compileEqn eqns
     scrutTys <- mapM scrutineeType es'
-    let occs = [[i] | i <- [0 .. length es' - 1]]
-        occMap = Map.fromList (zip occs es')
+    preparedScruts <- zipWithM prepareScrutinee es' scrutTys
+    let scrutBindings = concatMap fst preparedScruts
+        scrutVars = map snd preparedScruts
+        occs = [[i] | i <- [0 .. length es' - 1]]
+        occMap = Map.fromList (zip occs scrutVars)
         matrix = map fst eqns'
         actions = map snd eqns'
         bacts = [([], a) | a <- actions]
-        matchDesc = "match (" ++ intercalate ", " (map pretty es') ++ ")"
+        matchDesc = "match (" ++ intercalate ", " (map pretty scrutVars) ++ ")"
     pushCtx matchDesc $ do
       ctx <- askWarnCtx
       checkRedundancy ctx scrutTys matrix bacts
     tree <- pushCtx matchDesc $ compileMatrix scrutTys occs matrix bacts
-    treeToStmt occMap tree
+    stmt <- treeToStmt occMap tree
+    pure $
+      case scrutBindings of
+        [] -> stmt
+        binds -> Match [] [([], binds ++ [stmt])]
+
+prepareScrutinee :: Exp Id -> Ty -> CompilerM ([Stmt Id], Exp Id)
+prepareScrutinee e@(Var _) _ = pure ([], e)
+prepareScrutinee e ty = do
+  v <- freshId ty
+  pure ([Let v (Just ty) (Just e)], Var v)
 
 compileEqn :: Equation Id -> CompilerM (Equation Id)
 compileEqn (pats, stmts) = (pats,) <$> compile stmts
@@ -414,6 +427,13 @@ freshPat t = do
   n <- inc
   let v = Name $ "$v" ++ show n
   pure (PVar (Id v t))
+
+freshId :: Ty -> CompilerM Id
+freshId t = do
+  pat <- freshPat t
+  case pat of
+    PVar v -> pure v
+    _ -> error "freshId: freshPat returned a non-variable pattern"
 
 isComplete :: [Id] -> CompilerM Bool
 isComplete [] = pure False

--- a/src/Solcore/Desugarer/DecisionTreeCompiler.hs
+++ b/src/Solcore/Desugarer/DecisionTreeCompiler.hs
@@ -580,8 +580,8 @@ defaultMatrix = concatMap defaultRow
 specializedBoundActs :: Id -> Occurrence -> PatternMatrix -> [BoundAction] -> [BoundAction]
 specializedBoundActs k testOcc rows bacts =
   [ (addVarBinding row binds, a)
-    | (row, (binds, a)) <- zip rows bacts,
-      rowMatchesCon row
+  | (row, (binds, a)) <- zip rows bacts,
+    rowMatchesCon row
   ]
   where
     rowMatchesCon [] = False
@@ -596,10 +596,10 @@ specializedBoundActs k testOcc rows bacts =
 defaultBoundActs :: Occurrence -> PatternMatrix -> [BoundAction] -> [BoundAction]
 defaultBoundActs testOcc rows bacts =
   [ (addVarBinding row binds, a)
-    | (row, (binds, a)) <- zip rows bacts,
-      case row of
-        (p : _) -> isVarPat p
-        [] -> False
+  | (row, (binds, a)) <- zip rows bacts,
+    case row of
+      (p : _) -> isVarPat p
+      [] -> False
   ]
   where
     addVarBinding (PVar v : _) binds = binds ++ [(v, testOcc)]
@@ -608,8 +608,8 @@ defaultBoundActs testOcc rows bacts =
 litSpecializedBoundActs :: Literal -> Occurrence -> PatternMatrix -> [BoundAction] -> [BoundAction]
 litSpecializedBoundActs lit testOcc rows bacts =
   [ (addVarBinding row binds, a)
-    | (row, (binds, a)) <- zip rows bacts,
-      rowMatchesLit row
+  | (row, (binds, a)) <- zip rows bacts,
+    rowMatchesLit row
   ]
   where
     rowMatchesLit [] = False

--- a/src/Solcore/Desugarer/DecisionTreeCompiler.hs
+++ b/src/Solcore/Desugarer/DecisionTreeCompiler.hs
@@ -90,6 +90,8 @@ instance Compile (Stmt Id) where
     (:=) <$> compile e1 <*> compile e2
   compile (Let v mt me) =
     Let v mt <$> compile me
+  compile (Block body) =
+    Block <$> compile body
   compile (StmtExp e) =
     StmtExp <$> compile e
   compile (Return e) =
@@ -119,7 +121,7 @@ instance Compile (Stmt Id) where
     pure $
       case scrutBindings of
         [] -> stmt
-        binds -> Match [] [([], binds ++ [stmt])]
+        binds -> Block (binds ++ [stmt])
 
 prepareScrutinee :: Exp Id -> Ty -> CompilerM ([Stmt Id], Exp Id)
 prepareScrutinee e@(Var _) _ = pure ([], e)
@@ -290,7 +292,6 @@ instance Compile (Instance Id) where
 -- compiling a decision tree into a match
 
 -- Convert a decision tree to a statement body (list of statements).
--- Avoids wrapping multi-statement leaves in a fake Match node.
 treeToBody :: OccMap -> DecisionTree -> CompilerM [Stmt Id]
 treeToBody _ Fail = pure []
 treeToBody occMap (Leaf varBinds stmts) = do
@@ -299,12 +300,12 @@ treeToBody occMap (Leaf varBinds stmts) = do
 treeToBody occMap tree = (: []) <$> treeToStmt occMap tree
 
 treeToStmt :: OccMap -> DecisionTree -> CompilerM (Stmt Id)
-treeToStmt _ Fail = pure (Match [] [])
+treeToStmt _ Fail = pure (Block [])
 treeToStmt occMap (Leaf varBinds stmts) = do
   subst <- buildSubst occMap varBinds
   case map (substStmt subst) stmts of
     [s] -> pure s
-    ss -> pure (Match [] [([], ss)])
+    ss -> pure (Block ss)
 treeToStmt occMap (Switch occ branches mDef) = do
   scrutinee <- occToExp occMap occ
   eqns <- mapM (conBranchToEqn occMap occ) branches

--- a/src/Solcore/Desugarer/FieldAccess.hs
+++ b/src/Solcore/Desugarer/FieldAccess.hs
@@ -133,6 +133,7 @@ transStmt cenv stmt = (cenv, go stmt cenv)
     go :: NmStmt -> CEM NmStmt
     go (lhs := rhs) = transAssignment lhs rhs
     go (Return exp) = Return <$> transRhs exp
+    go (Block body) = pure (Block (transBody body cenv))
     go (StmtExp exp) = StmtExp <$> transRhs exp
     go (If e b1 b2) = If <$> transRhs e <*> transBody b1 <*> transBody b2
     go (Match es eqns) = traces [pretty (r cenv)] r where r = Match <$> mapM transRhs es <*> mapM transEquation eqns

--- a/src/Solcore/Desugarer/IfDesugarer.hs
+++ b/src/Solcore/Desugarer/IfDesugarer.hs
@@ -17,6 +17,8 @@ ifDesugarer cunit =
 desugarStmt :: Stmt Id -> Stmt Id
 desugarStmt (Match es eqns) =
   Match es (map (\(ps, bdy) -> (ps, map desugarStmt bdy)) eqns)
+desugarStmt (Block body) =
+  Block (map desugarStmt body)
 desugarStmt (If e bdy1 bdy2) =
   Match [e] [eqntrue, eqnfalse]
   where

--- a/src/Solcore/Desugarer/IndirectCall.hs
+++ b/src/Solcore/Desugarer/IndirectCall.hs
@@ -74,6 +74,8 @@ instance Desugar (Stmt Name) where
     (:=) <$> desugar lhs <*> desugar rhs
   desugar (Let n mt me) =
     Let n mt <$> desugar me
+  desugar (Block body) =
+    Block <$> desugar body
   desugar (StmtExp e) =
     StmtExp <$> desugar e
   desugar (Return e) =

--- a/src/Solcore/Frontend/Pretty/SolcorePretty.hs
+++ b/src/Solcore/Frontend/Pretty/SolcorePretty.hs
@@ -217,6 +217,10 @@ instance (Pretty a) => Pretty (Stmt a) where
     ppr n <+> equals <+> ppr e <+> semi
   ppr (Let n ty m) =
     text "let" <+> ppr n <+> pprOptTy ty <+> pprInitOpt m
+  ppr (Block body) =
+    lbrace
+      $$ nest 3 (ppr body)
+      $$ rbrace
   ppr (StmtExp e) =
     ppr e <> semi
   ppr (Return e) =

--- a/src/Solcore/Frontend/Pretty/TreePretty.hs
+++ b/src/Solcore/Frontend/Pretty/TreePretty.hs
@@ -197,6 +197,10 @@ instance Pretty Stmt where
     hsep [ppr e1, text "-=", ppr e2]
   ppr (Let n ty m) =
     text "let" <+> ppr n <+> pprOptTy ty <+> pprInitOpt m
+  ppr (Block body) =
+    lbrace
+      $$ nest 3 (ppr body)
+      $$ rbrace
   ppr (StmtExp e) =
     ppr e <> semi
   ppr (Return e) =

--- a/src/Solcore/Frontend/Syntax/NameResolution.hs
+++ b/src/Solcore/Frontend/Syntax/NameResolution.hs
@@ -232,6 +232,8 @@ instance Resolve S.Stmt where
       me' <- resolve me `wrapError` s
       addLocalVar n
       pure (Let n mt' me')
+  resolve (S.Block blk) =
+    withLocalCtx (Block <$> resolve blk)
   resolve s@(S.StmtExp e) =
     StmtExp <$> resolve e `wrapError` s
   resolve s@(S.Return e) =

--- a/src/Solcore/Frontend/Syntax/Stmt.hs
+++ b/src/Solcore/Frontend/Syntax/Stmt.hs
@@ -13,6 +13,7 @@ type Equations a = [Equation a]
 data Stmt a
   = (Exp a) := (Exp a) -- assignment
   | Let a (Maybe Ty) (Maybe (Exp a)) -- local variable
+  | Block (Body a) -- lexical block
   | StmtExp (Exp a) -- expression level statements
   | Return (Exp a) -- return statements
   | Match [Exp a] (Equations a) -- pattern matching

--- a/src/Solcore/Frontend/Syntax/SyntaxTree.hs
+++ b/src/Solcore/Frontend/Syntax/SyntaxTree.hs
@@ -192,6 +192,7 @@ data Stmt
   | StmtPlusEq Exp Exp -- e1 += e2
   | StmtMinusEq Exp Exp -- e1 -= e2
   | Let Name (Maybe Ty) (Maybe Exp) -- local variable
+  | Block Body -- lexical block
   | StmtExp Exp -- expression level statements
   | Return Exp -- return statements
   | Match [Exp] Equations -- pattern matching

--- a/src/Solcore/Frontend/TypeInference/Erase.hs
+++ b/src/Solcore/Frontend/TypeInference/Erase.hs
@@ -47,6 +47,8 @@ instance Erase (Stmt Id) where
     (erase e1) := (erase e2)
   erase (Let n mt me) =
     Let (idName n) mt (erase me)
+  erase (Block body) =
+    Block (erase body)
   erase (StmtExp e) =
     StmtExp (erase e)
   erase (Return e) =

--- a/src/Solcore/Frontend/TypeInference/SccAnalysis.hs
+++ b/src/Solcore/Frontend/TypeInference/SccAnalysis.hs
@@ -178,6 +178,8 @@ instance Names (Stmt Name) where
     names [e1, e2]
   names (Let _ mt me) =
     names mt `union` names me
+  names (Block body) =
+    names body
   names (StmtExp e) =
     names e
   names (Return e) =

--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -57,6 +57,10 @@ tcStmt e@(Let n mt me) =
     extEnv n (monotype tf)
     let e' = Let (Id n tf) (Just tf) me'
     withCurrentSubst (e', psf, unit)
+tcStmt (Block body) =
+  withLocalCtx [] $ do
+    (body', ps, t) <- tcBody body
+    pure (Block body', ps, t)
 tcStmt (StmtExp e) =
   do
     (e', ps', _) <- tcExp e
@@ -1365,6 +1369,7 @@ instance Vars (Stmt Id) where
   free (e1 := e2) = free [e1, e2]
   free (Let _ _ (Just e)) = free e
   free (Let _ _ _) = []
+  free (Block body) = free body
   free (StmtExp e) = free e
   free (Return e) = free e
   free (Match e eqns) = free e `union` free eqns
@@ -1372,6 +1377,7 @@ instance Vars (Stmt Id) where
   free (Asm _) = []
 
   bound (Let n _ _) = [n]
+  bound (Block _) = []
   bound _ = []
 
 instance Vars (Equation Id) where

--- a/src/Solcore/Frontend/TypeInference/TcSubst.hs
+++ b/src/Solcore/Frontend/TypeInference/TcSubst.hs
@@ -241,6 +241,8 @@ instance (HasType a) => HasType (Stmt a) where
       (apply s v)
       (apply s <$> mt)
       (apply s <$> me)
+  apply s (Block body) =
+    Block (apply s body)
   apply s (StmtExp e) =
     StmtExp (apply s e)
   apply s (Return e) =
@@ -261,6 +263,7 @@ instance (HasType a) => HasType (Stmt a) where
     fv v
       `union` (maybe [] fv mt)
       `union` (maybe [] fv me)
+  fv (Block body) = fv body
   fv (StmtExp e) = fv e
   fv (Return e) = fv e
   fv (Match es eqns) =
@@ -274,6 +277,7 @@ instance (HasType a) => HasType (Stmt a) where
     mv v
       `union` (maybe [] mv mt)
       `union` (maybe [] mv me)
+  mv (Block body) = mv body
   mv (StmtExp e) = mv e
   mv (Return e) = mv e
   mv (Match es eqns) =
@@ -287,6 +291,7 @@ instance (HasType a) => HasType (Stmt a) where
     bv v
       `union` (maybe [] bv mt)
       `union` (maybe [] bv me)
+  bv (Block body) = bv body
   bv (StmtExp e) = bv e
   bv (Return e) = bv e
   bv (Match es eqns) =

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -311,7 +311,8 @@ cases =
       runTestExpectingFailure "overlap-synonym-missed-order.solc" caseFolder,
       runTestExpectingFailure "overlap-synonym-missed-two-synonyms.solc" caseFolder,
       runTestForFile "copytomem.solc" caseFolder,
-      runTestForFile "fresh-variable-shadowing.solc" caseFolder
+      runTestForFile "fresh-variable-shadowing.solc" caseFolder,
+      runTestForFile "multi-stmt-var-leaf.solc" caseFolder
     ]
   where
     caseFolder = "./test/examples/cases"

--- a/test/MatchCompilerTests.hs
+++ b/test/MatchCompilerTests.hs
@@ -1,5 +1,6 @@
 module MatchCompilerTests where
 
+import Data.Generics (everything, mkQ)
 import Data.List (sort)
 import Data.Map qualified as Map
 import Solcore.Desugarer.DecisionTreeCompiler
@@ -30,7 +31,8 @@ matchTests =
       testGroup
         "treeToStmt"
         [ test_treeToStmt_singleVar_substituted,
-          test_treeToStmt_multiColumn_varsBoundViaSpecialize
+          test_treeToStmt_multiColumn_varsBoundViaSpecialize,
+          test_compileMatch_bindsScrutineeOnce
         ],
       testGroup
         "redundancy warnings"
@@ -100,6 +102,13 @@ runFull env occMap tys occs matrix acts =
   runCompilerM env $ do
     tree <- compileMatrix tys occs matrix [([], a) | a <- acts]
     treeToStmt occMap tree
+
+runCompileStmt ::
+  TypeEnv ->
+  Stmt Id ->
+  IO (Either String (Stmt Id, [Warning]))
+runCompileStmt env stmt =
+  runCompilerM env (compile stmt)
 
 assertRight ::
   String ->
@@ -466,6 +475,12 @@ varX = Var (Id (Name "x") tyBool)
 varY :: Exp Id
 varY = Var (Id (Name "y") tyBool)
 
+idF :: Id
+idF = Id (Name "f") (funtype [] tyBool)
+
+idG :: Id
+idG = Id (Name "g") (funtype [tyBool, tyBool] tyBool)
+
 -- Type environment with both List and Bool constructors
 listBoolEnv :: TypeEnv
 listBoolEnv = Map.union listEnv boolEnv
@@ -514,7 +529,38 @@ test_treeToStmt_multiColumn_varsBoundViaSpecialize =
             [] -> assertFailure "default branch not found in Match alts"
         _ -> assertFailure ("expected Match [x] …, got: " ++ show stmt)
 
--- 13. Rows after a first all-var row are warned as unreachable even when they
+-- 13. Compiling a catch-all over a non-variable scrutinee must not duplicate
+-- scrutinee evaluation.
+--
+-- match f() { | z => return g(z, z) }
+--
+-- The compiled statement should evaluate f() once and reuse the bound result.
+test_compileMatch_bindsScrutineeOnce :: TestTree
+test_compileMatch_bindsScrutineeOnce =
+  testCase "compile Match: catch-all row evaluates scrutinee only once" $ do
+    let idZ = Id (Name "z") tyBool
+        stmt =
+          Match
+            [Call Nothing idF []]
+            [([PVar idZ], [Return (Call Nothing idG [Var idZ, Var idZ])])]
+    r <- runCompileStmt boolEnv stmt
+    case r of
+      Left err -> assertFailure ("unexpected error: " ++ err)
+      Right (stmt', _) ->
+        assertEqual
+          "f() should appear exactly once after compilation"
+          1
+          (countNamedCalls (idName idF) stmt')
+  where
+    countNamedCalls :: Name -> Stmt Id -> Int
+    countNamedCalls target =
+      everything (+) (mkQ 0 countExp)
+      where
+        countExp :: Exp Id -> Int
+        countExp (Call Nothing i _) | idName i == target = 1
+        countExp _ = 0
+
+-- 14. Rows after a first all-var row are warned as unreachable even when they
 -- are NOT exhaustive by themselves.
 --
 -- match x { | z => return z; | True => return True; }
@@ -541,7 +587,7 @@ test_allVar_first_shadows_nonexhaustive_rest =
       assertBool "True clause must be warned as unreachable" (actionB `elem` redundantActs)
       assertBool "first all-var row must not be warned" (actionA `notElem` redundantActs)
 
--- 14. Two-column match: (True,z) / (w,True) / (a,b)
+-- 15. Two-column match: (True,z) / (w,True) / (a,b)
 -- The rows after the first are NOT globally redundant:
 --   row 1 fires for (False, True), row 2 fires for (False, False).
 -- No RedundantClause warnings should be emitted.

--- a/test/examples/cases/multi-stmt-var-leaf.solc
+++ b/test/examples/cases/multi-stmt-var-leaf.solc
@@ -1,0 +1,11 @@
+data Bool = False | True;
+
+contract MultiStmtVarLeaf {
+  function main(x:Bool) -> Bool {
+    match x {
+      | y =>
+        let z = y;
+        return z;
+    }
+  }
+}


### PR DESCRIPTION
* Fix a crash when a variable-only match branch contains multiple statements
* Avoid duplicating scrutinee evaluation in variable match branches
* Limit `ormolu` check to tracked source directories