### PR TITLE
Fixes on yule generation, to avoid wrong renaming of variables.

### DIFF
--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -415,7 +415,8 @@ cases =
       runTestExpectingFailure "overlap-synonym-missed-two-synonyms.solc" caseFolder,
       runTestForFile "copytomem.solc" caseFolder,
       runTestForFile "fresh-variable-shadowing.solc" caseFolder,
-      runTestForFile "simpleDiscount.solc" caseFolder
+      runTestForFile "simpleDiscount.solc" caseFolder,
+      runTestForFile "yul-deposit-example.solc" caseFolder
     ]
   where
     caseFolder = "./test/examples/cases"

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -420,8 +420,8 @@ cases =
       runTestForFile "yul-asm-for-body.solc" caseFolder,
       runTestForFile
         "yul-asm-switch-body.solc"
-        caseFolder
-        runTestForFile
+        caseFolder,
+      runTestForFile
         "multi-stmt-var-leaf.solc"
         caseFolder,
       runTestForFile "simpleDiscount.solc" caseFolder

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -418,8 +418,12 @@ cases =
       runTestForFile "simpleDiscount.solc" caseFolder,
       runTestForFile "yul-deposit-example.solc" caseFolder,
       runTestForFile "yul-asm-for-body.solc" caseFolder,
-      runTestForFile "yul-asm-switch-body.solc" caseFolder
-      runTestForFile "multi-stmt-var-leaf.solc" caseFolder,
+      runTestForFile
+        "yul-asm-switch-body.solc"
+        caseFolder
+        runTestForFile
+        "multi-stmt-var-leaf.solc"
+        caseFolder,
       runTestForFile "simpleDiscount.solc" caseFolder
     ]
   where

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -416,7 +416,9 @@ cases =
       runTestForFile "copytomem.solc" caseFolder,
       runTestForFile "fresh-variable-shadowing.solc" caseFolder,
       runTestForFile "simpleDiscount.solc" caseFolder,
-      runTestForFile "yul-deposit-example.solc" caseFolder
+      runTestForFile "yul-deposit-example.solc" caseFolder,
+      runTestForFile "yul-asm-for-body.solc" caseFolder,
+      runTestForFile "yul-asm-switch-body.solc" caseFolder
     ]
   where
     caseFolder = "./test/examples/cases"

--- a/test/examples/cases/simpleDiscount.solc
+++ b/test/examples/cases/simpleDiscount.solc
@@ -1,7 +1,7 @@
 // test complex match example from the blog post
 // simplified to use word instead of uint256
 
-import std;
+import std.{address, Num, Add, Sub, Div, Bounded, Eq, Ord, Typedef};
 
 data AuctionState =
     NotStarted(word)
@@ -13,14 +13,14 @@ data Phase = Early | Late;
 
 function discount(state : AuctionState, phase : Phase) -> word {
     match state, phase {
-    | Active(bid, _), Early => return bid / 10;
-    | Active(bid, _), Late  => return bid / 20;
+    | .Active(bid, _), .Early => return bid / 10;
+    | .Active(bid, _), .Late  => return bid / 20;
     | _, _                  => return 0;
     }
 }
 
 contract Discount {
   function main() -> word {
-    discount(Active(420,address(0)), Early)
+    discount(.Active(420,.address(0)), .Early)
   }
 }

--- a/test/examples/cases/yul-asm-for-body.solc
+++ b/test/examples/cases/yul-asm-for-body.solc
@@ -1,0 +1,16 @@
+import std.{*};
+
+function yul_asm_for_body() -> () {
+    let result : uint256 = uint256(0);
+    assembly {
+        for { let i := 0 } lt(i, 3) { i := add(i, 1) } {
+            result := callvalue()
+        }
+    }
+}
+
+contract Foo {
+    function main() -> () {
+        yul_asm_for_body()
+    }
+}

--- a/test/examples/cases/yul-asm-switch-body.solc
+++ b/test/examples/cases/yul-asm-switch-body.solc
@@ -1,0 +1,17 @@
+import std.{*};
+
+function yul_asm_switch_body() -> () {
+    let result : uint256 = uint256(0);
+    let flag : word = 1;
+    assembly {
+        switch flag
+        case 0 { result := 0 }
+        default { result := callvalue() }
+    }
+}
+
+contract Foo {
+    function main() -> () {
+        yul_asm_switch_body()
+    }
+}

--- a/test/examples/cases/yul-deposit-example.solc
+++ b/test/examples/cases/yul-deposit-example.solc
@@ -1,0 +1,14 @@
+import std.{*};
+
+function deposit(pubkey: memory(string), withdrawal_credentials: memory(string), signature: memory(string), deposit_data_root: uint256) -> () {
+    let msg_value : uint256 = uint256(0);
+    assembly {
+        msg_value := callvalue()
+    }
+}
+
+contract Foo {
+   function main () -> () {
+      deposit(memory(0), memory(0), memory(0), uint256(2));
+   }
+}

--- a/yule/Translate.hs
+++ b/yule/Translate.hs
@@ -116,12 +116,29 @@ genStmt (SAssembly stmts) = do
     -- this substitution a variable declared as `let msg_value : uint256` (which
     -- gets allocated as `_v0`) would be referenced by its Hull name and be
     -- undeclared in the generated Yul.
+    substAsmStmt env (YBlock body) =
+      YBlock (map (substAsmStmt env) body)
+    substAsmStmt env (YFun name args rets body) =
+      YFun name args rets (map (substAsmStmt env) body)
+    substAsmStmt env (YLet names me) =
+      YLet names (fmap (substAsmExp env) me)
     substAsmStmt env (YAssign lhs e) =
       YAssign (map (substAsmName env) lhs) (substAsmExp env e)
     substAsmStmt env (YExp e) =
       YExp (substAsmExp env e)
     substAsmStmt env (YIf e body) =
       YIf (substAsmExp env e) (map (substAsmStmt env) body)
