### PR TITLE
Add `payable` keyword to functions and update dispatch

### DIFF
--- a/run_contests.sh
+++ b/run_contests.sh
@@ -10,3 +10,4 @@ bash ./contest.sh test/examples/dispatch/neg.json
 bash ./contest.sh test/examples/dispatch/miniERC20.json
 bash ./contest.sh test/examples/dispatch/Revert.json
 bash ./contest.sh test/examples/dispatch/ownable.json
+bash ./contest.sh test/examples/dispatch/payable.json

--- a/src/Solcore/Backend/Specialise.hs
+++ b/src/Solcore/Backend/Specialise.hs
@@ -623,7 +623,7 @@ typeOfTcSignature sig = funtype (map typeOfTcParam $ sigParams sig) returnType
       Nothing -> error ("no return type in signature of: " ++ show (sigName sig))
 
 schemeOfTcSignature :: Signature Id -> Scheme
-schemeOfTcSignature sig@(Signature vs ps _n args (Just rt)) =
+schemeOfTcSignature sig@(Signature vs ps _n args (Just rt) _) =
   case mapM getType args of
     Just ts -> Forall vs (ps :=> (funtype ts rt))
     Nothing -> error $ unwords ["Invalid instance member signature:", pretty sig]

--- a/src/Solcore/Desugarer/ContractDispatch.hs
+++ b/src/Solcore/Desugarer/ContractDispatch.hs
@@ -65,7 +65,7 @@ genMainFn addMain (Contract cname tys cdecls)
     cdecls'' = if hasConstructor cdecls then cdecls else cdecls ++ [defaultConstructor]
     cdecls' = Set.unions (map (transformCDecl cname) cdecls'')
     defaultConstructor = CConstrDecl (Constructor {constrParams = [], constrBody = []})
-    mainfn = FunDef (Signature [] [] "main" [] (Just unit)) body
+    mainfn = FunDef (Signature [] [] "main" [] (Just unit) False) body
     body = [StmtExp (Call Nothing (QualName "RunContract" "exec") [cdata])]
     cdata = Con "Contract" [methods, fallback]
     methods = tupleExpFromList (fmap mkMethod (mapMaybe unwrapSigs cdecls))
@@ -78,12 +78,12 @@ genMainFn addMain (Contract cname tys cdecls)
           Var "fallback_default_implementation"
         ]
 
-    mkMethod (Signature _ _ fname fargs (Just ret))
+    mkMethod (Signature _ _ fname fargs (Just ret) payable)
       | all isTyped fargs =
           Con
             "Method"
             [ proxyExp (TyCon (nameTypeName cname fname) []),
-              proxyExp (TyCon "NonPayable" []),
+              proxyExp (TyCon (if payable then "Payable" else "NonPayable") []),
               proxyExp (tupleTyFromList (mapMaybe getTy fargs)),
               proxyExp ret,
               Var fname
@@ -117,7 +117,8 @@ transformConstructor contractName cons
           sigContext = mempty,
           sigName = initFunName,
           sigParams = params,
-          sigReturn = Just unit
+          sigReturn = Just unit,
+          sigPayable = False
         }
 
     copySig =
@@ -126,7 +127,8 @@ transformConstructor contractName cons
           sigContext = mempty,
           sigName = "copy_arguments_for_constructor",
           sigParams = mempty,
-          sigReturn = Just argsTuple
+          sigReturn = Just argsTuple,
+          sigPayable = False
         }
     contractString = show contractName
     yulContractName = YLit $ YulString contractString
@@ -166,7 +168,8 @@ transformConstructor contractName cons
           sigContext = mempty,
           sigName = deployerName,
           sigParams = mempty,
