### PR TITLE
Increase the solver iteration limit

### DIFF
--- a/src/Solcore/Frontend/TypeInference/TcEnv.hs
+++ b/src/Solcore/Frontend/TypeInference/TcEnv.hs
@@ -149,7 +149,7 @@ initTcEnv opts =
       trustedInstanceHeads = [],
       partialDataTypes = Set.empty,
       partialDataTypeConstructors = Map.empty,
-      maxRecursionDepth = 100,
+      maxRecursionDepth = 100000,
       tcOptions = opts
     }
 


### PR DESCRIPTION
Simple increase in solver iteration limit allows the compilation of the deposit contract without issues.