### PR TITLE
Allow comptime expressions as match labels

### DIFF
--- a/src/Solcore/Backend/EmitHull.hs
+++ b/src/Solcore/Backend/EmitHull.hs
@@ -371,6 +371,7 @@ emitWordMatch scrutinee alts = do
       hullStmts <- emitStmts stmts
       let hullName = show n
       return (Hull.Alt (Hull.PVar hullName) "$_" hullStmts)
+    emitWordAlt _ (MastPExp _, _) = errorsEM ["PANIC: MastPExp reached EmitHull — was not evaluated by MastEval"]
     emitWordAlt _ (pat, _) = errorsEM ["emitWordAlt not implemented for", show pat]
 
 type BranchMap = Map.Map Name [Hull.Stmt]

--- a/src/Solcore/Backend/Mast.hs
+++ b/src/Solcore/Backend/Mast.hs
@@ -125,6 +125,7 @@ data MastPat
   | MastPCon MastId [MastPat]
   | MastPWildcard
   | MastPLit Literal
+  | MastPExp MastExp -- comptime expression label; must be evaluated by MastEval
   deriving (Eq, Ord, Show)
 
 -----------------------------------------------------------------------
@@ -269,6 +270,7 @@ instance Pretty MastPat where
     | otherwise = ppr n >< parens (commaSep $ map ppr ps)
   ppr MastPWildcard = text "_"
   ppr (MastPLit l) = ppr l
+  ppr (MastPExp e) = text "comptime" <+> ppr e
 
 -----------------------------------------------------------------------
 -- Helpers (shared with SolcorePretty)

--- a/src/Solcore/Backend/MastEval.hs
+++ b/src/Solcore/Backend/MastEval.hs
@@ -196,8 +196,19 @@ evalAlt :: VEnv -> MastAlt -> EvalM MastAlt
 evalAlt env (pat, body) = do
   -- Pattern bindings shadow existing bindings, but we don't track them
   -- (conservative: treat all pattern-bound vars as unknown)
