### PR TITLE
Update README with Nix usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ recommended to try avoiding Nix.
 
 ```sh
 # enter a development shell with all required dependencies
+# note: do not run git submodule update --init, nix will take care of it
 nix develop
 
 # if prompted, may need to enable a feature: nix --extra-experimental-features "nix-command flakes" develop

--- a/README.md
+++ b/README.md
@@ -135,8 +135,7 @@ The project includes a C++ testrunner that executes end-to-end integration tests
 The testrunner requires cmake and boost, which are available in the `nix develop` shell:
 
 ```bash
-# If the repo was cloned without submodules, initialize JSON dependency:
-git submodule update --init deps/nlohmann_json
+# If the submodule is not initialized, make sure to run nix develop first.
 
 # Build the testrunner binary
 cmake -S . -B build


### PR DESCRIPTION
Added note about not running 'git submodule update --init' as Nix manages dependencies. Running it prior causes a build error.