### PR TITLE
Specialise: better diagnostics for unresolved type variables

### DIFF
--- a/src/Solcore/Backend/Specialise.hs
+++ b/src/Solcore/Backend/Specialise.hs
@@ -363,6 +363,19 @@ specCall i args ty = do
   case mres of
     Just (fd, fty, phi) -> do
       debug ["< resolution: ", show name, "~>", shortName fd, " : ", pretty fty, "@", pretty phi]
+      let varToVar = [(v, t) | (v, t) <- unTVSubst phi, isTyVar t]
+      unless (null varToVar) $
+        warns
+          [ "Warning: call to ",
+            show name,
+            " resolved with ungrounded type variable(s): ",
+            prettys (map snd varToVar),
+            "\n  The intermediate type cannot be determined from this call site.",
+            "\n  Expression: ",
+            pretty (Call Nothing i args),
+            "\n  This often occurs when a polymorphic-return function (e.g. `require`)",
+            "\n  is passed directly to a polymorphic-argument function (e.g. `void`)."
+          ]
       extSpSubst phi
       subst <- getSpSubst
       let ty'' = applytv subst fty
@@ -429,14 +442,19 @@ ensureClosed :: (Pretty a) => Ty -> a -> TVSubst -> SM ()
 ensureClosed ty ctxt subst = do
   let tvs = freetv ty
   unless (null tvs) $
-    panics
-      [ "spec(",
+    nopanics
+      [ "Error: cannot specialise ",
         pretty ctxt,
-        "): free type vars in ",
+        "\n",
+        "  Type variable(s) ",
+        prettys tvs,
+        " remain unresolved in type ",
         pretty ty,
-        ": ",
-        show tvs,
-        " @ subst=",
+        "\n",
+        "  This usually means a polymorphic return value is passed to another\n",
+        "  polymorphic function without any concrete type context to resolve\n",
+        "  the intermediate type (e.g. void(require(...))).\n",
+        "  Substitution: ",
         pretty subst
       ]
 
@@ -613,6 +631,10 @@ prettyResolutions = render . brackets . commaSep . map pprRes
 
 -- instance Pretty (Ty, FunDef Id) where
 --  ppr = pprRes
+
+isTyVar :: Ty -> Bool
+isTyVar (TyVar _) = True
+isTyVar _ = False
 
 specmgu :: Ty -> Ty -> Either String TVSubst
 specmgu (TyCon n ts) (TyCon n' ts')

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -1,7 +1,9 @@
 module Cases where
 
+import Control.Exception (try)
 import Solcore.Pipeline.Options
 import Solcore.Pipeline.SolcorePipeline
+import System.Exit (ExitCode (..))
 import System.FilePath
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -290,6 +292,7 @@ cases =
       runTestForFile "Memory2.solc" caseFolder,
       runTestExpectingFailure "missing-instance.solc" caseFolder,
       runTestForFile "modifier.solc" caseFolder,
+      runTestForFile "monomorphic-require.solc" caseFolder,
       runTestForFile "morefun.solc" caseFolder,
       runTestForFile "Mutuals.solc" caseFolder,
       runTestExpectingFailure "nano-desugared.solc" caseFolder,
@@ -309,6 +312,7 @@ cases =
       runTestForFile "Peano.solc" caseFolder,
       runTestForFile "PeanoMatch.solc" caseFolder,
       runTestForFile "polymatch-error.solc" caseFolder,
+      runTestExpectingFailure "polymorphic-require.solc" caseFolder,
       runTestExpectingFailure "pragma_merge_fail_coverage.solc" caseFolder,
       runTestExpectingFailure "pragma_merge_fail_patterson.solc" caseFolder,
       runTestForFile "pragma_merge_base.solc" caseFolder,
@@ -450,7 +454,9 @@ runTestExpectingFailureWith :: Option -> FileName -> BaseFolder -> TestTree
 runTestExpectingFailureWith opts file folder =
   testCase file $ do
     let filePath = folder </> file
-    result <- compile opts {fileName = filePath, optRootDir = folder}
-    case result of
-      Left _ -> return () -- Expected failure
-      Right _ -> assertFailure "Expected compilation to fail, but it succeeded"
+    outcome <- try (compile opts {fileName = filePath, optRootDir = folder})
+    case outcome of
+      Left (ExitFailure _) -> return () -- Expected failure via exitFailure
+      Left ExitSuccess -> assertFailure "Expected compilation to fail, but it exited successfully"
+      Right (Left _) -> return () -- Expected failure via Either
+      Right (Right _) -> assertFailure "Expected compilation to fail, but it succeeded"

--- a/test/examples/cases/monomorphic-require.solc
+++ b/test/examples/cases/monomorphic-require.solc
@@ -1,0 +1,36 @@
+// This should trigger a warning and an error in the specialiser
+// due to unability to resolve result type of require
+import std.{uint256,not,Eq,ne,Proxy,bytes4,string};
+import std.dispatch.{*};
+
+forall a.
+function myrevert(offset:word, length:word) -> a {
+        assembly {
+            revert(offset, length)
+        }
+
+}
+function require(cond: bool) -> () {
+    if (!cond) {
+     myrevert(0,0):();
+    }
+}
+
+function callvalue() -> uint256 {
+    let res : word;
+    assembly {
+        res := callvalue()
+    }
+    return uint256(res);
+}
+
+contract Deposit {
+function deposit() -> () {
+    require(callvalue() != uint256(0));
+    return ();
+  }
+
+function main() -> () {
+  deposit();
+}
+}

--- a/test/examples/cases/polymorphic-require.solc
+++ b/test/examples/cases/polymorphic-require.solc
@@ -1,0 +1,32 @@
+// This should trigger a warning and an error in the specialiser
+// due to unability to resolve result type of require
+import std.{uint256,not,Eq,ne,Proxy,bytes4,string};
+import std.dispatch.{*};
+
+forall a.
+function require(cond: bool) -> a {
+    if (!cond) {
+        assembly {
+            revert(0, 0)
+        }
+    }
+}
+
+function callvalue() -> uint256 {
+    let res : word;
+    assembly {
+        res := callvalue()
+    }
+    return uint256(res);
+}
+
+contract Deposit {
+function deposit() -> () {
+    require(callvalue() != uint256(0));
+    return ();
+  }
+
+function main() -> () {
+  deposit();
+}
+}


### PR DESCRIPTION
This PR introduces better diagnostics in Specialise so that it should not PANIC so much anymore. 
Sadly does not fix problems with unresolved type variables, but should make for better UX.
`test/examples/cases/monomorphic-require.solc` suggests a way of implementing require.