### PR TITLE
Improve no-warnings ci job performance

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -38,15 +38,4 @@ jobs:
     - uses: cachix/install-nix-action@v31
       with:
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
-    - run: |
-        set -euo pipefail
-        nix develop --command bash -lc '
-          set -euo pipefail
-          cabal update
-          cabal clean
-          cabal test sol-core-tests --ghc-options=-Werror --test-show-details=direct 2>&1 | tee sol-core-tests.log
-          if grep -Eq ": warning: \\[GHC-" sol-core-tests.log; then
-            echo "Unexpected GHC warning output detected in sol-core-tests."
-            exit 1
-          fi
-        '
+    - run: nix build -L .#tests-no-warnings

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,14 @@
             # Contract tests run in checks.contests where evmone/testrunner are provisioned.
             testTargets = [ "sol-core-tests" ];
           });
+        sol-core-tests-no-warnings = pkgs.haskell.lib.overrideCabal sol-core
+          (old: {
+            doHaddock = false;
+            enableLibraryProfiling = false;
+            configureFlags = (old.configureFlags or []) ++ [
+              "--ghc-options=-Werror"
+            ];
+          });
         texlive = pkgs.texlive.combine { inherit (pkgs.texlive) scheme-small thmtools pdfsync lkproof cm-super; };
         evmone-lib = pkgs.callPackage ./nix/evmone.nix { };
 
@@ -58,6 +66,7 @@
         packages.spec = pkgs.callPackage ./spec { solcoreTexlive = texlive; };
         packages.testrunner = testrunner;
         packages.evmone = evmone-lib;
+        packages.tests-no-warnings = sol-core-tests-no-warnings;
         packages.default = packages.sol-core;
 
         apps.sol-core = inputs.flake-utils.lib.mkApp { drv = packages.sol-core; };

--- a/flake.nix
+++ b/flake.nix
@@ -34,8 +34,13 @@
           });
         sol-core-tests-no-warnings = pkgs.haskell.lib.overrideCabal sol-core
           (old: {
+            buildTarget = "test:sol-core-tests";
             doHaddock = false;
             enableLibraryProfiling = false;
+            checkPhase = ''
+              runHook preCheck
+              runHook postCheck
+            '';
             configureFlags = (old.configureFlags or []) ++ [
               "--ghc-options=-Werror"
             ];


### PR DESCRIPTION
This PR improves the no-warnings CI job by avoiding entering the full dev-shell and running the cabal tests.