### PR TITLE
Comptime annotation check

### DIFF
--- a/sol-core.cabal
+++ b/sol-core.cabal
@@ -60,6 +60,7 @@ library
 
   -- cabal-fmt: expand src
   exposed-modules:
+      Solcore.Backend.ComptimeCheck
       Solcore.Backend.EmitHull
       Solcore.Backend.Mast
       Solcore.Backend.MastEval

--- a/sol-core.cabal
+++ b/sol-core.cabal
@@ -73,6 +73,7 @@ library
       Solcore.Desugarer.ContractDispatch
       Solcore.Desugarer.ReplaceFunTypeArgs
       Solcore.Desugarer.UniqueTypeGen
+      Solcore.Frontend.ComptimeCheck
       Solcore.Frontend.Lexer.SolcoreLexer
       Solcore.Frontend.Parser.SolcoreParser
       Solcore.Frontend.Pretty.SolcorePretty

--- a/src/Solcore/Backend/ComptimeCheck.hs
+++ b/src/Solcore/Backend/ComptimeCheck.hs
@@ -48,7 +48,14 @@ checkFunDef :: FunTable -> Set.Set Name -> MastFunDef -> Either String ()
 checkFunDef ft pure_ fd =
   checkStmts ft pure_ (mastFunRetComptime fd) (mastFunName fd) initEnv (mastFunBody fd)
   where
-    initEnv = Set.fromList [mastParamName p | p <- mastFunParams fd, mastParamComptime p]
+    -- For '-> comptime' functions, assume ALL params are comptime when checking
+    -- the body: this verifies "if all args happen to be comptime, is the result?"
+    -- For other functions, only explicitly-annotated comptime params are trusted.
+    initEnv = Set.fromList
+      [ mastParamName p
+      | p <- mastFunParams fd
+      , mastParamComptime p || mastFunRetComptime fd
+      ]
 
 -- | Check a sequence of statements, threading the comptime environment.
 checkStmts :: FunTable -> Set.Set Name -> Bool -> Name -> ComptimeEnv -> [MastStmt] -> Either String ()