-          sigReturn = Just unit
+          sigReturn = Just unit,
+          sigPayable = False
         }
     startBody =
       [ Asm [yulBlock|{ mstore(64, memoryguard(128)) }|],
@@ -198,7 +201,7 @@ mkNameTy cname fname = DataTy (nameTypeName cname fname) [] []
 mkNameInst :: DataTy -> Name -> Instance Name
 mkNameInst (DataTy dname [] []) fname =
   let nameTy = TyCon dname []
-      sig = Signature [] [] "sigStr" [Typed "p" (proxyTy nameTy)] (Just string)
+      sig = Signature [] [] "sigStr" [Typed "p" (proxyTy nameTy)] (Just string) False
       body = [Return (Lit (StrLit (show fname)))]
    in Instance
         { instDefault = False,

--- a/src/Solcore/Frontend/Lexer/SolcoreLexer.hs
+++ b/src/Solcore/Frontend/Lexer/SolcoreLexer.hs
@@ -59,6 +59,7 @@ reservedWords =
     "assembly",
     "match",
     "function",
+    "payable",
     "constructor",
     "return",
     "lam",

--- a/src/Solcore/Frontend/Module/Loader.hs
+++ b/src/Solcore/Frontend/Module/Loader.hs
@@ -1572,7 +1572,7 @@ stubType n =
 stubFunction :: Name -> FunDef
 stubFunction n =
   FunDef
-    (Signature [] [] n [] Nothing)
+    (Signature [] [] n [] Nothing False)
     []
 
 validationImportedDecls :: ModuleGraph -> (Import, Mod.ModuleId) -> Either String [TopDecl]

--- a/src/Solcore/Frontend/Parser/Decl.hs
+++ b/src/Solcore/Frontend/Parser/Decl.hs
@@ -241,11 +241,12 @@ implicitReturn stmts = stmts
 
 signatureP :: [Ty] -> [Pred] -> Parser Signature
 signatureP vars ctx = do
+  payable <- option False (True <$ keyword "payable")
   keyword "function"
   n <- Name <$> identifier
   ps <- parens (paramP `sepBy` comma)
   ret <- optional (symbol "->" *> typeP)
-  return (Signature vars ctx n ps ret)
+  return (Signature vars ctx n ps ret payable)
 
 -- | One function signature inside a class body.
 -- Commits to requiring ';' once the signature is parsed, so a missing

--- a/src/Solcore/Frontend/Pretty/SolcorePretty.hs
+++ b/src/Solcore/Frontend/Pretty/SolcorePretty.hs
@@ -216,8 +216,9 @@ pprSignatures =
   vcat . map ((<> semi) . ppr)
 
 instance (Pretty a) => Pretty (Signature a) where
-  ppr (Signature vs ctx n ps ty) =
+  ppr (Signature vs ctx n ps ty pay) =
     pprSigPrefix vs ctx
+      <+> (if pay then text "payable" else empty)
       <+> text "function"
       <+> ppr n
       <+> pprParams ps

--- a/src/Solcore/Frontend/Pretty/TreePretty.hs
+++ b/src/Solcore/Frontend/Pretty/TreePretty.hs
@@ -192,8 +192,9 @@ pprSignatures =
   vcat . map ((<> semi) . ppr)
 
 instance Pretty Signature where
-  ppr (Signature vs ctx n ps ty) =
+  ppr (Signature vs ctx n ps ty pay) =
     pprSigPrefix vs ctx
+      <+> (if pay then text "payable" else empty)
       <+> text "function"
       <+> ppr n
       <+> pprParams ps

--- a/src/Solcore/Frontend/Syntax/Contract.hs
+++ b/src/Solcore/Frontend/Syntax/Contract.hs
@@ -164,7 +164,8 @@ data Signature a
     sigContext :: [Pred],
     sigName :: Name,
     sigParams :: [Param a],
-    sigReturn :: Maybe Ty
+    sigReturn :: Maybe Ty,
+    sigPayable :: Bool
   }
   deriving (Eq, Ord, Show, Data, Typeable)
 

--- a/src/Solcore/Frontend/Syntax/NameResolution.hs
+++ b/src/Solcore/Frontend/Syntax/NameResolution.hs
@@ -278,7 +278,7 @@ instance Resolve S.Class where
 instance Resolve S.Signature where
   type Result S.Signature = Signature Name
 
-  resolve s@(S.Signature vs ctx n ps mt) =
+  resolve s@(S.Signature vs ctx n ps mt pay) =
     withLocalCtx $ do
       let ns = map tyconName vs
       mapM_ addTyVar ns
@@ -286,7 +286,7 @@ instance Resolve S.Signature where
       ps' <- resolve ps `wrapError` s
       mt' <- resolve mt `wrapError` s
       let vs' = map TVar ns
-      pure (Signature vs' ctx' n ps' mt')
+      pure (Signature vs' ctx' n ps' mt' pay)
 
 instance Resolve S.Instance where
   type Result S.Instance = Instance Name
@@ -338,7 +338,7 @@ instance Resolve S.PragmaStatus where
 instance Resolve S.FunDef where
   type Result S.FunDef = FunDef Name
 
-  resolve f@(S.FunDef (S.Signature vs ctx n ps mt) bds) =
+  resolve f@(S.FunDef (S.Signature vs ctx n ps mt pay) bds) =
     do
       let ns = map tyconName vs
       withLocalCtx $ do
@@ -350,7 +350,7 @@ instance Resolve S.FunDef where
         mapM_ addParameter args
         bds' <- resolve bds `wrapError` f
         let vs' = map TVar ns
-            sig = Signature vs' ctx' n ps' mt'
+            sig = Signature vs' ctx' n ps' mt' pay
         pure (FunDef sig bds')
 
 instance Resolve S.Stmt where

--- a/src/Solcore/Frontend/Syntax/SyntaxTree.hs
+++ b/src/Solcore/Frontend/Syntax/SyntaxTree.hs
@@ -187,7 +187,8 @@ data Signature
     sigContext :: [Pred],
     sigName :: Name,
     sigParams :: [Param],
-    sigReturn :: Maybe Ty
+    sigReturn :: Maybe Ty,
+    sigPayable :: Bool
   }
   deriving (Eq, Ord, Show, Data, Typeable)
 

--- a/src/Solcore/Frontend/TypeInference/Erase.hs
+++ b/src/Solcore/Frontend/TypeInference/Erase.hs
@@ -37,8 +37,8 @@ instance Erase (FunDef Id) where
 instance Erase (Signature Id) where
   type EraseRes (Signature Id) = Signature Name
 
-  erase (Signature n ps t args rt) =
-    Signature n ps t (erase args) rt
+  erase (Signature n ps t args rt pay) =
+    Signature n ps t (erase args) rt pay
 
 instance Erase (Stmt Id) where
   type EraseRes (Stmt Id) = Stmt Name

--- a/src/Solcore/Frontend/TypeInference/InvokeGen.hs
+++ b/src/Solcore/Frontend/TypeInference/InvokeGen.hs
@@ -60,7 +60,7 @@ createInstance udt fd sch =
     (spvs, svs) <- freshPatData udt
     -- pattern variables for arguments
     (sargs, sarg) <- unzip <$> mapM (const freshPatArg) args'
-    let isig = Signature [] qs invokeName [selfParam, argParam] (Just returnTy)
+    let isig = Signature [] qs invokeName [selfParam, argParam] (Just returnTy) False
         -- building the match of function body
         discr = epair (Var sn) (Var an)
         fname = sigName (funSignature fd)

--- a/src/Solcore/Frontend/TypeInference/SccAnalysis.hs
+++ b/src/Solcore/Frontend/TypeInference/SccAnalysis.hs
@@ -212,7 +212,7 @@ instance Names (Equation Name) where
   names (_, bdy) = names bdy
 
 instance Names (Signature Name) where
-  names (Signature _ ctx _ ps mret) =
+  names (Signature _ ctx _ ps mret _) =
     names ctx `union` names ps `union` names mret
 
 instance Names (FunDef Name) where

--- a/src/Solcore/Frontend/TypeInference/TcContract.hs
+++ b/src/Solcore/Frontend/TypeInference/TcContract.hs
@@ -348,7 +348,7 @@ tcField d@(Field n t _) =
 tcClass :: Class Name -> TcM (Class Id)
 tcClass iclass@(Class bvs classCtx n vs v sigs) =
   do
-    let freeInSig (Signature sv _ _ ps mt) = bv (ps, mt) \\ sv
+    let freeInSig (Signature sv _ _ ps mt _) = bv (ps, mt) \\ sv
         bvs' = bv classCtx `union` bv (map TyVar (v : vs)) `union` concatMap freeInSig sigs
         ns = map sigName sigs
         qs = map (QualName n . pretty) ns
@@ -374,6 +374,7 @@ tcSig (sig, (Forall _ (_ :=> t))) =
           (sigName sig)
           params'
           (Just r)
+          (sigPayable sig)
       )
 
 -- type checking binding groups
