### PR TITLE
Fix hash for ABIInputTruncated error

### DIFF
--- a/std/dispatch.solc
+++ b/std/dispatch.solc
@@ -149,7 +149,7 @@ forall payability args rets fn
       cdsz := calldatasize()
     }
     if ((cdsz - 4) < hdsz) {
-      let ABIInputTruncated = Error(0x9d11c942);
+      let ABIInputTruncated = Error(0x08638556);
       revertWithError(ABIInputTruncated);
     }
 

--- a/test/examples/dispatch/basic.json
+++ b/test/examples/dispatch/basic.json
@@ -90,7 +90,7 @@
         },
         "kind": "call",
         "output": {
-          "returndata":"9d11c942",
+          "returndata":"08638556",
           "status": "failure"
         }
       },


### PR DESCRIPTION
The hash was calculated wrongly.