+  pat' <- evalPat env pat
   (_, body') <- evalStmts env body
-  pure (pat, body')
+  pure (pat', body')
+
+-- Evaluate expression labels in patterns.
+-- MastPExp must reduce to a literal; any other form is a compile-time error.
+evalPat :: VEnv -> MastPat -> EvalM MastPat
+evalPat env (MastPExp e) = do
+  e' <- evalExp env e
+  case e' of
+    MastLit l -> pure (MastPLit l)
+    _ -> error $ "comptime expression in match label could not be evaluated to a literal: " ++ show e'
+evalPat _ pat = pure pat
 
 -----------------------------------------------------------------------
 -- Evaluate expressions
@@ -333,7 +344,8 @@ evalFunBody env (stmt : rest) = case stmt of
     pure $ if isKnownValue e' then Just e' else Nothing
   MastMatch scrut alts -> do
     scrut' <- evalExp env scrut
-    case matchAlts env scrut' alts of
+    alts' <- mapM (\(p, b) -> (,b) <$> evalPat env p) alts
+    case matchAlts env scrut' alts' of
       Just (env', body) -> evalFunBody env' body
       Nothing -> pure Nothing -- Scrutinee not known, can't select branch
   MastAsm _ -> pure Nothing -- Should not happen: purity analysis excludes asm functions
@@ -373,6 +385,7 @@ findLitMatch env lit ((pat, body) : rest) =
       let env' = Map.insert varId (MastLit lit) env
        in Just (env', body)
     MastPWildcard -> Just (env, body)
+    MastPExp _ -> error "PANIC: MastPExp reached findLitMatch — evalAlt failed to evaluate it"
     _ -> findLitMatch env lit rest
 
 -- Bind pattern variables to argument expressions
@@ -401,6 +414,7 @@ bindPatterns env (pat : pats) (arg : args) =
       case arg of
         MastLit argLit | argLit == patLit -> bindPatterns env pats args
         _ -> Nothing
+    MastPExp _ -> error "PANIC: MastPExp reached bindPatterns — evalAlt failed to evaluate it"
 
 -----------------------------------------------------------------------
 -- Helpers

--- a/src/Solcore/Backend/Specialise.hs
+++ b/src/Solcore/Backend/Specialise.hs
@@ -499,8 +499,15 @@ specMatch exps alts = do
       -- debug ["specAlt, pattern: ", show pat]
       -- debug ["specAlt, body: ", show body]
       body' <- specBody body
-      pat' <- atCurrentSubst pat
+      pat' <- mapM specPat =<< atCurrentSubst pat
       return (pat', body')
+    -- Specialize function calls inside PExp patterns.
+    -- Other pattern forms only need type substitution (handled by atCurrentSubst).
+    specPat :: Pat Id -> SM (Pat Id)
+    specPat (PExp e) = do
+      ty <- atCurrentSubst (typeOfTcExp e)
+      PExp <$> specExp e ty
+    specPat p = pure p
     specScruts = mapM specScrut
     specScrut e = do
       ty <- atCurrentSubst (typeOfTcExp e)
@@ -853,3 +860,4 @@ toMastPat (PVar i) = MastPVar (toMastId i)
 toMastPat (PCon i ps) = MastPCon (toMastId i) (map toMastPat ps)
 toMastPat PWildcard = MastPWildcard
 toMastPat (PLit l) = MastPLit l
+toMastPat (PExp e) = MastPExp (toMastExp e)

--- a/src/Solcore/Desugarer/DecisionTreeCompiler.hs
+++ b/src/Solcore/Desugarer/DecisionTreeCompiler.hs
@@ -244,10 +244,10 @@ buildAtomicSwitch testOcc restOccs testTy restTys matrix bacts headAtomics = do
       else Just <$> compileMatrix restTys restOccs defMat defBacts
   pure (AtomicSwitch testOcc branches mDefault)
   where
-    buildBranch ap = do
-      let specMat = specializeAtomic ap matrix
-          specBacts = atomicSpecializedBoundActs ap testOcc matrix bacts
-      (ap,) <$> compileMatrix restTys restOccs specMat specBacts
+    buildBranch apat = do
+      let specMat = specializeAtomic apat matrix
+          specBacts = atomicSpecializedBoundActs apat testOcc matrix bacts
+      (apat,) <$> compileMatrix restTys restOccs specMat specBacts
 
 instance Compile (Exp Id) where
   compile v@(Var _) =
@@ -541,14 +541,14 @@ specRow k pats (p : rest) =
     _ -> error "PANIC! Found wildcard in specRow"
 
 specializeAtomic :: AtomicPat -> PatternMatrix -> PatternMatrix
-specializeAtomic ap = mapMaybe specAtomicRow
+specializeAtomic apat = mapMaybe specAtomicRow
   where
     specAtomicRow [] = Nothing
     specAtomicRow (p : rest) =
       case p of
-        PLit l | Left l == ap -> Just rest
+        PLit l | Left l == apat -> Just rest
         PLit _ -> Nothing
-        PExp e | Right e == ap -> Just rest
+        PExp e | Right e == apat -> Just rest
         PExp _ -> Nothing
         PVar _ -> Just rest
         PCon _ _ -> Nothing
@@ -598,7 +598,7 @@ defaultBoundActs testOcc rows bacts =
     addVarBinding _ binds = binds
 
 atomicSpecializedBoundActs :: AtomicPat -> Occurrence -> PatternMatrix -> [BoundAction] -> [BoundAction]
-atomicSpecializedBoundActs ap testOcc rows bacts =
+atomicSpecializedBoundActs apat testOcc rows bacts =
   [ (addVarBinding row binds, a)
     | (row, (binds, a)) <- zip rows bacts,
       rowMatchesAtomic row
@@ -606,8 +606,8 @@ atomicSpecializedBoundActs ap testOcc rows bacts =
   where
     rowMatchesAtomic [] = False
     rowMatchesAtomic (p : _) = case p of
-      PLit l -> Left l == ap
-      PExp e -> Right e == ap
+      PLit l -> Left l == apat
+      PExp e -> Right e == apat
       PVar _ -> True
       _ -> False
     addVarBinding (PVar v : _) binds = binds ++ [(v, testOcc)]

--- a/src/Solcore/Desugarer/DecisionTreeCompiler.hs
+++ b/src/Solcore/Desugarer/DecisionTreeCompiler.hs
@@ -141,12 +141,12 @@ compileMatrix tys occs matrix bacts = do
     (testTy : restTys, testOcc : restOccs, _) -> do
       let firstCol = [p | (p : _) <- matrix']
           headCons = nub (mapMaybe patHeadCon firstCol)
-          headLits = nub (mapMaybe patHeadLit firstCol)
-      case (headCons, headLits) of
+          headAtomics = nub (mapMaybe patHeadAtomic firstCol)
+      case (headCons, headAtomics) of
         (c : cs, _) ->
           buildConSwitch testOcc restOccs testTy restTys matrix' bacts (c : cs)
-        ([], ls@(_ : _)) ->
-          buildLitSwitch testOcc restOccs testTy restTys matrix' bacts ls
+        ([], as@(_ : _)) ->
+          buildAtomicSwitch testOcc restOccs testTy restTys matrix' bacts as
         ([], []) ->
           -- All wildcards after reordering: strip column and continue
           compileMatrix restTys restOccs (defaultMatrix matrix') (defaultBoundActs testOcc matrix' bacts)
@@ -220,34 +220,34 @@ buildConSwitch testOcc restOccs _testTy restTys matrix bacts headCons = do
               pure (Just Fail)
             else Just <$> compileMatrix restTys restOccs defMat defBacts
 
-buildLitSwitch ::
+buildAtomicSwitch ::
   Occurrence ->
   [Occurrence] ->
   Ty ->
   [Ty] ->
   PatternMatrix ->
   [BoundAction] ->
-  [Literal] ->
+  [AtomicPat] ->
   CompilerM DecisionTree
-buildLitSwitch testOcc restOccs testTy restTys matrix bacts headLits = do
-  branches <- mapM buildBranch headLits
+buildAtomicSwitch testOcc restOccs testTy restTys matrix bacts headAtomics = do
+  branches <- mapM buildBranch headAtomics
   let defMat = defaultMatrix matrix
       defBacts = defaultBoundActs testOcc matrix bacts
   mDefault <-
     if null defMat
       then do
-        litWit <- freshPat testTy
+        wit <- freshPat testTy
         restWit <- mapM freshPat restTys
         ctx <- askWarnCtx
-        tell [NonExhaustive ctx (litWit : restWit)]
+        tell [NonExhaustive ctx (wit : restWit)]
         pure (Just Fail)
       else Just <$> compileMatrix restTys restOccs defMat defBacts
-  pure (LitSwitch testOcc branches mDefault)
+  pure (AtomicSwitch testOcc branches mDefault)
   where
-    buildBranch lit = do
-      let specMat = specializeLit lit matrix
-          specBacts = litSpecializedBoundActs lit testOcc matrix bacts
-      (lit,) <$> compileMatrix restTys restOccs specMat specBacts
+    buildBranch ap = do
+      let specMat = specializeAtomic ap matrix
+          specBacts = atomicSpecializedBoundActs ap testOcc matrix bacts
+      (ap,) <$> compileMatrix restTys restOccs specMat specBacts
 
 instance Compile (Exp Id) where
   compile v@(Var _) =
@@ -303,9 +303,9 @@ treeToStmt occMap (Switch occ branches mDef) = do
       v <- freshPat ty
       pure [([v], body)]
   pure (Match [scrutinee] (eqns ++ defEqns))
-treeToStmt occMap (LitSwitch occ branches mDef) = do
+treeToStmt occMap (AtomicSwitch occ branches mDef) = do
   scrutinee <- occToExp occMap occ
-  eqns <- mapM (litBranchToEqn occMap) branches
+  eqns <- mapM (atomicBranchToEqn occMap) branches
   defEqns <- case mDef of
     Nothing -> pure []
     Just def -> do
@@ -349,10 +349,13 @@ conBranchToEqn occMap occ (k, srcPats, tree) = do
   body <- treeToBody occMap' tree
   pure ([PCon k srcPats], body)
 
-litBranchToEqn :: OccMap -> (Literal, DecisionTree) -> CompilerM (PatternRow, Action)
-litBranchToEqn occMap (lit, tree) = do
+atomicBranchToEqn :: OccMap -> (AtomicPat, DecisionTree) -> CompilerM (PatternRow, Action)
+atomicBranchToEqn occMap (Left lit, tree) = do
   body <- treeToBody occMap tree
   pure ([PLit lit], body)
+atomicBranchToEqn occMap (Right e, tree) = do
+  body <- treeToBody occMap tree
+  pure ([PExp e], body)
 
 -- definition of a monad
 
@@ -445,8 +448,13 @@ data DecisionTree
   = Leaf [(Id, Occurrence)] Action -- var-occ bindings to substitute before running action
   | Fail
   | Switch Occurrence [(Id, [Pattern], DecisionTree)] (Maybe DecisionTree)
-  | LitSwitch Occurrence [(Literal, DecisionTree)] (Maybe DecisionTree)
+  | AtomicSwitch Occurrence [(AtomicPat, DecisionTree)] (Maybe DecisionTree)
   deriving (Eq, Show)
+
+-- An atomic pattern is a compile-time value used as a match label.
+-- Left  = integer literal (already evaluated)
+-- Right = comptime expression (evaluated post-specialization by MastEval)
+type AtomicPat = Either Literal (Exp Id)
 
 -- data constructor information and environment
 
@@ -529,20 +537,22 @@ specRow k pats (p : rest) =
       | otherwise -> Nothing
     PVar _ -> Just (pats ++ rest)
     PLit _ -> Nothing
+    PExp _ -> Nothing
     _ -> error "PANIC! Found wildcard in specRow"
 
-specializeLit :: Literal -> PatternMatrix -> PatternMatrix
-specializeLit lit = mapMaybe specLitRow
+specializeAtomic :: AtomicPat -> PatternMatrix -> PatternMatrix
+specializeAtomic ap = mapMaybe specAtomicRow
   where
-    specLitRow [] = Nothing
-    specLitRow (p : rest) =
+    specAtomicRow [] = Nothing
+    specAtomicRow (p : rest) =
       case p of
-        PLit l
-          | l == lit -> Just rest
-          | otherwise -> Nothing
+        PLit l | Left l == ap -> Just rest
+        PLit _ -> Nothing
+        PExp e | Right e == ap -> Just rest
+        PExp _ -> Nothing
         PVar _ -> Just rest
         PCon _ _ -> Nothing
-        _ -> error "PANIC! Found wildcard in specializeLit"
+        _ -> error "PANIC! Found wildcard in specializeAtomic"
 
 -- matrix definitions
 
@@ -555,6 +565,7 @@ defaultMatrix = concatMap defaultRow
         PVar _ -> [rest]
         PCon _ _ -> []
         PLit _ -> []
+        PExp _ -> []
         _ -> error "PANIC! Found wildcard in defaultMatrix"
 
 specializedBoundActs :: Id -> Occurrence -> PatternMatrix -> [BoundAction] -> [BoundAction]
@@ -569,6 +580,7 @@ specializedBoundActs k testOcc rows bacts =
       PCon k' _ -> idName k' == idName k
       PVar _ -> True
       PLit _ -> False
+      PExp _ -> False
       PWildcard -> error "PANIC! Found wildcard in specializedBoundActs"
     addVarBinding (PVar v : _) binds = binds ++ [(v, testOcc)]
     addVarBinding _ binds = binds
@@ -585,16 +597,17 @@ defaultBoundActs testOcc rows bacts =
     addVarBinding (PVar v : _) binds = binds ++ [(v, testOcc)]
     addVarBinding _ binds = binds
 
-litSpecializedBoundActs :: Literal -> Occurrence -> PatternMatrix -> [BoundAction] -> [BoundAction]
-litSpecializedBoundActs lit testOcc rows bacts =
+atomicSpecializedBoundActs :: AtomicPat -> Occurrence -> PatternMatrix -> [BoundAction] -> [BoundAction]
+atomicSpecializedBoundActs ap testOcc rows bacts =
   [ (addVarBinding row binds, a)
     | (row, (binds, a)) <- zip rows bacts,
-      rowMatchesLit row
+      rowMatchesAtomic row
   ]
   where
-    rowMatchesLit [] = False
-    rowMatchesLit (p : _) = case p of
-      PLit l -> l == lit
+    rowMatchesAtomic [] = False
+    rowMatchesAtomic (p : _) = case p of
+      PLit l -> Left l == ap
+      PExp e -> Right e == ap
       PVar _ -> True
       _ -> False
     addVarBinding (PVar v : _) binds = binds ++ [(v, testOcc)]
@@ -662,9 +675,10 @@ patHeadCon :: Pattern -> Maybe Id
 patHeadCon (PCon k _) = Just k
 patHeadCon _ = Nothing
 
-patHeadLit :: Pattern -> Maybe Literal
-patHeadLit (PLit l) = Just l
-patHeadLit _ = Nothing
+patHeadAtomic :: Pattern -> Maybe AtomicPat
+patHeadAtomic (PLit l) = Just (Left l)
+patHeadAtomic (PExp e) = Just (Right e)
+patHeadAtomic _ = Nothing
 
 -- redundancy checking (pre-pass over the original matrix)
 
@@ -692,7 +706,9 @@ isUseful tys matrix (q1 : qRest) =
       specMat <- specialize k fieldTys matrix
       isUseful (fieldTys ++ drop 1 tys) specMat (ps ++ qRest)
     PLit l ->
-      isUseful (drop 1 tys) (specializeLit l matrix) qRest
+      isUseful (drop 1 tys) (specializeAtomic (Left l) matrix) qRest
+    PExp _ ->
+      pure True -- conservative: expression labels are always considered useful
     PVar _ ->
       case tys of
         [] -> pure False
@@ -718,10 +734,10 @@ inhabitsM _ [] = pure Nothing
 inhabitsM matrix (ty : restTys) = do
   let firstCol = [p | (p : _) <- matrix]
       headCons = nub (mapMaybe patHeadCon firstCol)
-      headLits = nub (mapMaybe patHeadLit firstCol)
-  case (headCons, headLits) of
+      headAtomics = nub (mapMaybe patHeadAtomic firstCol)
+  case (headCons, headAtomics) of
     (cs@(_ : _), _) -> inhabitsConCol matrix ty restTys cs
-    ([], _ : _) -> inhabitsLitCol matrix ty restTys
+    ([], _ : _) -> inhabitsAtomCol matrix ty restTys
     ([], []) -> do
       r <- inhabitsM (defaultMatrix matrix) restTys
       case r of
@@ -764,8 +780,8 @@ inhabitsConCol matrix _ty restTys headCons =
           let (fieldWit, restWit) = splitAt (length fieldTys) wit
           pure (Just (PCon k fieldWit : restWit))
 
-inhabitsLitCol :: PatternMatrix -> Ty -> [Ty] -> CompilerM (Maybe [Pattern])
-inhabitsLitCol matrix ty restTys = do
+inhabitsAtomCol :: PatternMatrix -> Ty -> [Ty] -> CompilerM (Maybe [Pattern])
+inhabitsAtomCol matrix ty restTys = do
   r <- inhabitsM (defaultMatrix matrix) restTys
   case r of
     Nothing -> pure Nothing

--- a/src/Solcore/Desugarer/IfDesugarer.hs
+++ b/src/Solcore/Desugarer/IfDesugarer.hs
@@ -57,6 +57,7 @@ desugarBoolPat (PCon c@(Id n _) ps)
 desugarBoolPat (PVar a) = PVar a
 desugarBoolPat PWildcard = PWildcard
 desugarBoolPat (PLit l) = PLit l
+desugarBoolPat (PExp e) = PExp e
 
 -- desugaring the boolean type constructor
 

--- a/src/Solcore/Frontend/Parser/SolcoreParser.y
+++ b/src/Solcore/Frontend/Parser/SolcoreParser.y
@@ -384,6 +384,7 @@ Pattern :: { Pat }
 Pattern : Name PatternList                         {Pat $1 $2}
         | '_'                                      {PWildcard}
         | Literal                                  {PLit $1}
+        | 'comptime' Expr                          {PExp $2}
         | '(' Pattern ')'                          {$2}
         | PatternList                              {Pat (Name "pair") $1}
 

--- a/src/Solcore/Frontend/Pretty/SolcorePretty.hs
+++ b/src/Solcore/Frontend/Pretty/SolcorePretty.hs
@@ -318,6 +318,8 @@ instance (Pretty a) => Pretty (Pat a) where
     text "_"
   ppr (PLit l) =
     ppr l
+  ppr (PExp e) =
+    text "comptime" <+> ppr e
 
 instance Pretty Literal where
   ppr (IntLit l) = integer (toInteger l)

--- a/src/Solcore/Frontend/Pretty/TreePretty.hs
+++ b/src/Solcore/Frontend/Pretty/TreePretty.hs
@@ -330,6 +330,8 @@ instance Pretty Pat where
     text "_"
   ppr (PLit l) =
     ppr l
+  ppr (PExp e) =
+    text "comptime" <+> ppr e
 
 instance Pretty Literal where
   ppr (IntLit l) = integer (toInteger l)

--- a/src/Solcore/Frontend/Syntax/NameResolution.hs
+++ b/src/Solcore/Frontend/Syntax/NameResolution.hs
@@ -255,6 +255,7 @@ instance Resolve S.Pat where
 
   resolve S.PWildcard = pure PWildcard
   resolve (S.PLit l) = PLit <$> resolve l
+  resolve (S.PExp e) = PExp <$> resolve e
   resolve p@(S.Pat n ps) =
     do
       ps' <- resolve ps `wrapError` p

--- a/src/Solcore/Frontend/Syntax/Stmt.hs
+++ b/src/Solcore/Frontend/Syntax/Stmt.hs
@@ -52,6 +52,7 @@ data Pat a
   | PCon a [Pat a]
   | PWildcard
   | PLit Literal
+  | PExp (Exp a) -- comptime expression label (numeric matches only)
   deriving (Eq, Ord, Show, Data, Typeable)
 
 -- definition of literals

--- a/src/Solcore/Frontend/Syntax/SyntaxTree.hs
+++ b/src/Solcore/Frontend/Syntax/SyntaxTree.hs
@@ -240,6 +240,7 @@ data Pat
   = Pat Name [Pat]
   | PWildcard
   | PLit Literal
+  | PExp Exp -- comptime expression label (numeric matches only)
   deriving (Eq, Ord, Show, Data, Typeable)
 
 -- definition of literals

--- a/src/Solcore/Frontend/TypeInference/Erase.hs
+++ b/src/Solcore/Frontend/TypeInference/Erase.hs
@@ -98,3 +98,5 @@ instance Erase (Pat Id) where
     PWildcard
   erase (PLit l) =
     PLit l
+  erase (PExp e) =
+    PExp (erase e)

--- a/src/Solcore/Frontend/TypeInference/TcMonad.hs
+++ b/src/Solcore/Frontend/TypeInference/TcMonad.hs
@@ -15,6 +15,7 @@ import Solcore.Frontend.TypeInference.TcEnv
 import Solcore.Frontend.TypeInference.TcSubst
 import Solcore.Frontend.TypeInference.TcUnify
 import Solcore.Pipeline.Options (Option (..))
+import Solcore.Primitives.Primitives (word)
 import System.TimeIt qualified as TimeIt
 import Text.Printf
 
@@ -78,6 +79,22 @@ isUniqueTyName :: Name -> TcM Bool
 isUniqueTyName n = do
   uenv <- gets uniqueTypes
   pure $ any (\d -> dataName d == n) (Map.elems uenv)
+
+-- A type is numeric if it is 'word', or if it is an algebraic type with
+-- exactly one constructor that takes exactly one argument of type 'word'.
+-- Examples: word, uint256 (= data uint256 = uint256(word))
+-- Non-examples: bool, mw (= data mw = N | J(word))
+isNumericTy :: Ty -> TcM Bool
+isNumericTy ty
+  | ty == word = pure True
+  | TyCon n [] <- ty = do
+      mti <- maybeAskTypeInfo n
+      case mti of
+        Just (TypeInfo _ [con] _) -> do
+          (Constr _ fields, _) <- constrsFromEnv con
+          pure (fields == [word])
+        _ -> pure False
+  | otherwise = pure False
 
 typeInfoFor :: DataTy -> TypeInfo
 typeInfoFor (DataTy _ vs cons) =

--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -173,6 +173,18 @@ tcPat t' (PLit l) =
     t <- tcLit l
     s <- unify t t'
     pure (PLit l, apply s t, [])
+tcPat t' (PExp e) =
+  do
+    (e', _ps, t) <- tcExp e
+    -- _ps (predicates) are discarded: comptime expression labels have concrete
+    -- numeric types resolved by unification with the scrutinee, so constraints
+    -- are solved implicitly. A fuller implementation would thread _ps upward.
+    s <- unify t t'
+    numericOk <- isNumericTy (apply s t)
+    unless numericOk $
+      tcmError $
+        "expression match label must have a numeric type, got: " ++ pretty (apply s t)
+    withCurrentSubst (PExp (apply s e'), apply s t, [])
 
 -- type inference for expressions
 

--- a/test/MatchCompilerTests.hs
+++ b/test/MatchCompilerTests.hs
@@ -2,6 +2,7 @@ module MatchCompilerTests where
 
 import Data.List (sort)
 import Data.Map qualified as Map
+import Data.Maybe (mapMaybe)
 import Solcore.Desugarer.DecisionTreeCompiler
 import Solcore.Frontend.Pretty.SolcorePretty
 import Solcore.Frontend.Syntax
@@ -136,8 +137,8 @@ branchNames bs = sort [nameOf (idName k) | (k, _, _) <- bs]
   where
     nameOf n = pretty n
 
-branchLits :: [(Literal, DecisionTree)] -> [Literal]
-branchLits = map fst
+branchLits :: [(AtomicPat, DecisionTree)] -> [Literal]
+branchLits = mapMaybe (either Just (const Nothing) . fst)
 
 tyBool :: Ty
 tyBool = TyCon (Name "Bool") []
@@ -395,10 +396,10 @@ test_twoColumn_completeCover_noWarnings =
     assertInnerHasNoDefault t =
       assertFailure ("inner subtree should have no default branch, got: " ++ show t)
 
--- 8. Literal patterns with a variable catch-all → LitSwitch with Leaf default, no warnings
+-- 8. Literal patterns with a variable catch-all → AtomicSwitch with Leaf default, no warnings
 test_litPats_withVarDefault_noWarnings :: TestTree
 test_litPats_withVarDefault_noWarnings =
-  testCase "lit patterns with variable fallback -> LitSwitch with Leaf default, no warnings"
+  testCase "lit patterns with variable fallback -> AtomicSwitch with Leaf default, no warnings"
     $ assertRight
       "lit-default"
       ( runMatrix
@@ -410,7 +411,7 @@ test_litPats_withVarDefault_noWarnings =
       )
     $ \tree warns -> do
       case tree of
-        LitSwitch [0] branches (Just (Leaf _ defAct)) -> do
+        AtomicSwitch [0] branches (Just (Leaf _ defAct)) -> do
           assertBool
             "should have literal 0 branch"
             (IntLit 0 `elem` branchLits branches)
@@ -419,15 +420,15 @@ test_litPats_withVarDefault_noWarnings =
             (IntLit 1 `elem` branchLits branches)
           assertEqual "default leaf should be actionC" actionC defAct
           assertBool "should have no warnings:" (null warns)
-        LitSwitch _ _ Nothing ->
+        AtomicSwitch _ _ Nothing ->
           assertFailure "expected a default branch for the variable catch-all"
         _ ->
-          assertFailure ("expected LitSwitch, got: " ++ show tree)
+          assertFailure ("expected AtomicSwitch, got: " ++ show tree)
 
--- 9. Literal patterns without a catch-all → LitSwitch with Fail default + NonExhaustive
+-- 9. Literal patterns without a catch-all → AtomicSwitch with Fail default + NonExhaustive
 test_litPats_noDefault_nonExhaustive :: TestTree
 test_litPats_noDefault_nonExhaustive =
-  testCase "lit patterns without catch-all -> LitSwitch with Fail default and NonExhaustive"
+  testCase "lit patterns without catch-all -> AtomicSwitch with Fail default and NonExhaustive"
     $ assertRight
       "lit-no-default"
       ( runMatrix
@@ -439,7 +440,7 @@ test_litPats_noDefault_nonExhaustive =
       )
     $ \tree warns -> do
       case tree of
-        LitSwitch [0] branches (Just Fail) -> do
+        AtomicSwitch [0] branches (Just Fail) -> do
           assertBool
             "should have literal 0 branch"
             (IntLit 0 `elem` branchLits branches)
@@ -448,7 +449,7 @@ test_litPats_noDefault_nonExhaustive =
             (IntLit 1 `elem` branchLits branches)
           assertBool "should emit NonExhaustive warning" (any isNonExh warns)
         _ ->
-          assertFailure ("expected LitSwitch … (Just Fail), got: " ++ show tree)
+          assertFailure ("expected AtomicSwitch … (Just Fail), got: " ++ show tree)
 
 -- 10. Constructor absent from the TypeEnv → Left error
 test_unknownConstructor_isError :: TestTree

--- a/test/examples/comptime/match_labels.solc
+++ b/test/examples/comptime/match_labels.solc
@@ -1,0 +1,33 @@
+/* Test comptime expression match labels.
+   Covers: comptime literal, comptime arithmetic with a variable,
+   comptime function call, and pattern variable catch-all.
+*/
+
+import std;
+
+forall i.
+class i : Int {
+  function fromWord(x:word) -> comptime i;
+  function toWord(x:i) -> comptime word;
+}
+
+instance uint256 : Int {
+  function fromWord(x:word) -> comptime uint256 { uint256(x) }
+  function toWord(x:uint256) -> comptime word { Typedef.rep(x) }
+}
+
+contract MatchLabels {
+
+  function classify(x : word) -> word {
+    let two : comptime word = 2;
+    match x {
+      | comptime two + 0             => return 2;
+      | comptime toWord(uint256(40)) => return 40;
+      | other                        => return other;
+    }
+  }
+
+  function main() -> word {
+    return classify(0) + classify(2) + classify(40);
+  }
+}


### PR DESCRIPTION
Allow stuff like

```
  function classify(x : word) -> word {
    let two : comptime word = 2;
    match x {
      | comptime two + 0             => return 2;
      | comptime toWord(uint256(40)) => return 40;
      | other                        => return other;
    }
  }
```

The idea is to use it for dispatch instead of chained if statements.