@@ -445,7 +446,7 @@ checkClass icls@(Class bvs ps n vs v sigs) =
     addClassInfo n (length vs) ms' ps p
     mapM_ (checkSignature p) sigs
   where
-    checkSignature p sig@(Signature methodVars _ _ params mt) =
+    checkSignature p sig@(Signature methodVars _ _ params mt _) =
       do
         fullSignature sig `wrapError` icls
         _ <- mapM tyParam params
@@ -470,7 +471,7 @@ addClassInfo n ar ms ps p =
       )
 
 addClassMethod :: Pred -> Signature Name -> TcM ()
-addClassMethod p@(InCls c _ _) sig@(Signature _ methodCtx f ps t) =
+addClassMethod p@(InCls c _ _) sig@(Signature _ methodCtx f ps t _) =
   do
     tps <- mapM tyParam ps
     t' <- maybe (pure unit) pure t
@@ -483,7 +484,7 @@ addClassMethod p@(InCls c _ _) sig@(Signature _ methodCtx f ps t) =
     unless (isNothing r) (duplicatedClassMethod f `wrapError` sig)
     extEnv qn sch
     pure ()
-addClassMethod p@(_ :~: _) (Signature _ _ n _ _) =
+addClassMethod p@(_ :~: _) (Signature _ _ n _ _ _) =
   throwError $
     unlines
       [ "Invalid constraint:",
@@ -495,7 +496,7 @@ addClassMethod p@(_ :~: _) (Signature _ _ n _ _) =
 -- error for class definitions
 
 signatureError :: Name -> Tyvar -> Signature Name -> Ty -> TcM ()
-signatureError n v (Signature _ methodCtx f _ _) t
+signatureError n v (Signature _ methodCtx f _ _ _) t
   | null methodCtx =
       throwError $
         unlines

--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -508,7 +508,7 @@ createClosureFun fn freeIds cdt args bdy ps ty =
         (_, retTy1) = splitTy ty
         vs' = union (bv ct) (bv ps0)
         ty' = ct :-> ty
-        sig = Signature vs' ps0 fn args' (Just retTy1)
+        sig = Signature vs' ps0 fn args' (Just retTy1) False
     bdy' <- createClosureBody cName cdt freeIds bdy
     sch <- generalize (ps0, ty')
     pure (everywhere (mkT gen) $ FunDef sig bdy', sch)
@@ -537,7 +537,7 @@ createClosureFreeFun fn args bdy ps ty =
   do
     let (_, retTy1) = splitTy ty
         vs = bv ty `union` bv ps
-        sig = Signature vs ps fn args (Just retTy1)
+        sig = Signature vs ps fn args (Just retTy1) False
     pure (everywhere (mkT gen) $ FunDef sig bdy)
 
 tcArgs :: [Param Name] -> TcM ([Param Id], [(Name, Scheme)], [Ty])
@@ -558,7 +558,7 @@ tcArg a@(Typed n ty) =
     pure (Typed (Id n ty1) ty1, (n, monotype ty1), ty1)
 
 hasAnn :: Signature Name -> Bool
-hasAnn (Signature _ _ _ args rt) =
+hasAnn (Signature _ _ _ args rt _) =
   any isAnn args || isJust rt
   where
     isAnn (Typed _ _) = True
@@ -584,7 +584,7 @@ tiArgs :: [Param Name] -> TcM ([Param Id], [(Name, Scheme)], [Ty])
 tiArgs args = unzip3 <$> mapM tiArg args
 
 tiFunDef :: FunDef Name -> TcM (FunDef Id, Scheme)
-tiFunDef d@(FunDef sig@(Signature _ _ n args _) bd) =
+tiFunDef d@(FunDef sig@(Signature _ _ n args _ _) bd) =
   do
     info ["# tiFunDef:", pretty sig]
     -- getting fresh type variables for arguments
@@ -640,7 +640,7 @@ checkAllTypeVarsBound context used declared =
    in unless (null unbound) $ unboundTypeVars context unbound
 
 annotatedScheme :: [Tyvar] -> [Pred] -> Signature Name -> TcM Scheme
-annotatedScheme vs' qs (Signature vs ps _ args rt) =
+annotatedScheme vs' qs (Signature vs ps _ args rt _) =
   do
     ts <- mapM argumentAnnotation args
     t <- maybe freshTyVar pure rt
@@ -648,7 +648,7 @@ annotatedScheme vs' qs (Signature vs ps _ args rt) =
     pure (Forall vs1 ((qs ++ ps) :=> (funtype ts t)))
 
 tcFunDef :: Bool -> [Tyvar] -> [Pred] -> FunDef Name -> TcM (FunDef Id, Scheme)
-tcFunDef incl vs' qs d@(FunDef sig@(Signature vs ps n _ _) _)
+tcFunDef incl vs' qs d@(FunDef sig@(Signature vs ps n _ _ _) _)
   | hasAnn sig = do
       info ["\n# tcFunDef ", pretty d]
       let vars = vs `union` vs'
@@ -657,7 +657,7 @@ tcFunDef incl vs' qs d@(FunDef sig@(Signature vs ps n _ _) _)
       -- instantiate signatures in function definition
       sks <- mapM (const freshTyVar) vars
       let env = zip vars sks
-          FunDef sig1@(Signature _ ps1 _ args1 rt1) bd1 = everywhere (mkT (insts @Ty env)) d
+          FunDef sig1@(Signature _ ps1 _ args1 rt1 _) bd1 = everywhere (mkT (insts @Ty env)) d
           qs1 = everywhere (mkT (insts @Ty env)) qs
       -- checking if all constraints have a respective class and are well kinded
       checkConstraints ps `wrapError` d
@@ -837,7 +837,7 @@ elabSignature vs1 sig (Forall _ (ps :=> t)) =
         -- formal parameters are present in the signature.
         ret = Just $ if null params' then t else (funtype rs t')
         vs' = bv params' `union` bv ret `union` bv ps
-    sig2 <- withCurrentSubst (Signature (vs' \\ vs1) ps (sigName sig) params' ret)
+    sig2 <- withCurrentSubst (Signature (vs' \\ vs1) ps (sigName sig) params' ret (sigPayable sig))
     pure sig2
 
 elabParam :: Ty -> Param Name -> TcM (Param Id)
@@ -846,7 +846,7 @@ elabParam t (Untyped n) = pure $ Typed (Id n t) t
 
 annotateSignature :: Scheme -> Signature Name -> TcM (Signature Name)
 annotateSignature (Forall vs (ps :=> t)) sig =
-  pure $ Signature vs ps (sigName sig) params' ret
+  pure $ Signature vs ps (sigName sig) params' ret (sigPayable sig)
   where
     (ts, t') = splitTy t
     params' = zipWith annotateParam ts (sigParams sig)
@@ -868,7 +868,7 @@ correctName (Name s) =
       else pure (Name s)
 
 extSignature :: Signature Name -> TcM ()
-extSignature sig@(Signature _ _ n _ _) =
+extSignature sig@(Signature _ _ n _ _ _) =
   do
     te <- gets directCalls
     -- checking if the function is previously defined
@@ -998,7 +998,7 @@ invalidMemberType n cls ins =
       ]
 
 schemeFromSignature :: Signature Id -> TcM Scheme
-schemeFromSignature sig@(Signature vs ps _ args (Just rt)) =
+schemeFromSignature sig@(Signature vs ps _ args (Just rt) _) =
   do
     unless (all isTyped args) $
       throwError $
@@ -1018,8 +1018,8 @@ schemeFromSignature sig =
     unwords ["Invalid instance member signature (missing return type):", pretty sig]
 
 updateSignature :: [Tyvar] -> Name -> FunDef Id -> FunDef Id
-updateSignature vs' c (FunDef (Signature vs ps n args rt) bd) =
-  FunDef (Signature (vs \\ vs') ps (QualName c (pretty n)) args rt) bd
+updateSignature vs' c (FunDef (Signature vs ps n args rt pay) bd) =
+  FunDef (Signature (vs \\ vs') ps (QualName c (pretty n)) args rt pay) bd
 
 checkDeferedConstraints :: [(FunDef Id, [Pred])] -> TcM ()
 checkDeferedConstraints = mapM_ checkDeferedConstraint
@@ -1238,7 +1238,7 @@ requireAnnotations (FunDef sig _) =
         ]
 
 isFullyAnnotated :: Signature Name -> Bool
-isFullyAnnotated (Signature _ _ _ ps rt) =
+isFullyAnnotated (Signature _ _ _ ps rt _) =
   all isTyped ps && isJust rt
   where
     isTyped (Typed _ _) = True

--- a/src/Solcore/Frontend/TypeInference/TcSubst.hs
+++ b/src/Solcore/Frontend/TypeInference/TcSubst.hs
@@ -125,15 +125,15 @@ instance HasType Scheme where
   bv (Forall vs qt) = vs `union` bv qt
 
 instance (HasType a) => HasType (Signature a) where
-  apply s (Signature _ ctx n p r) =
+  apply s (Signature _ ctx n p r pay) =
     let ctx' = apply s ctx
         p' = apply s p
         r' = apply s r
         vs' = bv ctx' `union` bv p' `union` bv r'
-     in Signature vs' ctx' n p' r'
-  fv (Signature vs c _ p r) = fv (c, p, r) \\ vs
-  mv (Signature _ c _ p r) = mv (c, p, r)
-  bv (Signature vs c _ p r) = vs `union` bv (c, p, r)
+     in Signature vs' ctx' n p' r' pay
+  fv (Signature vs c _ p r _) = fv (c, p, r) \\ vs
+  mv (Signature _ c _ p r _) = mv (c, p, r)
+  bv (Signature vs c _ p r _) = vs `union` bv (c, p, r)
 
 instance (HasType a) => HasType (Param a) where
   apply s (Typed i t) = Typed (apply s i) (apply s t)

--- a/src/Solcore/Primitives/Primitives.hs
+++ b/src/Solcore/Primitives/Primitives.hs
@@ -59,6 +59,7 @@ invokeSignature =
       Typed argsName (TyVar argsVar)
     ]
     (Just (TyVar retVar))
+    False
 
 -- basic types
 

--- a/std/dispatch.solc
+++ b/std/dispatch.solc
@@ -97,19 +97,37 @@ forall ty . class ty:ExecMethod {
   function exec(x: ty) -> ();
 }
 
-// If fn matches the provided args/ret types, then we can execute any method
-forall name payability args rets fn
+// If fn matches the provided args/ret types, then we can execute any non-payable method
+forall name args rets fn
   . fn:invokable(args,rets)
   , args:ABIAttribs
   , rets:ABIAttribs
   , ABIDecoder(args,CalldataWordReader):ABIDecode(args)
   , rets:ABIEncode
-  , payability:MethodLevelCallvalueCheck
-=> instance Method(name,payability,args,rets,fn):ExecMethod {
-  function exec(m : Method(name,payability,args,rets,fn)) -> () {
+=> instance Method(name,NonPayable,args,rets,fn):ExecMethod {
+  function exec(m : Method(name,NonPayable,args,rets,fn)) -> () {
     match m {
       | Method(pnm,ppayability,pargs,prets,fn) =>
-        do_exec(ppayability, pargs, prets, fn);
+        // non-payable methods must reject any callvalue before running
+        MethodLevelCallvalueCheck.checkCallvalue(Proxy : Proxy(NonPayable));
+        do_exec(pargs, prets, fn);
+    }
+  }
+}
+
+// If fn matches the provided args/ret types, then we can execute any payable method
+// payable methods skip the callvalue check entirely
+forall name args rets fn
+  . fn:invokable(args,rets)
+  , args:ABIAttribs
+  , rets:ABIAttribs
+  , ABIDecoder(args,CalldataWordReader):ABIDecode(args)
+  , rets:ABIEncode
+=> instance Method(name,Payable,args,rets,fn):ExecMethod {
+  function exec(m : Method(name,Payable,args,rets,fn)) -> () {
+    match m {
+      | Method(pnm,ppayability,pargs,prets,fn) =>
+        do_exec(pargs, prets, fn);
     }
   }
 }
@@ -126,22 +144,19 @@ forall payability args rets fn
   function exec(fb : Fallback(payability,args,rets,fn)) -> () {
     match fb {
       | Fallback(ppayability, pargs, prets, fn) =>
-        do_exec(ppayability, pargs, prets, fn);
+        MethodLevelCallvalueCheck.checkCallvalue(Proxy : Proxy(payability));
+        do_exec(pargs, prets, fn);
     }
   }
 }
 
-forall payability args rets fn
+forall args rets fn
   . fn:invokable(args,rets)
   , args:ABIAttribs
   , rets:ABIAttribs
   , ABIDecoder(args,CalldataWordReader):ABIDecode(args)
   , rets:ABIEncode
-  , payability:MethodLevelCallvalueCheck
-=> function do_exec(ppayability : Proxy(payability), pargs : Proxy(args), prets : Proxy(rets), fn : fn) -> () {
-    // check callvalue
-    MethodLevelCallvalueCheck.checkCallvalue(Proxy : Proxy(payability));
-
+=> function do_exec(pargs : Proxy(args), prets : Proxy(rets), fn : fn) -> () {
     // check we have enough calldata for the head of args
     let hdsz = ABIAttribs.headSize(pargs);
     let cdsz;

--- a/test/ModuleTypeCheckTests.hs
+++ b/test/ModuleTypeCheckTests.hs
@@ -128,5 +128,6 @@ wordSignature funName =
       sigContext = [],
       sigName = Name funName,
       sigParams = [],
-      sigReturn = Just wordTy
+      sigReturn = Just wordTy,
+      sigPayable = False
     }

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -349,7 +349,7 @@ declTests =
           "function answer() -> word { return 42; }"
           ( TFunDef
               ( FunDef
-                  (Signature [] [] "answer" [] (Just word))
+                  (Signature [] [] "answer" [] (Just word) False)
                   [Return (lit 42)]
               )
           ),
@@ -359,7 +359,7 @@ declTests =
           "function id(x:word) -> word { return x; }"
           ( TFunDef
               ( FunDef
-                  (Signature [] [] "id" [Typed "x" word] (Just word))
+                  (Signature [] [] "id" [Typed "x" word] (Just word) False)
                   [Return (var "x")]
               )
           ),
@@ -369,7 +369,7 @@ declTests =
           "function answer() -> word { 42 }"
           ( TFunDef
               ( FunDef
-                  (Signature [] [] "answer" [] (Just word))
+                  (Signature [] [] "answer" [] (Just word) False)
                   [Return (lit 42)]
               )
           ),
@@ -385,6 +385,7 @@ declTests =
                       "id"
                       [Typed "x" (TyCon "a" [])]
                       (Just (TyCon "a" []))
+                      False
                   )
                   [Return (var "x")]
               )
@@ -401,6 +402,7 @@ declTests =
                       "eqSelf"
                       [Typed "x" (TyCon "a" [])]
                       (Just bool)
+                      False
                   )
                   [Return (ExpEE (var "x") (var "x"))]
               )
@@ -459,6 +461,7 @@ declTests =
                       "eq"
                       [Typed "x" (TyCon "a" []), Typed "y" (TyCon "a" [])]
                       (Just bool)
+                      False
                   ]
               )
           ),
@@ -479,6 +482,7 @@ declTests =
                       "cmp"
                       [Typed "x" (TyCon "a" []), Typed "y" (TyCon "a" [])]
                       (Just word)
+                      False
                   ]
               )
           ),
