### PR TITLE
Specialise: in StmtExp, ground all type vars to ()

### DIFF
--- a/src/Solcore/Backend/Specialise.hs
+++ b/src/Solcore/Backend/Specialise.hs
@@ -507,7 +507,14 @@ specStmt (Block body) =
   Block <$> specBody body
 specStmt (StmtExp e) = do
   ty <- atCurrentSubst (typeOfTcExp e)
-  e' <- specExp e ty
+  -- replace all type variables with unit - the value is dropped anyway
+
+  let groundTy (TyVar _) = unit
+      groundTy (TyCon n tys) = TyCon n (map groundTy tys)
+      groundTy (a :-> b) = groundTy a :-> groundTy b
+      groundTy t = t
+
+  e' <- specExp e (groundTy ty)
   return $ StmtExp e'
 specStmt (Asm ys) = pure (Asm ys)
 specStmt stmt = errors ["specStmt not implemented for: ", show stmt]

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -312,7 +312,7 @@ cases =
       runTestForFile "Peano.solc" caseFolder,
       runTestForFile "PeanoMatch.solc" caseFolder,
       runTestForFile "polymatch-error.solc" caseFolder,
-      runTestExpectingFailure "polymorphic-require.solc" caseFolder,
+      runTestForFile "polymorphic-require.solc" caseFolder,
       runTestExpectingFailure "pragma_merge_fail_coverage.solc" caseFolder,
       runTestExpectingFailure "pragma_merge_fail_patterson.solc" caseFolder,
       runTestForFile "pragma_merge_base.solc" caseFolder,


### PR DESCRIPTION
If we have an statement consisting of an expression, such as `revert(0,0);` the value of the expression is dropped anyway, so it should be safe to ground all variables in its type to ().

While this does not solve the problem of unresolved variables at specialisation time, at least it should solve problems with `revert` and hence `require`