### PR TITLE
Add ownable contract example and integration test

### DIFF
--- a/run_contests.sh
+++ b/run_contests.sh
@@ -9,3 +9,4 @@ bash ./contest.sh test/examples/dispatch/basic.json
 bash ./contest.sh test/examples/dispatch/neg.json
 bash ./contest.sh test/examples/dispatch/miniERC20.json
 bash ./contest.sh test/examples/dispatch/Revert.json
+bash ./contest.sh test/examples/dispatch/ownable.json

--- a/test/examples/dispatch/ownable.json
+++ b/test/examples/dispatch/ownable.json
@@ -1,0 +1,64 @@
+{
+  "ownable": {
+    "bytecode": "",
+    "contract": "Ownable",
+    "tests": [
+      {
+        "input": {
+          "comment": "constructor()",
+          "calldata": "",
+          "value": "0"
+        },
+        "kind": "constructor"
+      },
+      {
+        "input": {
+          "comment": "getOwner()(uint256) - should return deployer address",
+          "calldata": "893d20e8",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000001212121212121212121212121212120000000012",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "changeOwner(uint256) to 0xdead - should succeed from owner",
+          "calldata": "924c19f7000000000000000000000000000000000000000000000000000000000000dead",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "getOwner()(uint256) - should now return 0xdead",
+          "calldata": "893d20e8",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "000000000000000000000000000000000000000000000000000000000000dead",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "changeOwner(uint256) - should fail, caller is no longer owner",
+          "calldata": "924c19f7000000000000000000000000000000000000000000000000000000000000beef",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "00000000000000000000000000000000000000000000006e6f74206f776e6572",
+          "status": "failure"
+        }
+      }
+    ]
+  }
+}

--- a/test/examples/dispatch/ownable.solc
+++ b/test/examples/dispatch/ownable.solc
@@ -1,6 +1,11 @@
 import std;
 import dispatch;
 
+// caller(), myrevert(), require() are not in the std library yet,
+// so every contract must define its own
+
+// returns uint256 instead of address because the dispatch system
+// requires ABIEncode for function params/returns, and address has no ABIEncode instance yet
 function caller() -> uint256 {
   let res: word;
   assembly {
@@ -18,12 +23,14 @@ function require(cond: bool, msg: word) {
 }
 
 contract Ownable {
+  // stored as uint256 instead of address for the same ABIEncode reason
   owner : uint256;
 
   constructor() {
     owner = caller();
   }
 
+  // named getOwner() instead of owner() to avoid collision with the field name
   function getOwner() -> uint256 {
     return owner;
   }

--- a/test/examples/dispatch/ownable.solc
+++ b/test/examples/dispatch/ownable.solc
@@ -1,0 +1,35 @@
+import std;
+import dispatch;
+
+function caller() -> uint256 {
+  let res: word;
+  assembly {
+     res := caller()
+  }
+  return uint256(res);
+}
+
+function myrevert(msg: word) -> () {
+  assembly { mstore(0, msg) revert(0, 32) }
+}
+
+function require(cond: bool, msg: word) {
+  if (!cond) { myrevert(msg); }
+}
+
+contract Ownable {
+  owner : uint256;
+
+  constructor() {
+    owner = caller();
+  }
+
+  function getOwner() -> uint256 {
+    return owner;
+  }
+
+  function changeOwner(newOwner : uint256) -> () {
+    require(caller() == owner, 0x6e6f74206f776e6572);
+    owner = newOwner;
+  }
+}


### PR DESCRIPTION
Simple contract with owner field, getter, and guarded setter.
Tests cover deployment, reading owner, transferring ownership, and rejection of unauthorized ownership change.
Added test to `run_contests.sh`