+    substAsmStmt env (YSwitch e cases mdef) =
+      YSwitch
+        (substAsmExp env e)
+        (map (\(lit, body) -> (lit, map (substAsmStmt env) body)) cases)
+        (fmap (map (substAsmStmt env)) mdef)
+    substAsmStmt env (YFor pre cond post body) =
+      YFor
+        (map (substAsmStmt env) pre)
+        (substAsmExp env cond)
+        (map (substAsmStmt env) post)
+        (map (substAsmStmt env) body)
     substAsmStmt _ s = s
 
     substAsmExp env (YIdent n) = case Map.lookup (show n) env of

--- a/yule/Translate.hs
+++ b/yule/Translate.hs
@@ -4,6 +4,7 @@ module Translate where
 
 import Builtins
 import Common.Pretty
+import Data.Map qualified as Map
 import Data.String
 import GHC.Stack
 import Language.Hull hiding (Name)
@@ -107,7 +108,34 @@ genStmtWithComment s = do
 genStmt :: Stmt -> TM [YulStmt]
 genStmt (SAssembly stmts) = do
   -- debug ["assembly:", render$ ppr (Yul stmts)]
-  pure stmts
+  env <- getVarEnv
+  pure (map (substAsmStmt env) stmts)
+  where
+    -- Substitute Hull variable references in assembly statements with their
+    -- current Yul names.  Assembly blocks are emitted verbatim, so without
+    -- this substitution a variable declared as `let msg_value : uint256` (which
+    -- gets allocated as `_v0`) would be referenced by its Hull name and be
+    -- undeclared in the generated Yul.
+    substAsmStmt env (YAssign lhs e) 
+        = YAssign (map (substAsmName env) lhs) (substAsmExp env e)
+    substAsmStmt env (YExp e) 
+        = YExp (substAsmExp env e)
+    substAsmStmt env (YIf e body)       
+        = YIf (substAsmExp env e) (map (substAsmStmt env) body)
+    substAsmStmt _   s = s
+
+    substAsmExp env (YIdent n) = case Map.lookup (show n) env of
+      Just loc -> case flattenRhs loc of
+        [e'] -> e'
+        _    -> YIdent n  -- multi-slot locations cannot appear in assembly
+      Nothing  -> YIdent n
+    substAsmExp env (YCall f args) = YCall f (map (substAsmExp env) args)
+    substAsmExp _   e              = e
+
+    substAsmName env n = case Map.lookup (show n) env of
+      Just (LocStack i)  -> stkLoc i
+      Just (LocNamed n') -> fromString n'
+      _                  -> n
 genStmt (SAlloc name typ) = allocVar name typ
 genStmt (SAssign name expr) = hullAssign name expr
 genStmt (SReturn expr) = do

--- a/yule/Translate.hs
+++ b/yule/Translate.hs
@@ -116,26 +116,26 @@ genStmt (SAssembly stmts) = do
     -- this substitution a variable declared as `let msg_value : uint256` (which
     -- gets allocated as `_v0`) would be referenced by its Hull name and be
     -- undeclared in the generated Yul.
-    substAsmStmt env (YAssign lhs e) 
-        = YAssign (map (substAsmName env) lhs) (substAsmExp env e)
-    substAsmStmt env (YExp e) 
-        = YExp (substAsmExp env e)
-    substAsmStmt env (YIf e body)       
-        = YIf (substAsmExp env e) (map (substAsmStmt env) body)
-    substAsmStmt _   s = s
+    substAsmStmt env (YAssign lhs e) =
+      YAssign (map (substAsmName env) lhs) (substAsmExp env e)
+    substAsmStmt env (YExp e) =
+      YExp (substAsmExp env e)
+    substAsmStmt env (YIf e body) =
+      YIf (substAsmExp env e) (map (substAsmStmt env) body)
+    substAsmStmt _ s = s
 
     substAsmExp env (YIdent n) = case Map.lookup (show n) env of
       Just loc -> case flattenRhs loc of
         [e'] -> e'
-        _    -> YIdent n  -- multi-slot locations cannot appear in assembly
-      Nothing  -> YIdent n
+        _ -> YIdent n -- multi-slot locations cannot appear in assembly
+      Nothing -> YIdent n
     substAsmExp env (YCall f args) = YCall f (map (substAsmExp env) args)
-    substAsmExp _   e              = e
+    substAsmExp _ e = e
 
     substAsmName env n = case Map.lookup (show n) env of
-      Just (LocStack i)  -> stkLoc i
+      Just (LocStack i) -> stkLoc i
       Just (LocNamed n') -> fromString n'
-      _                  -> n
+      _ -> n
 genStmt (SAlloc name typ) = allocVar name typ
 genStmt (SAssign name expr) = hullAssign name expr
 genStmt (SReturn expr) = do


### PR DESCRIPTION
This PR fixes a problem in the yul code emission. Consider the following snippet: 

```
  function deposit(pubkey: memory(string), withdrawal_credentials: memory(string), signature: memory(string), deposit_data_root: uint256) -> () {
    let msg_value : uint256 = uint256(0);
    assembly {
        msg_value := callvalue()
    }
}
```

The emitted Yul eliminates the definition of `msg_value`:

```
function usr$deposit (pubkey, withdrawal_credentials, signature, deposit_data_root) {
        let _v382
        _v382 := 0
        msg_value := callvalue()
}
```