--- a/src/Solcore/Backend/ComptimeCheck.hs
+++ b/src/Solcore/Backend/ComptimeCheck.hs
@@ -1,0 +1,146 @@
+module Solcore.Backend.ComptimeCheck (checkComptime) where
+
+{- MAST-level comptime verification pass.
+   Runs on MastCompUnit after specialization and partial evaluation.
+
+   Two independent concerns:
+     1. Classification: is an expression statically comptime?
+        A value is comptime if it is a literal, a comptime-bound variable,
+        or a call to a pure function whose arguments are all comptime.
+        Purity is determined by computePureFuns (MastEval).
+
+     2. Constraint checking: annotations must be consistent with reality.
+        - A parameter annotated 'comptime' must receive a comptime argument
+          at every call site.
+        - A 'let x : comptime T = e' binding requires e to be comptime.
+        - A function annotated '-> comptime T' requires every returned
+          expression to be comptime.
+
+   The verifier reports the first violation found as a String error.
+-}
+
+import Data.Map qualified as Map
+import Data.Set qualified as Set
+import Solcore.Backend.Mast
+import Solcore.Backend.MastEval (FunTable, buildFunTable, computePureFuns)
+import Solcore.Frontend.Syntax.Name (Name)
+
+-- | Set of variable names known to be comptime in the current scope.
+type ComptimeEnv = Set.Set Name
+
+-- | Entry point: check all functions in the compilation unit.
+checkComptime :: MastCompUnit -> Either String ()
+checkComptime cu = mapM_ checkTopDecl (mastTopDecls cu)
+  where
+    ft = buildFunTable cu
+    pure_ = computePureFuns ft
+
+    checkTopDecl (MastTContr c) = mapM_ (checkContractDecl ft pure_) (mastContrDecls c)
+    checkTopDecl (MastTDataDef _) = Right ()
+
+checkContractDecl :: FunTable -> Set.Set Name -> MastContractDecl -> Either String ()
+checkContractDecl ft pure_ (MastCFunDecl fd) = checkFunDef ft pure_ fd
+checkContractDecl ft pure_ (MastCMutualDecl ds) = mapM_ (checkContractDecl ft pure_) ds
+checkContractDecl _ _ (MastCDataDecl _) = Right ()
+
+-- | Check a single function definition.
+checkFunDef :: FunTable -> Set.Set Name -> MastFunDef -> Either String ()
+checkFunDef ft pure_ fd =
+  checkStmts ft pure_ (mastFunRetComptime fd) (mastFunName fd) initEnv (mastFunBody fd)
+  where
+    initEnv = Set.fromList [mastParamName p | p <- mastFunParams fd, mastParamComptime p]
+
+-- | Check a sequence of statements, threading the comptime environment.
+checkStmts :: FunTable -> Set.Set Name -> Bool -> Name -> ComptimeEnv -> [MastStmt] -> Either String ()
+checkStmts _ _ _ _ _ [] = Right ()
+checkStmts ft pure_ retCt fname env (s : ss) = do
+  env' <- checkStmt ft pure_ retCt fname env s
+  checkStmts ft pure_ retCt fname env' ss
+
+-- | Check one statement; returns the updated comptime environment.
+checkStmt :: FunTable -> Set.Set Name -> Bool -> Name -> ComptimeEnv -> MastStmt -> Either String ComptimeEnv
+checkStmt ft pure_ retCt fname env stmt = case stmt of
+  MastLet ct i _ mInit -> do
+    case mInit of
+      Nothing -> return env
+      Just e -> do
+        checkExp ft pure_ env e
+        let ct' = isComptime ft pure_ env e
+        when_ (ct && not ct') $
+          "comptime let '" ++ show (mastIdName i) ++ "' is bound to a runtime expression"
+        return $ if ct || ct' then Set.insert (mastIdName i) env else env
+  MastAssign _ e -> do
+    checkExp ft pure_ env e
+    return env
+  MastStmtExp e -> do
+    checkExp ft pure_ env e
+    return env
+  MastReturn e -> do
+    checkExp ft pure_ env e
+    let ct' = isComptime ft pure_ env e
+    when_ (retCt && not ct') $
+      "function '" ++ show fname ++ "' annotated '-> comptime' returns a runtime expression"
+    return env
+  MastMatch scrut alts -> do
+    checkExp ft pure_ env scrut
+    mapM_ (checkAlt ft pure_ retCt fname env) alts
+    return env
+  MastAsm _ ->
+    return env
+
+-- | Check an alternative in a match expression.
+checkAlt :: FunTable -> Set.Set Name -> Bool -> Name -> ComptimeEnv -> MastAlt -> Either String ()
+checkAlt ft pure_ retCt fname env (_, body) =
+  checkStmts ft pure_ retCt fname env body
+
+-- | Check comptime-param constraints inside an expression (recursive).
+checkExp :: FunTable -> Set.Set Name -> ComptimeEnv -> MastExp -> Either String ()
+checkExp ft pure_ env (MastCall f args) = do
+  checkCallSite ft pure_ env f args
+  mapM_ (checkExp ft pure_ env) args
+checkExp ft pure_ env (MastCon _ args) =
+  mapM_ (checkExp ft pure_ env) args
+checkExp ft pure_ env (MastCond c t e) =
+  mapM_ (checkExp ft pure_ env) [c, t, e]
+checkExp _ _ _ _ = Right ()
+
+-- | Verify that comptime-annotated parameters receive comptime arguments.
+checkCallSite :: FunTable -> Set.Set Name -> ComptimeEnv -> MastId -> [MastExp] -> Either String ()
+checkCallSite ft pure_ env f args =
+  case Map.lookup (mastIdName f) ft of
+    Nothing -> Right () -- builtin or unknown; no annotation to check
+    Just fd ->
+      mapM_ checkArg (zip (mastFunParams fd) args)
+  where
+    checkArg (param, arg) =
+      when_ (mastParamComptime param && not (isComptime ft pure_ env arg)) $
+        "runtime value passed to comptime parameter '"
+          ++ show (mastParamName param)
+          ++ "' of '"
+          ++ show (mastIdName f)
+          ++ "'"
+
+-- | Classify an expression as comptime (True) or runtime (False).
+--
+-- A value is comptime if it is:
+--   - a literal
+--   - a variable bound in the comptime environment
+--   - a call to a pure function with all comptime arguments
+--   - a constructor applied to all comptime arguments
+--   - a conditional whose scrutinee and both branches are comptime
+isComptime :: FunTable -> Set.Set Name -> ComptimeEnv -> MastExp -> Bool
+isComptime _ _ _ (MastLit _) = True
+isComptime _ _ env (MastVar i) = mastIdName i `Set.member` env
+isComptime ft pure_ env (MastCall f args) =
+  mastIdName f `Set.member` pure_ && all (isComptime ft pure_ env) args
+isComptime ft pure_ env (MastCon _ args) =
+  all (isComptime ft pure_ env) args
+isComptime ft pure_ env (MastCond c t e) =
+  isComptime ft pure_ env c
+    && isComptime ft pure_ env t
+    && isComptime ft pure_ env e
+
+-- | Like 'when' but for Either.
+when_ :: Bool -> String -> Either String ()
+when_ True msg = Left msg
+when_ False _ = Right ()

--- a/src/Solcore/Backend/ComptimeCheck.hs
+++ b/src/Solcore/Backend/ComptimeCheck.hs
@@ -51,11 +51,12 @@ checkFunDef ft pure_ fd =
     -- For '-> comptime' functions, assume ALL params are comptime when checking
     -- the body: this verifies "if all args happen to be comptime, is the result?"
     -- For other functions, only explicitly-annotated comptime params are trusted.
-    initEnv = Set.fromList
-      [ mastParamName p
-      | p <- mastFunParams fd
-      , mastParamComptime p || mastFunRetComptime fd
-      ]
+    initEnv =
+      Set.fromList
+        [ mastParamName p
+          | p <- mastFunParams fd,
+            mastParamComptime p || mastFunRetComptime fd
+        ]
 
 -- | Check a sequence of statements, threading the comptime environment.
 checkStmts :: FunTable -> Set.Set Name -> Bool -> Name -> ComptimeEnv -> [MastStmt] -> Either String ()

--- a/src/Solcore/Backend/EmitHull.hs
+++ b/src/Solcore/Backend/EmitHull.hs
@@ -371,6 +371,7 @@ emitWordMatch scrutinee alts = do
       hullStmts <- emitStmts stmts
       let hullName = show n
       return (Hull.Alt (Hull.PVar hullName) "$_" hullStmts)
+    emitWordAlt _ (MastPExp _, _) = errorsEM ["PANIC: MastPExp reached EmitHull — was not evaluated by MastEval"]
     emitWordAlt _ (pat, _) = errorsEM ["emitWordAlt not implemented for", show pat]
 
 type BranchMap = Map.Map Name [Hull.Stmt]

--- a/src/Solcore/Backend/EmitHull.hs
+++ b/src/Solcore/Backend/EmitHull.hs
@@ -160,7 +160,7 @@ emitFunDef fd = withContext (show (mastFunName fd)) do
   return [hullFun]
 
 translateParam :: MastParam -> EM Hull.Arg
-translateParam (MastParam n t) = Hull.TArg (show n) <$> translateMastType t
+translateParam (MastParam n _ct t) = Hull.TArg (show n) <$> translateMastType t
 
 -----------------------------------------------------------------------
 -- Translating types and value constructors

--- a/src/Solcore/Backend/Mast.hs
+++ b/src/Solcore/Backend/Mast.hs
@@ -85,6 +85,7 @@ data MastFunDef = MastFunDef
 
 data MastParam = MastParam
   { mastParamName :: Name,
+    mastParamComptime :: ComptimeFlag,
     mastParamType :: MastTy
   }
   deriving (Eq, Ord, Show)
@@ -214,7 +215,7 @@ instance Pretty MastFunDef where
       $$ rbrace
 
 instance Pretty MastParam where
-  ppr (MastParam n t) = ppr n <+> colon <+> ppr t
+  ppr (MastParam n ct t) = (if ct then text "comptime" <+> ppr n else ppr n) <+> colon <+> ppr t
 
 instance Pretty MastStmt where
   ppr (MastAssign i e) = ppr i <+> equals <+> ppr e <+> semi

--- a/src/Solcore/Backend/Mast.hs
+++ b/src/Solcore/Backend/Mast.hs
@@ -125,6 +125,7 @@ data MastPat
   | MastPCon MastId [MastPat]
   | MastPWildcard
   | MastPLit Literal
+  | MastPExp MastExp -- comptime expression label; must be evaluated by MastEval
   deriving (Eq, Ord, Show)
 
 -----------------------------------------------------------------------
@@ -269,6 +270,7 @@ instance Pretty MastPat where
     | otherwise = ppr n >< parens (commaSep $ map ppr ps)
   ppr MastPWildcard = text "_"
   ppr (MastPLit l) = ppr l
+  ppr (MastPExp e) = text "comptime" <+> ppr e
 
 -----------------------------------------------------------------------
 -- Helpers (shared with SolcorePretty)

--- a/src/Solcore/Backend/MastEval.hs
+++ b/src/Solcore/Backend/MastEval.hs
@@ -2,6 +2,9 @@ module Solcore.Backend.MastEval
   ( evalCompUnit,
     defaultFuel,
     eliminateDeadCode,
+    FunTable,
+    buildFunTable,
+    computePureFuns,
   )
 where
 

--- a/src/Solcore/Backend/MastEval.hs
+++ b/src/Solcore/Backend/MastEval.hs
@@ -7,7 +7,7 @@ where
 
 {- Partial Evaluator for Mast
    Performs compile-time evaluation where possible:
-   - Folds calls to `addWord`, `gtWord`, `eqWord` with literal arguments
+   - Folds calls to `addWord`, `subWord`, `mulWord`, `gtWord`, `eqWord` with literal arguments
    - Propagates known variable values
    - Inlines simple pure functions with literal arguments
 -}
@@ -256,6 +256,8 @@ evalPrimitive (Name "addWord") [MastLit (IntLit a), MastLit (IntLit b)] =
   Just (MastLit (IntLit (a + b)))
 evalPrimitive (Name "subWord") [MastLit (IntLit a), MastLit (IntLit b)] =
   Just (MastLit (IntLit (a - b)))
+evalPrimitive (Name "mulWord") [MastLit (IntLit a), MastLit (IntLit b)] =
+  Just (MastLit (IntLit (a * b)))
 evalPrimitive (Name "gtWord") [MastLit (IntLit a), MastLit (IntLit b)] =
   Just $ mkBool (a > b)
 evalPrimitive (Name "eqWord") [MastLit (IntLit a), MastLit (IntLit b)] =
@@ -437,6 +439,7 @@ builtinPureFuns =
   Set.fromList
     [ Name "addWord",
       Name "subWord",
+      Name "mulWord",
       Name "gtWord",
       Name "eqWord",
       Name "concatLit",

--- a/src/Solcore/Backend/MastEval.hs
+++ b/src/Solcore/Backend/MastEval.hs
@@ -196,8 +196,19 @@ evalAlt :: VEnv -> MastAlt -> EvalM MastAlt
 evalAlt env (pat, body) = do
   -- Pattern bindings shadow existing bindings, but we don't track them
   -- (conservative: treat all pattern-bound vars as unknown)
+  pat' <- evalPat env pat
   (_, body') <- evalStmts env body
-  pure (pat, body')
+  pure (pat', body')
+
+-- Evaluate expression labels in patterns.
+-- MastPExp must reduce to a literal; any other form is a compile-time error.
+evalPat :: VEnv -> MastPat -> EvalM MastPat
+evalPat env (MastPExp e) = do
+  e' <- evalExp env e
+  case e' of
+    MastLit l -> pure (MastPLit l)
+    _ -> error $ "comptime expression in match label could not be evaluated to a literal: " ++ show e'
+evalPat _ pat = pure pat
 
 -----------------------------------------------------------------------
 -- Evaluate expressions
@@ -333,7 +344,8 @@ evalFunBody env (stmt : rest) = case stmt of
     pure $ if isKnownValue e' then Just e' else Nothing
   MastMatch scrut alts -> do
     scrut' <- evalExp env scrut
-    case matchAlts env scrut' alts of
+    alts' <- mapM (\(p, b) -> (,b) <$> evalPat env p) alts
+    case matchAlts env scrut' alts' of
       Just (env', body) -> evalFunBody env' body
       Nothing -> pure Nothing -- Scrutinee not known, can't select branch
   MastAsm _ -> pure Nothing -- Should not happen: purity analysis excludes asm functions
@@ -373,6 +385,7 @@ findLitMatch env lit ((pat, body) : rest) =
       let env' = Map.insert varId (MastLit lit) env
        in Just (env', body)
     MastPWildcard -> Just (env, body)
+    MastPExp _ -> error "PANIC: MastPExp reached findLitMatch — evalAlt failed to evaluate it"
     _ -> findLitMatch env lit rest
 
 -- Bind pattern variables to argument expressions
@@ -401,6 +414,7 @@ bindPatterns env (pat : pats) (arg : args) =
       case arg of
         MastLit argLit | argLit == patLit -> bindPatterns env pats args
         _ -> Nothing
+    MastPExp _ -> error "PANIC: MastPExp reached bindPatterns — evalAlt failed to evaluate it"
 
 -----------------------------------------------------------------------
 -- Helpers

--- a/src/Solcore/Backend/MastEval.hs
+++ b/src/Solcore/Backend/MastEval.hs
@@ -457,6 +457,8 @@ builtinImpureFuns = Set.fromList [Name "revert"]
 -- | Compute the set of pure functions via fixed-point iteration.
 -- Start from builtinPureFuns; each iteration adds functions whose bodies
 -- contain no asm and whose every call target is already known-pure.
+-- Self-recursive calls are handled by including the candidate function in
+-- the assumed-pure set when checking its own body.
 computePureFuns :: FunTable -> Set.Set Name
 computePureFuns ft = go builtinPureFuns
   where
@@ -468,7 +470,7 @@ computePureFuns ft = go builtinPureFuns
                     || fname `Set.member` builtinImpureFuns
                     then acc
                     else
-                      if bodyIsPure acc (mastFunBody fd)
+                      if bodyIsPure (Set.insert fname acc) (mastFunBody fd)
                         then Set.insert fname acc
                         else acc
               )

--- a/src/Solcore/Backend/Specialise.hs
+++ b/src/Solcore/Backend/Specialise.hs
@@ -499,8 +499,15 @@ specMatch exps alts = do
       -- debug ["specAlt, pattern: ", show pat]
       -- debug ["specAlt, body: ", show body]
       body' <- specBody body
-      pat' <- atCurrentSubst pat
+      pat' <- mapM specPat =<< atCurrentSubst pat
       return (pat', body')
+    -- Specialize function calls inside PExp patterns.
+    -- Other pattern forms only need type substitution (handled by atCurrentSubst).
+    specPat :: Pat Id -> SM (Pat Id)
+    specPat (PExp e) = do
+      ty <- atCurrentSubst (typeOfTcExp e)
+      PExp <$> specExp e ty
+    specPat p = pure p
     specScruts = mapM specScrut
     specScrut e = do
       ty <- atCurrentSubst (typeOfTcExp e)
@@ -853,3 +860,4 @@ toMastPat (PVar i) = MastPVar (toMastId i)
 toMastPat (PCon i ps) = MastPCon (toMastId i) (map toMastPat ps)
 toMastPat PWildcard = MastPWildcard
 toMastPat (PLit l) = MastPLit l
+toMastPat (PExp e) = MastPExp (toMastExp e)

--- a/src/Solcore/Backend/Specialise.hs
+++ b/src/Solcore/Backend/Specialise.hs
@@ -818,7 +818,7 @@ toMastFunDef (FunDef sig body) =
     }
 
 toMastParam :: Param Id -> MastParam
-toMastParam p = MastParam (idName i) (toMastTy (idType i))
+toMastParam p = MastParam (idName i) (paramComptime p) (toMastTy (idType i))
   where
     i = getParamId p
 

--- a/src/Solcore/Desugarer/DecisionTreeCompiler.hs
+++ b/src/Solcore/Desugarer/DecisionTreeCompiler.hs
@@ -244,10 +244,10 @@ buildAtomicSwitch testOcc restOccs testTy restTys matrix bacts headAtomics = do
       else Just <$> compileMatrix restTys restOccs defMat defBacts
   pure (AtomicSwitch testOcc branches mDefault)
   where
-    buildBranch ap = do
-      let specMat = specializeAtomic ap matrix
-          specBacts = atomicSpecializedBoundActs ap testOcc matrix bacts
-      (ap,) <$> compileMatrix restTys restOccs specMat specBacts
+    buildBranch apat = do
+      let specMat = specializeAtomic apat matrix
+          specBacts = atomicSpecializedBoundActs apat testOcc matrix bacts
+      (apat,) <$> compileMatrix restTys restOccs specMat specBacts
 
 instance Compile (Exp Id) where
   compile v@(Var _) =
@@ -541,14 +541,14 @@ specRow k pats (p : rest) =
     _ -> error "PANIC! Found wildcard in specRow"
 
 specializeAtomic :: AtomicPat -> PatternMatrix -> PatternMatrix
-specializeAtomic ap = mapMaybe specAtomicRow
+specializeAtomic apat = mapMaybe specAtomicRow
   where
     specAtomicRow [] = Nothing
     specAtomicRow (p : rest) =
       case p of
-        PLit l | Left l == ap -> Just rest
+        PLit l | Left l == apat -> Just rest
         PLit _ -> Nothing
-        PExp e | Right e == ap -> Just rest
+        PExp e | Right e == apat -> Just rest
         PExp _ -> Nothing
         PVar _ -> Just rest
         PCon _ _ -> Nothing
@@ -598,7 +598,7 @@ defaultBoundActs testOcc rows bacts =
     addVarBinding _ binds = binds
 
 atomicSpecializedBoundActs :: AtomicPat -> Occurrence -> PatternMatrix -> [BoundAction] -> [BoundAction]
-atomicSpecializedBoundActs ap testOcc rows bacts =
+atomicSpecializedBoundActs apat testOcc rows bacts =
   [ (addVarBinding row binds, a)
     | (row, (binds, a)) <- zip rows bacts,
       rowMatchesAtomic row
@@ -606,8 +606,8 @@ atomicSpecializedBoundActs ap testOcc rows bacts =
   where
     rowMatchesAtomic [] = False
     rowMatchesAtomic (p : _) = case p of
-      PLit l -> Left l == ap
-      PExp e -> Right e == ap
+      PLit l -> Left l == apat
+      PExp e -> Right e == apat
       PVar _ -> True
       _ -> False
     addVarBinding (PVar v : _) binds = binds ++ [(v, testOcc)]

--- a/src/Solcore/Desugarer/DecisionTreeCompiler.hs
+++ b/src/Solcore/Desugarer/DecisionTreeCompiler.hs
@@ -141,12 +141,12 @@ compileMatrix tys occs matrix bacts = do
     (testTy : restTys, testOcc : restOccs, _) -> do
       let firstCol = [p | (p : _) <- matrix']
           headCons = nub (mapMaybe patHeadCon firstCol)
-          headLits = nub (mapMaybe patHeadLit firstCol)
-      case (headCons, headLits) of
+          headAtomics = nub (mapMaybe patHeadAtomic firstCol)
+      case (headCons, headAtomics) of
         (c : cs, _) ->
           buildConSwitch testOcc restOccs testTy restTys matrix' bacts (c : cs)
-        ([], ls@(_ : _)) ->
-          buildLitSwitch testOcc restOccs testTy restTys matrix' bacts ls
+        ([], as@(_ : _)) ->
+          buildAtomicSwitch testOcc restOccs testTy restTys matrix' bacts as
         ([], []) ->
           -- All wildcards after reordering: strip column and continue
           compileMatrix restTys restOccs (defaultMatrix matrix') (defaultBoundActs testOcc matrix' bacts)
@@ -220,34 +220,34 @@ buildConSwitch testOcc restOccs _testTy restTys matrix bacts headCons = do
               pure (Just Fail)
             else Just <$> compileMatrix restTys restOccs defMat defBacts
 
-buildLitSwitch ::
+buildAtomicSwitch ::
   Occurrence ->
   [Occurrence] ->
   Ty ->
   [Ty] ->
   PatternMatrix ->
   [BoundAction] ->
-  [Literal] ->
+  [AtomicPat] ->
   CompilerM DecisionTree
-buildLitSwitch testOcc restOccs testTy restTys matrix bacts headLits = do
-  branches <- mapM buildBranch headLits
+buildAtomicSwitch testOcc restOccs testTy restTys matrix bacts headAtomics = do
+  branches <- mapM buildBranch headAtomics
   let defMat = defaultMatrix matrix
       defBacts = defaultBoundActs testOcc matrix bacts
   mDefault <-
     if null defMat
       then do
-        litWit <- freshPat testTy
+        wit <- freshPat testTy
         restWit <- mapM freshPat restTys
         ctx <- askWarnCtx
-        tell [NonExhaustive ctx (litWit : restWit)]
+        tell [NonExhaustive ctx (wit : restWit)]
         pure (Just Fail)
       else Just <$> compileMatrix restTys restOccs defMat defBacts
-  pure (LitSwitch testOcc branches mDefault)
+  pure (AtomicSwitch testOcc branches mDefault)
   where
-    buildBranch lit = do
-      let specMat = specializeLit lit matrix
-          specBacts = litSpecializedBoundActs lit testOcc matrix bacts
-      (lit,) <$> compileMatrix restTys restOccs specMat specBacts
+    buildBranch ap = do
+      let specMat = specializeAtomic ap matrix
+          specBacts = atomicSpecializedBoundActs ap testOcc matrix bacts
+      (ap,) <$> compileMatrix restTys restOccs specMat specBacts
 
 instance Compile (Exp Id) where
   compile v@(Var _) =
@@ -303,9 +303,9 @@ treeToStmt occMap (Switch occ branches mDef) = do
       v <- freshPat ty
       pure [([v], body)]
   pure (Match [scrutinee] (eqns ++ defEqns))
-treeToStmt occMap (LitSwitch occ branches mDef) = do
+treeToStmt occMap (AtomicSwitch occ branches mDef) = do
   scrutinee <- occToExp occMap occ
-  eqns <- mapM (litBranchToEqn occMap) branches
+  eqns <- mapM (atomicBranchToEqn occMap) branches
   defEqns <- case mDef of
     Nothing -> pure []
     Just def -> do
@@ -349,10 +349,13 @@ conBranchToEqn occMap occ (k, srcPats, tree) = do
   body <- treeToBody occMap' tree
   pure ([PCon k srcPats], body)
 
-litBranchToEqn :: OccMap -> (Literal, DecisionTree) -> CompilerM (PatternRow, Action)
-litBranchToEqn occMap (lit, tree) = do
+atomicBranchToEqn :: OccMap -> (AtomicPat, DecisionTree) -> CompilerM (PatternRow, Action)
+atomicBranchToEqn occMap (Left lit, tree) = do
   body <- treeToBody occMap tree
   pure ([PLit lit], body)
+atomicBranchToEqn occMap (Right e, tree) = do
+  body <- treeToBody occMap tree
+  pure ([PExp e], body)
 
 -- definition of a monad
 
@@ -445,8 +448,13 @@ data DecisionTree
   = Leaf [(Id, Occurrence)] Action -- var-occ bindings to substitute before running action
   | Fail
   | Switch Occurrence [(Id, [Pattern], DecisionTree)] (Maybe DecisionTree)
-  | LitSwitch Occurrence [(Literal, DecisionTree)] (Maybe DecisionTree)
+  | AtomicSwitch Occurrence [(AtomicPat, DecisionTree)] (Maybe DecisionTree)
   deriving (Eq, Show)
+
+-- An atomic pattern is a compile-time value used as a match label.
+-- Left  = integer literal (already evaluated)
+-- Right = comptime expression (evaluated post-specialization by MastEval)
+type AtomicPat = Either Literal (Exp Id)
 
 -- data constructor information and environment
 
@@ -529,20 +537,22 @@ specRow k pats (p : rest) =
       | otherwise -> Nothing
     PVar _ -> Just (pats ++ rest)
     PLit _ -> Nothing
+    PExp _ -> Nothing
     _ -> error "PANIC! Found wildcard in specRow"
 
-specializeLit :: Literal -> PatternMatrix -> PatternMatrix
-specializeLit lit = mapMaybe specLitRow
+specializeAtomic :: AtomicPat -> PatternMatrix -> PatternMatrix
+specializeAtomic ap = mapMaybe specAtomicRow
   where
-    specLitRow [] = Nothing
-    specLitRow (p : rest) =
+    specAtomicRow [] = Nothing
+    specAtomicRow (p : rest) =
       case p of
-        PLit l
-          | l == lit -> Just rest
-          | otherwise -> Nothing
+        PLit l | Left l == ap -> Just rest
+        PLit _ -> Nothing
+        PExp e | Right e == ap -> Just rest
+        PExp _ -> Nothing
         PVar _ -> Just rest
         PCon _ _ -> Nothing
-        _ -> error "PANIC! Found wildcard in specializeLit"
+        _ -> error "PANIC! Found wildcard in specializeAtomic"
 
 -- matrix definitions
 
@@ -555,6 +565,7 @@ defaultMatrix = concatMap defaultRow
         PVar _ -> [rest]
         PCon _ _ -> []
         PLit _ -> []
+        PExp _ -> []
         _ -> error "PANIC! Found wildcard in defaultMatrix"
 
 specializedBoundActs :: Id -> Occurrence -> PatternMatrix -> [BoundAction] -> [BoundAction]
@@ -569,6 +580,7 @@ specializedBoundActs k testOcc rows bacts =
       PCon k' _ -> idName k' == idName k
       PVar _ -> True
       PLit _ -> False
+      PExp _ -> False
       PWildcard -> error "PANIC! Found wildcard in specializedBoundActs"
     addVarBinding (PVar v : _) binds = binds ++ [(v, testOcc)]
     addVarBinding _ binds = binds
@@ -585,16 +597,17 @@ defaultBoundActs testOcc rows bacts =
     addVarBinding (PVar v : _) binds = binds ++ [(v, testOcc)]
     addVarBinding _ binds = binds
 
-litSpecializedBoundActs :: Literal -> Occurrence -> PatternMatrix -> [BoundAction] -> [BoundAction]
-litSpecializedBoundActs lit testOcc rows bacts =
+atomicSpecializedBoundActs :: AtomicPat -> Occurrence -> PatternMatrix -> [BoundAction] -> [BoundAction]
+atomicSpecializedBoundActs ap testOcc rows bacts =
   [ (addVarBinding row binds, a)
     | (row, (binds, a)) <- zip rows bacts,
-      rowMatchesLit row
+      rowMatchesAtomic row
   ]
   where
-    rowMatchesLit [] = False
-    rowMatchesLit (p : _) = case p of
-      PLit l -> l == lit
+    rowMatchesAtomic [] = False
+    rowMatchesAtomic (p : _) = case p of
+      PLit l -> Left l == ap
+      PExp e -> Right e == ap
       PVar _ -> True
       _ -> False
     addVarBinding (PVar v : _) binds = binds ++ [(v, testOcc)]
@@ -662,9 +675,10 @@ patHeadCon :: Pattern -> Maybe Id
 patHeadCon (PCon k _) = Just k
 patHeadCon _ = Nothing
 
-patHeadLit :: Pattern -> Maybe Literal
-patHeadLit (PLit l) = Just l
-patHeadLit _ = Nothing
+patHeadAtomic :: Pattern -> Maybe AtomicPat
+patHeadAtomic (PLit l) = Just (Left l)
+patHeadAtomic (PExp e) = Just (Right e)
+patHeadAtomic _ = Nothing
 
 -- redundancy checking (pre-pass over the original matrix)
 
@@ -692,7 +706,9 @@ isUseful tys matrix (q1 : qRest) =
       specMat <- specialize k fieldTys matrix
       isUseful (fieldTys ++ drop 1 tys) specMat (ps ++ qRest)
     PLit l ->
-      isUseful (drop 1 tys) (specializeLit l matrix) qRest
+      isUseful (drop 1 tys) (specializeAtomic (Left l) matrix) qRest
+    PExp _ ->
+      pure True -- conservative: expression labels are always considered useful
     PVar _ ->
       case tys of
         [] -> pure False
@@ -718,10 +734,10 @@ inhabitsM _ [] = pure Nothing
 inhabitsM matrix (ty : restTys) = do
   let firstCol = [p | (p : _) <- matrix]
       headCons = nub (mapMaybe patHeadCon firstCol)
-      headLits = nub (mapMaybe patHeadLit firstCol)
-  case (headCons, headLits) of
+      headAtomics = nub (mapMaybe patHeadAtomic firstCol)
+  case (headCons, headAtomics) of
     (cs@(_ : _), _) -> inhabitsConCol matrix ty restTys cs
-    ([], _ : _) -> inhabitsLitCol matrix ty restTys
+    ([], _ : _) -> inhabitsAtomCol matrix ty restTys
     ([], []) -> do
       r <- inhabitsM (defaultMatrix matrix) restTys
       case r of
@@ -764,8 +780,8 @@ inhabitsConCol matrix _ty restTys headCons =
           let (fieldWit, restWit) = splitAt (length fieldTys) wit
           pure (Just (PCon k fieldWit : restWit))
 
-inhabitsLitCol :: PatternMatrix -> Ty -> [Ty] -> CompilerM (Maybe [Pattern])
-inhabitsLitCol matrix ty restTys = do
+inhabitsAtomCol :: PatternMatrix -> Ty -> [Ty] -> CompilerM (Maybe [Pattern])
+inhabitsAtomCol matrix ty restTys = do
   r <- inhabitsM (defaultMatrix matrix) restTys
   case r of
     Nothing -> pure Nothing

--- a/src/Solcore/Desugarer/IfDesugarer.hs
+++ b/src/Solcore/Desugarer/IfDesugarer.hs
@@ -57,6 +57,7 @@ desugarBoolPat (PCon c@(Id n _) ps)
 desugarBoolPat (PVar a) = PVar a
 desugarBoolPat PWildcard = PWildcard
 desugarBoolPat (PLit l) = PLit l
+desugarBoolPat (PExp e) = PExp e
 
 -- desugaring the boolean type constructor
 

--- a/src/Solcore/Frontend/ComptimeCheck.hs
+++ b/src/Solcore/Frontend/ComptimeCheck.hs
@@ -1,0 +1,259 @@
+module Solcore.Frontend.ComptimeCheck (checkComptimeEarly) where
+
+{- SAIL-level comptime verification pass.
+   Runs on CompUnit Id immediately after type checking.
+
+   Classification uses three states:
+     CTComptime  — definitely comptime: literal, comptime-bound variable, or
+                   a call to a function annotated '-> comptime' with all
+                   comptime-param arguments classified as CTComptime.
+     CTRuntime   — definitely not comptime: a variable bound by a non-comptime
+                   function parameter.
+     CTDeferred  — uncertain: call results where the function has no comptime
+                   return annotation, or unannotated let bindings.
+                   These are passed to the MAST-level verifier.
+
+   Errors are reported only for CTRuntime violations:
+     - A parameter annotated 'comptime' receives a CTRuntime argument.
+     - A 'let x : comptime T = e' binding where e classifies as CTRuntime.
+
+   CTDeferred values are never rejected here; the MAST-level pass handles them.
+-}
+
+import Data.Map qualified as Map
+import Solcore.Frontend.Syntax.Contract
+import Solcore.Frontend.Syntax.Name (Name)
+import Solcore.Frontend.Syntax.Stmt
+import Solcore.Frontend.Syntax.Ty (Ty (..))
+import Solcore.Frontend.TypeInference.Id (Id (..))
+
+-----------------------------------------------------------------------
+-- Comptime-ness classification
+-----------------------------------------------------------------------
+
+data Ctness = CTComptime | CTRuntime | CTDeferred
+  deriving (Eq, Show)
+
+-----------------------------------------------------------------------
+-- Signature table: Name -> Signature Id
+-----------------------------------------------------------------------
+
+type SigTable = Map.Map Name (Signature Id)
+
+buildSigTable :: CompUnit Id -> SigTable
+buildSigTable (CompUnit _ topDecls) = Map.fromList $ concatMap fromTopDecl topDecls
+  where
+    fromTopDecl (TFunDef fd) = [(sigName (funSignature fd), funSignature fd)]
+    fromTopDecl (TContr c) = concatMap fromContrDecl (decls c)
+    fromTopDecl (TClassDef cl) = [(sigName s, s) | s <- signatures cl]
+    fromTopDecl (TInstDef inst) = [(sigName (funSignature fd), funSignature fd) | fd <- instFunctions inst]
+    fromTopDecl _ = []
+
+    fromContrDecl (CFunDecl fd) = [(sigName (funSignature fd), funSignature fd)]
+    fromContrDecl _ = []
+
+-----------------------------------------------------------------------
+-- Comptime environment: variable name -> Ctness
+-----------------------------------------------------------------------
+
+type CtEnv = Map.Map Name Ctness
+
+-----------------------------------------------------------------------
+-- Entry point
+-----------------------------------------------------------------------
+
+-- | Run the early comptime check on a typed compilation unit.
+checkComptimeEarly :: CompUnit Id -> Either String ()
+checkComptimeEarly cu = mapM_ (checkTopDecl st) (contracts cu)
+  where
+    st = buildSigTable cu
+
+checkTopDecl :: SigTable -> TopDecl Id -> Either String ()
+checkTopDecl st (TFunDef fd) = checkFunDef st ctx fd
+  where
+    ctx = "function '" ++ show (sigName (funSignature fd)) ++ "'"
+checkTopDecl st (TContr c) = mapM_ (checkContrDecl st) (decls c)
+checkTopDecl st (TInstDef inst) = mapM_ (checkFunDefInst st inst) (instFunctions inst)
+checkTopDecl _ _ = Right ()
+
+checkContrDecl :: SigTable -> ContractDecl Id -> Either String ()
+checkContrDecl st (CFunDecl fd) = checkFunDef st ctx fd
+  where
+    ctx = "function '" ++ show (sigName (funSignature fd)) ++ "'"
+checkContrDecl _ _ = Right ()
+
+-----------------------------------------------------------------------
+-- Function checking
+-----------------------------------------------------------------------
+
+checkFunDef :: SigTable -> String -> FunDef Id -> Either String ()
+checkFunDef st ctx fd = checkBody st (sigRetComptime sig) ctx initEnv (funDefBody fd)
+  where
+    sig = funSignature fd
+    initEnv =
+      Map.fromList
+        [ (idName (paramName p), if paramComptime p then CTComptime else CTRuntime)
+          | p <- sigParams sig
+        ]
+
+-- | Check an instance method, including the instance head in error context.
+checkFunDefInst :: SigTable -> Instance Id -> FunDef Id -> Either String ()
+checkFunDefInst st inst fd = checkFunDef st ctx fd
+  where
+    ctx =
+      "in instance "
+        ++ tyHeadName (mainTy inst)
+        ++ ":"
+        ++ show (instName inst)
+        ++ ", function '"
+        ++ show (sigName (funSignature fd))
+        ++ "'"
+
+-- | Extract a readable name from a concrete type (e.g. @word@ from @TyCon "word" []@).
+tyHeadName :: Ty -> String
+tyHeadName (TyCon n _) = show n
+tyHeadName t = show t
+
+checkBody :: SigTable -> Bool -> String -> CtEnv -> Body Id -> Either String ()
+checkBody _ _ _ _ [] = Right ()
+checkBody st retCt ctx env (s : ss) = do
+  env' <- checkStmt st retCt ctx env s
+  checkBody st retCt ctx env' ss
+
+checkStmt :: SigTable -> Bool -> String -> CtEnv -> Stmt Id -> Either String CtEnv
+checkStmt st retCt ctx env stmt = case stmt of
+  Let ct x _ mInit -> do
+    case mInit of
+      Nothing -> return env
+      Just e -> do
+        checkExp st env e
+        let ct' = classifyExp st env e
+        when_ (ct && ct' == CTRuntime) $
+          "comptime let '"
+            ++ show (idName x)
+            ++ "' is bound to a runtime expression"
+        return $ Map.insert (idName x) (letCtness ct ct') env
+  (_ := e) -> checkExp st env e >> return env
+  StmtExp e -> checkExp st env e >> return env
+  Return e -> do
+    checkExp st env e
+    when_ (retCt && classifyExp st env e == CTRuntime) $
+      ctx ++ ": function annotated '-> comptime' returns a runtime expression"
+    return env
+  Match es eqs -> do
+    mapM_ (checkExp st env) es
+    mapM_ (checkEq st retCt ctx env) eqs
+    return env
+  If cond t f -> do
+    checkExp st env cond
+    checkBody st retCt ctx env t
+    checkBody st retCt ctx env f
+    return env
+  Asm _ -> return env
+
+-- | Decide the Ctness to assign to a let-bound variable.
+--   If declared comptime, treat as CTComptime (Stage 1 verifies the RHS).
+--   Otherwise, inherit the classification of the init expression.
+letCtness :: Bool -> Ctness -> Ctness
+letCtness True _ = CTComptime
+letCtness False ct' = ct'
+
+checkEq :: SigTable -> Bool -> String -> CtEnv -> ([Pat Id], Body Id) -> Either String ()
+checkEq st retCt ctx env (_, body) = checkBody st retCt ctx env body
+
+-----------------------------------------------------------------------
+-- Expression checking: recurse and enforce comptime-param constraints
+-----------------------------------------------------------------------
+
+checkExp :: SigTable -> CtEnv -> Exp Id -> Either String ()
+checkExp st env (Call _ f args) = do
+  checkCallSite st env f args
+  mapM_ (checkExp st env) args
+checkExp st env (Con _ args) = mapM_ (checkExp st env) args
+checkExp st env (Cond c t e) = mapM_ (checkExp st env) [c, t, e]
+checkExp st env (TyExp e _) = checkExp st env e
+checkExp st env (Lam ps body _) = checkBody st False "lambda" lamEnv body
+  where
+    lamEnv =
+      Map.fromList
+        [(idName (paramName p), if paramComptime p then CTComptime else CTRuntime) | p <- ps]
+        `Map.union` env
+checkExp _ _ _ = Right ()
+
+-- | Verify that each comptime-annotated parameter receives a non-Runtime arg.
+--   Skips polymorphic signatures (those whose comptime parameter types contain
+--   type variables): the concrete types are only known after specialisation,
+--   so polymorphic calls are deferred to the MAST-level check.
+checkCallSite :: SigTable -> CtEnv -> Id -> [Exp Id] -> Either String ()
+checkCallSite st env f args =
+  case Map.lookup (idName f) st of
+    Nothing -> Right ()
+    Just sig
+      | any (hasTypeVar . paramTy) (filter paramComptime (sigParams sig)) ->
+          Right () -- polymorphic comptime param — defer to MAST-level check
+      | otherwise ->
+          mapM_ checkArg (zip (sigParams sig) args)
+  where
+    checkArg (param, arg) =
+      when_ (paramComptime param && classifyExp st env arg == CTRuntime) $
+        "runtime value passed to comptime parameter '"
+          ++ show (idName (paramName param))
+          ++ "' of '"
+          ++ show (idName f)
+          ++ "'"
+    paramTy (Typed _ _ ty) = ty
+    paramTy (Untyped _ _) = TyCon (error "paramTy: Untyped") []
+
+-- | True if the type contains any type variable or meta variable.
+hasTypeVar :: Ty -> Bool
+hasTypeVar (TyVar _) = True
+hasTypeVar (Meta _) = True
+hasTypeVar (TyCon _ ts) = any hasTypeVar ts
+
+-----------------------------------------------------------------------
+-- Expression classification
+-----------------------------------------------------------------------
+
+classifyExp :: SigTable -> CtEnv -> Exp Id -> Ctness
+classifyExp _ _ (Lit _) = CTComptime
+classifyExp _ env (Var x) = Map.findWithDefault CTDeferred (idName x) env
+classifyExp st env (TyExp e _) = classifyExp st env e
+classifyExp st env (Call _ f args) = classifyCall st env f args
+classifyExp st env (Con _ args) = combineCt (map (classifyExp st env) args)
+classifyExp st env (Cond c t e) = combineCt (map (classifyExp st env) [c, t, e])
+classifyExp _ _ _ = CTDeferred
+
+-- | Combine a list of Ctness values: all Comptime → Comptime;
+--   any Runtime → Runtime; otherwise Deferred.
+combineCt :: [Ctness] -> Ctness
+combineCt cts
+  | all (== CTComptime) cts = CTComptime
+  | any (== CTRuntime) cts = CTRuntime
+  | otherwise = CTDeferred
+
+-- | Classify a function call result.
+--   CTComptime iff the function is annotated '-> comptime' and every
+--   argument to a comptime-annotated parameter is CTComptime.
+--   Never CTRuntime for calls — uncertain cases are deferred to Stage 1.
+classifyCall :: SigTable -> CtEnv -> Id -> [Exp Id] -> Ctness
+classifyCall st env f args =
+  case Map.lookup (idName f) st of
+    Nothing -> CTDeferred
+    Just sig
+      | sigRetComptime sig && allCtParamsAreComptime sig ->
+          CTComptime
+      | otherwise ->
+          CTDeferred
+  where
+    allCtParamsAreComptime sig =
+      all
+        (\(param, arg) -> not (paramComptime param) || classifyExp st env arg == CTComptime)
+        (zip (sigParams sig) args)
+
+-----------------------------------------------------------------------
+-- Helper
+-----------------------------------------------------------------------
+
+when_ :: Bool -> String -> Either String ()
+when_ True msg = Left msg
+when_ False _ = Right ()

--- a/src/Solcore/Frontend/ComptimeCheck.hs
+++ b/src/Solcore/Frontend/ComptimeCheck.hs
@@ -90,9 +90,12 @@ checkFunDef :: SigTable -> String -> FunDef Id -> Either String ()
 checkFunDef st ctx fd = checkBody st (sigRetComptime sig) ctx initEnv (funDefBody fd)
   where
     sig = funSignature fd
+    -- For '-> comptime' functions, treat ALL params as CTComptime when checking
+    -- the body: this verifies "given comptime args, does the body produce comptime?"
+    -- For other functions, non-comptime params are CTRuntime.
     initEnv =
       Map.fromList
-        [ (idName (paramName p), if paramComptime p then CTComptime else CTRuntime)
+        [ (idName (paramName p), if paramComptime p || sigRetComptime sig then CTComptime else CTRuntime)
           | p <- sigParams sig
         ]
 
@@ -232,23 +235,22 @@ combineCt cts
   | otherwise = CTDeferred
 
 -- | Classify a function call result.
---   CTComptime iff the function is annotated '-> comptime' and every
---   argument to a comptime-annotated parameter is CTComptime.
---   Never CTRuntime for calls — uncertain cases are deferred to Stage 1.
+--   CTComptime iff the function is annotated '-> comptime' and ALL arguments
+--   are CTComptime.  A non-comptime-annotated param in a '-> comptime' function
+--   means "result is comptime when this arg happens to be comptime", so all args
+--   must be checked, not just the comptime-annotated ones.
+--   Never CTRuntime for calls — uncertain cases are deferred to MAST.
 classifyCall :: SigTable -> CtEnv -> Id -> [Exp Id] -> Ctness
 classifyCall st env f args =
   case Map.lookup (idName f) st of
     Nothing -> CTDeferred
     Just sig
-      | sigRetComptime sig && allCtParamsAreComptime sig ->
+      | sigRetComptime sig && allArgsComptime ->
           CTComptime
       | otherwise ->
           CTDeferred
   where
-    allCtParamsAreComptime sig =
-      all
-        (\(param, arg) -> not (paramComptime param) || classifyExp st env arg == CTComptime)
-        (zip (sigParams sig) args)
+    allArgsComptime = all (\arg -> classifyExp st env arg == CTComptime) args
 
 -----------------------------------------------------------------------
 -- Helper

--- a/src/Solcore/Frontend/Parser/SolcoreParser.y
+++ b/src/Solcore/Frontend/Parser/SolcoreParser.y
@@ -384,6 +384,7 @@ Pattern :: { Pat }
 Pattern : Name PatternList                         {Pat $1 $2}
         | '_'                                      {PWildcard}
         | Literal                                  {PLit $1}
+        | 'comptime' Expr                          {PExp $2}
         | '(' Pattern ')'                          {$2}
         | PatternList                              {Pat (Name "pair") $1}
 

--- a/src/Solcore/Frontend/Pretty/SolcorePretty.hs
+++ b/src/Solcore/Frontend/Pretty/SolcorePretty.hs
@@ -318,6 +318,8 @@ instance (Pretty a) => Pretty (Pat a) where
     text "_"
   ppr (PLit l) =
     ppr l
+  ppr (PExp e) =
+    text "comptime" <+> ppr e
 
 instance Pretty Literal where
   ppr (IntLit l) = integer (toInteger l)

--- a/src/Solcore/Frontend/Pretty/TreePretty.hs
+++ b/src/Solcore/Frontend/Pretty/TreePretty.hs
@@ -330,6 +330,8 @@ instance Pretty Pat where
     text "_"
   ppr (PLit l) =
     ppr l
+  ppr (PExp e) =
+    text "comptime" <+> ppr e
 
 instance Pretty Literal where
   ppr (IntLit l) = integer (toInteger l)

--- a/src/Solcore/Frontend/Syntax/NameResolution.hs
+++ b/src/Solcore/Frontend/Syntax/NameResolution.hs
@@ -255,6 +255,7 @@ instance Resolve S.Pat where
 
   resolve S.PWildcard = pure PWildcard
   resolve (S.PLit l) = PLit <$> resolve l
+  resolve (S.PExp e) = PExp <$> resolve e
   resolve p@(S.Pat n ps) =
     do
       ps' <- resolve ps `wrapError` p

--- a/src/Solcore/Frontend/Syntax/Stmt.hs
+++ b/src/Solcore/Frontend/Syntax/Stmt.hs
@@ -31,6 +31,10 @@ paramName :: Param a -> a
 paramName (Typed _ n _) = n
 paramName (Untyped _ n) = n
 
+paramComptime :: Param a -> Bool
+paramComptime (Typed ct _ _) = ct
+paramComptime (Untyped ct _) = ct
+
 -- definition of the expression syntax
 
 data Exp a

--- a/src/Solcore/Frontend/Syntax/Stmt.hs
+++ b/src/Solcore/Frontend/Syntax/Stmt.hs
@@ -52,6 +52,7 @@ data Pat a
   | PCon a [Pat a]
   | PWildcard
   | PLit Literal
+  | PExp (Exp a) -- comptime expression label (numeric matches only)
   deriving (Eq, Ord, Show, Data, Typeable)
 
 -- definition of literals

--- a/src/Solcore/Frontend/Syntax/SyntaxTree.hs
+++ b/src/Solcore/Frontend/Syntax/SyntaxTree.hs
@@ -240,6 +240,7 @@ data Pat
   = Pat Name [Pat]
   | PWildcard
   | PLit Literal
+  | PExp Exp -- comptime expression label (numeric matches only)
   deriving (Eq, Ord, Show, Data, Typeable)
 
 -- definition of literals

--- a/src/Solcore/Frontend/TypeInference/Erase.hs
+++ b/src/Solcore/Frontend/TypeInference/Erase.hs
@@ -98,3 +98,5 @@ instance Erase (Pat Id) where
     PWildcard
   erase (PLit l) =
     PLit l
+  erase (PExp e) =
+    PExp (erase e)

--- a/src/Solcore/Frontend/TypeInference/TcMonad.hs
+++ b/src/Solcore/Frontend/TypeInference/TcMonad.hs
@@ -15,6 +15,7 @@ import Solcore.Frontend.TypeInference.TcEnv
 import Solcore.Frontend.TypeInference.TcSubst
 import Solcore.Frontend.TypeInference.TcUnify
 import Solcore.Pipeline.Options (Option (..))
+import Solcore.Primitives.Primitives (word)
 import System.TimeIt qualified as TimeIt
 import Text.Printf
 
@@ -78,6 +79,22 @@ isUniqueTyName :: Name -> TcM Bool
 isUniqueTyName n = do
   uenv <- gets uniqueTypes
   pure $ any (\d -> dataName d == n) (Map.elems uenv)
+
+-- A type is numeric if it is 'word', or if it is an algebraic type with
+-- exactly one constructor that takes exactly one argument of type 'word'.
+-- Examples: word, uint256 (= data uint256 = uint256(word))
+-- Non-examples: bool, mw (= data mw = N | J(word))
+isNumericTy :: Ty -> TcM Bool
+isNumericTy ty
+  | ty == word = pure True
+  | TyCon n [] <- ty = do
+      mti <- maybeAskTypeInfo n
+      case mti of
+        Just (TypeInfo _ [con] _) -> do
+          (Constr _ fields, _) <- constrsFromEnv con
+          pure (fields == [word])
+        _ -> pure False
+  | otherwise = pure False
 
 typeInfoFor :: DataTy -> TypeInfo
 typeInfoFor (DataTy _ vs cons) =

--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -175,6 +175,18 @@ tcPat t' (PLit l) =
     t <- tcLit l
     s <- unify t t'
     pure (PLit l, apply s t, [])
+tcPat t' (PExp e) =
+  do
+    (e', _ps, t) <- tcExp e
+    -- _ps (predicates) are discarded: comptime expression labels have concrete
+    -- numeric types resolved by unification with the scrutinee, so constraints
+    -- are solved implicitly. A fuller implementation would thread _ps upward.
+    s <- unify t t'
+    numericOk <- isNumericTy (apply s t)
+    unless numericOk $
+      tcmError $
+        "expression match label must have a numeric type, got: " ++ pretty (apply s t)
+    withCurrentSubst (PExp (apply s e'), apply s t, [])
 
 -- type inference for expressions
 

--- a/src/Solcore/Pipeline/SolcorePipeline.hs
+++ b/src/Solcore/Pipeline/SolcorePipeline.hs
@@ -20,6 +20,7 @@ import Solcore.Desugarer.IfDesugarer (ifDesugarer)
 import Solcore.Desugarer.IndirectCall (indirectCall)
 import Solcore.Desugarer.ReplaceFunTypeArgs
 import Solcore.Desugarer.ReplaceWildcard (replaceWildcard)
+import Solcore.Frontend.ComptimeCheck (checkComptimeEarly)
 import Solcore.Frontend.Parser.SolcoreParser
 import Solcore.Frontend.Pretty.SolcorePretty
 import Solcore.Frontend.Syntax hiding (contracts)
@@ -148,6 +149,9 @@ compile opts = runExceptT $ do
     mapM_ putStrLn (reverse $ logs tcEnv)
     putStrLn "> Elaborated tree:"
     putStrLn $ pretty typed
+
+  -- SAIL-level comptime verification
+  ExceptT $ return $ checkComptimeEarly typed
 
   -- If / boolean desugaring
   desugared <-

--- a/src/Solcore/Pipeline/SolcorePipeline.hs
+++ b/src/Solcore/Pipeline/SolcorePipeline.hs
@@ -8,6 +8,7 @@ import Data.Time qualified as Time
 import Language.Hull qualified as Hull
 -- Pretty instances for MastCompUnit
 
+import Solcore.Backend.ComptimeCheck (checkComptime)
 import Solcore.Backend.EmitHull (emitHull)
 import Solcore.Backend.Mast ()
 import Solcore.Backend.MastEval (defaultFuel, eliminateDeadCode, evalCompUnit)
@@ -203,6 +204,9 @@ compile opts = runExceptT $ do
       liftIO $ when (optDumpSpec opts) $ do
         putStrLn "> After dead code elimination:"
         putStrLn (pretty optimized)
+
+      -- Comptime verification: check comptime annotations are satisfied
+      ExceptT $ return $ checkComptime optimized
 
       hull <-
         liftIO $

--- a/std/std.solc
+++ b/std/std.solc
@@ -284,13 +284,17 @@ instance word:Sub {
     }
 }
 
+function mulWord(l: word, r: word) -> word {
+    let rw : word;
+    assembly {
+        rw := mul(l,r);
+    }
+    return rw;
+}
+
 instance word:Mul {
     function mul(l: word, r: word) -> word {
-        let rw : word;
-        assembly {
-            rw := mul(l,r);
-        }
-        return rw;
+        return mulWord(l, r);
     }
 }
 

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -32,7 +32,17 @@ comptime =
       runTestForFile "string-lit-ops.solc" comptimeFolder,
       runTestForFile "string-lit-len.solc" comptimeFolder,
       runTestForFile "string-lit-keccak.solc" comptimeFolder,
-      runTestForFile "comptime_syntax.solc" comptimeFolder
+      runTestForFile "comptime_syntax.solc" comptimeFolder,
+      -- comptime verification: positive cases (must compile)
+      runTestForFile "ct_param_ok.solc" comptimeFolder,
+      runTestForFile "ct_chain_ok.solc" comptimeFolder,
+      runTestForFile "ct_let_ok.solc" comptimeFolder,
+      runTestForFile "ct_overloaded_ok.solc" comptimeFolder,
+      -- comptime verification: negative cases (must be rejected)
+      runTestExpectingFailure "ct_runtime_arg.solc" comptimeFolder,
+      runTestExpectingFailure "ct_let_runtime.solc" comptimeFolder,
+      runTestExpectingFailure "ct_asm_ret.solc" comptimeFolder,
+      runTestExpectingFailure "ct_overloaded_bad.solc" comptimeFolder
     ]
   where
     comptimeFolder = "./test/examples/comptime"

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -38,6 +38,9 @@ comptime =
       runTestForFile "ct_chain_ok.solc" comptimeFolder,
       runTestForFile "ct_let_ok.solc" comptimeFolder,
       runTestForFile "ct_overloaded_ok.solc" comptimeFolder,
+      runTestForFile "fib.solc" comptimeFolder,
+      runTestForFile "fib2.solc" comptimeFolder,
+      runTestForFile "fib3.solc" comptimeFolder,
       -- comptime verification: negative cases (must be rejected)
       runTestExpectingFailure "ct_param_runtime.solc" comptimeFolder,
       runTestExpectingFailure "ct_param_poly_runtime.solc" comptimeFolder,

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -39,6 +39,8 @@ comptime =
       runTestForFile "ct_let_ok.solc" comptimeFolder,
       runTestForFile "ct_overloaded_ok.solc" comptimeFolder,
       -- comptime verification: negative cases (must be rejected)
+      runTestExpectingFailure "ct_param_runtime.solc" comptimeFolder,
+      runTestExpectingFailure "ct_param_poly_runtime.solc" comptimeFolder,
       runTestExpectingFailure "ct_runtime_arg.solc" comptimeFolder,
       runTestExpectingFailure "ct_let_runtime.solc" comptimeFolder,
       runTestExpectingFailure "ct_asm_ret.solc" comptimeFolder,

--- a/test/MatchCompilerTests.hs
+++ b/test/MatchCompilerTests.hs
@@ -2,6 +2,7 @@ module MatchCompilerTests where
 
 import Data.List (sort)
 import Data.Map qualified as Map
+import Data.Maybe (mapMaybe)
 import Solcore.Desugarer.DecisionTreeCompiler
 import Solcore.Frontend.Pretty.SolcorePretty
 import Solcore.Frontend.Syntax
@@ -136,8 +137,8 @@ branchNames bs = sort [nameOf (idName k) | (k, _, _) <- bs]
   where
     nameOf n = pretty n
 
-branchLits :: [(Literal, DecisionTree)] -> [Literal]
-branchLits = map fst
+branchLits :: [(AtomicPat, DecisionTree)] -> [Literal]
+branchLits = mapMaybe (either Just (const Nothing) . fst)
 
 tyBool :: Ty
 tyBool = TyCon (Name "Bool") []
@@ -395,10 +396,10 @@ test_twoColumn_completeCover_noWarnings =
     assertInnerHasNoDefault t =
       assertFailure ("inner subtree should have no default branch, got: " ++ show t)
 
--- 8. Literal patterns with a variable catch-all → LitSwitch with Leaf default, no warnings
+-- 8. Literal patterns with a variable catch-all → AtomicSwitch with Leaf default, no warnings
 test_litPats_withVarDefault_noWarnings :: TestTree
 test_litPats_withVarDefault_noWarnings =
-  testCase "lit patterns with variable fallback -> LitSwitch with Leaf default, no warnings"
+  testCase "lit patterns with variable fallback -> AtomicSwitch with Leaf default, no warnings"
     $ assertRight
       "lit-default"
       ( runMatrix
@@ -410,7 +411,7 @@ test_litPats_withVarDefault_noWarnings =
       )
     $ \tree warns -> do
       case tree of
-        LitSwitch [0] branches (Just (Leaf _ defAct)) -> do
+        AtomicSwitch [0] branches (Just (Leaf _ defAct)) -> do
           assertBool
             "should have literal 0 branch"
             (IntLit 0 `elem` branchLits branches)
@@ -419,15 +420,15 @@ test_litPats_withVarDefault_noWarnings =
             (IntLit 1 `elem` branchLits branches)
           assertEqual "default leaf should be actionC" actionC defAct
           assertBool "should have no warnings:" (null warns)
-        LitSwitch _ _ Nothing ->
+        AtomicSwitch _ _ Nothing ->
           assertFailure "expected a default branch for the variable catch-all"
         _ ->
-          assertFailure ("expected LitSwitch, got: " ++ show tree)
+          assertFailure ("expected AtomicSwitch, got: " ++ show tree)
 
--- 9. Literal patterns without a catch-all → LitSwitch with Fail default + NonExhaustive
+-- 9. Literal patterns without a catch-all → AtomicSwitch with Fail default + NonExhaustive
 test_litPats_noDefault_nonExhaustive :: TestTree
 test_litPats_noDefault_nonExhaustive =
-  testCase "lit patterns without catch-all -> LitSwitch with Fail default and NonExhaustive"
+  testCase "lit patterns without catch-all -> AtomicSwitch with Fail default and NonExhaustive"
     $ assertRight
       "lit-no-default"
       ( runMatrix
@@ -439,7 +440,7 @@ test_litPats_noDefault_nonExhaustive =
       )
     $ \tree warns -> do
       case tree of
-        LitSwitch [0] branches (Just Fail) -> do
+        AtomicSwitch [0] branches (Just Fail) -> do
           assertBool
             "should have literal 0 branch"
             (IntLit 0 `elem` branchLits branches)
@@ -448,7 +449,7 @@ test_litPats_noDefault_nonExhaustive =
             (IntLit 1 `elem` branchLits branches)
           assertBool "should emit NonExhaustive warning" (any isNonExh warns)
         _ ->
-          assertFailure ("expected LitSwitch … (Just Fail), got: " ++ show tree)
+          assertFailure ("expected AtomicSwitch … (Just Fail), got: " ++ show tree)
 
 -- 10. Constructor absent from the TypeEnv → Left error
 test_unknownConstructor_isError :: TestTree

--- a/test/examples/comptime/ct_asm_ret.solc
+++ b/test/examples/comptime/ct_asm_ret.solc
@@ -1,0 +1,17 @@
+/* Negative: function annotated '-> comptime word' but body reads from
+   storage via sload — storage is mutable state, never comptime.
+   The verifier must reject this.
+*/
+
+contract ComptimeAsmRet {
+  function loadFromStorage() -> comptime word {
+    let v : word;
+    assembly {
+      v := sload(0)
+    }
+    return v;
+  }
+  function main() -> word {
+    return loadFromStorage();
+  }
+}

--- a/test/examples/comptime/ct_chain_ok.solc
+++ b/test/examples/comptime/ct_chain_ok.solc
@@ -1,0 +1,16 @@
+/* Positive: comptime result threaded through two comptime functions.
+   increment(20) is comptime, so it can be passed to double's comptime param.
+*/
+import std;
+
+contract ComptimeChainOk {
+  function increment(comptime x : word) -> comptime word {
+    return x + 1;
+  }
+  function double(comptime x : word) -> comptime word {
+    return x + x;
+  }
+  function main() -> word {
+    return double(increment(20));
+  }
+}

--- a/test/examples/comptime/ct_let_ok.solc
+++ b/test/examples/comptime/ct_let_ok.solc
@@ -1,0 +1,12 @@
+/* Positive: comptime let binding fed from a comptime function call. */
+import std;
+
+contract ComptimeLetOk {
+  function double(comptime x : word) -> comptime word {
+    return x + x;
+  }
+  function main() -> word {
+    let y : comptime word = double(21);
+    return y;
+  }
+}

--- a/test/examples/comptime/ct_let_runtime.solc
+++ b/test/examples/comptime/ct_let_runtime.solc
@@ -1,0 +1,21 @@
+/* Negative: comptime let bound to a runtime expression — must fail.
+   sloadWord reads from storage (sload); storage is mutable state,
+   so its result is runtime.  Binding it with 'let y : comptime word'
+   must be rejected by the verifier.
+*/
+import std;
+
+function sloadWord() -> word {
+  let v : word;
+  assembly {
+    v := sload(0)
+  }
+  return v;
+}
+
+contract ComptimeLetRuntime {
+  function main() -> word {
+    let y : comptime word = sloadWord();
+    return y;
+  }
+}

--- a/test/examples/comptime/ct_overloaded_bad.solc
+++ b/test/examples/comptime/ct_overloaded_bad.solc
@@ -1,0 +1,27 @@
+/* Negative: Scale instance whose 'scale' reads from storage — not comptime.
+   Despite the comptime annotations on the method signature, the word
+   instance body uses sload (mutable storage state), making the result
+   a runtime value.  The verifier must reject the comptime let binding.
+*/
+import std;
+
+forall a. class a : Scale {
+  function scale(comptime factor : word, comptime x : a) -> comptime a;
+}
+
+instance word : Scale {
+  function scale(comptime factor : word, comptime x : word) -> comptime word {
+    let base : word;
+    assembly {
+      base := sload(0)
+    }
+    return base + x * factor;
+  }
+}
+
+contract ComptimeOverloadedBad {
+  function main() -> word {
+    let a : comptime word = Scale.scale(3, 10);
+    return a;
+  }
+}

--- a/test/examples/comptime/ct_overloaded_ok.solc
+++ b/test/examples/comptime/ct_overloaded_ok.solc
@@ -1,0 +1,29 @@
+/* Positive: comptime through an overloaded (type class) function.
+   Scale.scale takes a comptime factor; if factor == 1 it returns x
+   unchanged (conditional evaluated at comptime since factor is comptime).
+   mulWord is builtinPure, so multiplication of comptime values is comptime.
+   The verifier must follow specialization and accept this.
+*/
+import std;
+
+forall a. class a : Scale {
+  function scale(comptime factor : word, comptime x : a) -> comptime a;
+}
+
+instance word : Scale {
+  function scale(comptime factor : word, comptime x : word) -> comptime word {
+    if (factor == 1) {
+      return x;
+    } else {
+      return x * factor;
+    }
+  }
+}
+
+contract ComptimeOverloadedOk {
+  function main() -> word {
+    let a : comptime word = Scale.scale(1, 32);
+    let b : comptime word = Scale.scale(3, 10);
+    return a + b;
+  }
+}

--- a/test/examples/comptime/ct_param_ok.solc
+++ b/test/examples/comptime/ct_param_ok.solc
@@ -1,0 +1,14 @@
+/* Positive: literal passed to comptime param.
+   x+x desugars to Add.add(x,x) -> addWord(x,x), which is builtinPure,
+   so the comptime annotation on the result is valid.
+*/
+import std;
+
+contract ComptimeParamOk {
+  function double(comptime x : word) -> comptime word {
+    return x + x;
+  }
+  function main() -> word {
+    return double(21);
+  }
+}

--- a/test/examples/comptime/ct_param_poly_runtime.solc
+++ b/test/examples/comptime/ct_param_poly_runtime.solc
@@ -1,0 +1,27 @@
+/* Negative: comptime violation in a polymorphic (generic) function.
+   Before specialisation the concrete type of 'z' is unknown, so this
+   cannot be resolved by inlining.  The SAIL-level check catches the
+   violation: 'z' is a non-comptime parameter and cannot satisfy the
+   comptime contract of 'unwrap'.
+*/
+import std;
+
+forall t. class t : Wrap {
+  function unwrap(comptime x : t) -> comptime word;
+}
+
+instance word : Wrap {
+  function unwrap(comptime x : word) -> comptime word {
+    return x;
+  }
+}
+
+forall t. t:Wrap => function process(z : t) -> word {
+  return Wrap.unwrap(z);
+}
+
+contract ComptimeParamPolyRuntime {
+  function main() -> word {
+    return process(42);
+  }
+}

--- a/test/examples/comptime/ct_param_runtime.solc
+++ b/test/examples/comptime/ct_param_runtime.solc
@@ -1,0 +1,19 @@
+/* Negative: non-comptime function parameter passed to a comptime parameter.
+   Caught by the SAIL-level check: 'process' CAN be called with an argument
+   not known at compile time, which would violate the comptime requirement
+   of 'double'.  The SAIL check rejects this on the parameter type alone,
+   before looking at specific call sites.
+*/
+import std;
+
+contract ComptimeParamRuntime {
+  function double(comptime x : word) -> comptime word {
+    return x + x;
+  }
+  function process(value : word) -> word {
+    return double(value);
+  }
+  function main() -> word {
+    return process(21);
+  }
+}

--- a/test/examples/comptime/ct_runtime_arg.solc
+++ b/test/examples/comptime/ct_runtime_arg.solc
@@ -1,0 +1,22 @@
+/* Negative: runtime value passed to a comptime parameter — must fail.
+   sloadWord uses sload; storage is mutable state, so its result is
+   a runtime value; passing it to double's comptime param is an error.
+*/
+import std;
+
+function sloadWord() -> word {
+  let v : word;
+  assembly {
+    v := sload(0)
+  }
+  return v;
+}
+
+contract ComptimeRuntimeArg {
+  function double(comptime x : word) -> comptime word {
+    return x + x;
+  }
+  function main() -> word {
+    return double(sloadWord());
+  }
+}

--- a/test/examples/comptime/fib2.solc
+++ b/test/examples/comptime/fib2.solc
@@ -1,0 +1,12 @@
+import std;
+
+function fib2(n : word) -> comptime word {
+   if(n < 2) { return n; } else {return fib2(n-1) + fib2(n-2); }
+}
+
+contract Fib {
+  function main() -> word {
+    let res : comptime word = fib2(10);
+    return res;
+  }
+}

--- a/test/examples/comptime/fib3.solc
+++ b/test/examples/comptime/fib3.solc
@@ -1,0 +1,12 @@
+import std;
+
+function fib3(n : word) -> word {
+   if(n < 2) { return n; } else {return fib3(n-1) + fib3(n-2); }
+}
+
+contract Fib {
+  function main() -> word {
+    let res : comptime word = fib3(10);
+    return res;
+  }
+}

--- a/test/examples/comptime/match_labels.solc
+++ b/test/examples/comptime/match_labels.solc
@@ -1,0 +1,33 @@
+/* Test comptime expression match labels.
+   Covers: comptime literal, comptime arithmetic with a variable,
+   comptime function call, and pattern variable catch-all.
+*/
+
+import std;
+
+forall i.
+class i : Int {
+  function fromWord(x:word) -> comptime i;
+  function toWord(x:i) -> comptime word;
+}
+
+instance uint256 : Int {
+  function fromWord(x:word) -> comptime uint256 { uint256(x) }
+  function toWord(x:uint256) -> comptime word { Typedef.rep(x) }
+}
+
+contract MatchLabels {
+
+  function classify(x : word) -> word {
+    let two : comptime word = 2;
+    match x {
+      | comptime two + 0             => return 2;
+      | comptime toWord(uint256(40)) => return 40;
+      | other                        => return other;
+    }
+  }
+
+  function main() -> word {
+    return classify(0) + classify(2) + classify(40);
+  }
+}


### PR DESCRIPTION
This PR introduces two passes checking `comptime` annotations on parameters, results and let-bound variables (introduced by #343).

The first pass is done on SAIL level, however for polymorphic and overloaded functions sometimes this is at least difficult to decide before specialisation, and  these cases are deferred to MAST-level checker.