@@ -495,7 +499,7 @@ declTests =
                   []
                   word
                   [ FunDef
-                      (Signature [] [] "eq" [Typed "x" word, Typed "y" word] (Just bool))
+                      (Signature [] [] "eq" [Typed "x" word, Typed "y" word] (Just bool) False)
                       [Return (ExpEE (var "x") (var "y"))]
                   ]
               )
@@ -521,6 +525,7 @@ declTests =
                             Typed "y" (TyCon "pair" [TyCon "a" [], TyCon "a" []])
                           ]
                           (Just bool)
+                          False
                       )
                       [Return (lit 0)]
                   ]
@@ -551,7 +556,7 @@ declTests =
                   []
                   [ CFunDecl
                       ( FunDef
-                          (Signature [] [] "get" [] (Just word))
+                          (Signature [] [] "get" [] (Just word) False)
                           [Return (var "x")]
                       )
                   ]

--- a/test/examples/dispatch/payable.json
+++ b/test/examples/dispatch/payable.json
@@ -1,0 +1,64 @@
+{
+  "payable": {
+    "bytecode": "",
+    "contract": "PayableTest",
+    "tests": [
+      {
+        "input": {
+          "calldata": "",
+          "value": "0"
+        },
+        "kind": "constructor"
+      },
+      {
+        "input": {
+	    "text-calldata": "deposit()(uint256)",
+          "calldata": "d0e30db0",
+          "value": "42"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "000000000000000000000000000000000000000000000000000000000000002a",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+	    "text-calldata": "deposit()(uint256)",
+          "calldata": "d0e30db0",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000000",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+	    "text-calldata": "balance()(uint256)",
+          "calldata": "b69ef8a8",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "000000000000000000000000000000000000000000000000000000000000002a",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+	    "text-calldata": "balance()(uint256)",
+          "calldata": "b69ef8a8",
+          "value": "42"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "b5988ea3",
+          "status": "failure"
+        }
+      }
+
+    ]
+  }
+}

--- a/test/examples/dispatch/payable.solc
+++ b/test/examples/dispatch/payable.solc
@@ -1,0 +1,22 @@
+import std.{*};
+import std.dispatch.{*};
+
+contract PayableTest {
+    constructor() {}
+
+    payable function deposit() -> uint256 {
+        let value;
+        assembly {
+            value := callvalue()
+        }
+        return uint256(value);
+    }
+
+    function balance() -> uint256 {
+        let value;
+        assembly {
+            value := selfbalance()
+        }
+        return uint256(value);
+    }
+}


### PR DESCRIPTION
This allows payable functions to be declared. Dispatch handles both payable and non-payable functions, inserting a call value check.