### PR TITLE
Include cabal update command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Bug reports and feedback are very welcome.
 # enter a development shell with all required dependencies
 nix develop
 
+# update the package list of hackage.haskell.org
+cabal update
+
 # enter a repl
 cabal repl
 


### PR DESCRIPTION
When I tried following the steps, I had to run `cabal update` before being able to run  `cabal repl`