### PR TITLE
Add `fallback` keyword for contract-level fallback functions

### DIFF
--- a/run_contests.sh
+++ b/run_contests.sh
@@ -11,3 +11,4 @@ bash ./contest.sh test/examples/dispatch/miniERC20.json
 bash ./contest.sh test/examples/dispatch/Revert.json
 bash ./contest.sh test/examples/dispatch/ownable.json
 bash ./contest.sh test/examples/dispatch/payable.json
+bash ./contest.sh test/examples/dispatch/fallback.json

--- a/src/Solcore/Desugarer/ContractDispatch.hs
+++ b/src/Solcore/Desugarer/ContractDispatch.hs
@@ -15,7 +15,7 @@ module Solcore.Desugarer.ContractDispatch
 where
 
 import Data.List (mapAccumL)
-import Data.Maybe (mapMaybe)
+import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Language.Yul
@@ -42,23 +42,37 @@ hasConstructor = any isConstr
     isConstr (CConstrDecl _) = True
     isConstr _ = False
 
+-- | Special internal name used by the parser for the (optional) `fallback`
+-- function defined inside a contract.
+fallbackName :: Name
+fallbackName = Name "fallback"
+
+isFallback :: FunDef a -> Bool
+isFallback fd = sigName (funSignature fd) == fallbackName
+
 functionNames :: Contract a -> [Name]
 functionNames = foldr go [] . decls
   where
     go (CFunDecl fd) = (sigName (funSignature fd) :)
     go _ = id
 
+-- | Returns the (at most one) user-defined fallback function for a contract.
+findFallback :: Contract a -> Maybe (FunDef a)
+findFallback c = listToMaybe [fd | CFunDecl fd <- decls c, isFallback fd]
+
 genNameDecls :: Contract Name -> Set (TopDecl Name)
 genNameDecls (Contract cname _ cdecls) = foldl go Set.empty cdecls
   where
-    go acc (CFunDecl (FunDef sig _)) =
-      let dataTy = mkNameTy cname (sigName sig)
-          instDef = mkNameInst dataTy (sigName sig)
-       in Set.union (Set.fromList [TDataDef dataTy, TInstDef instDef]) acc
+    go acc (CFunDecl (FunDef sig _))
+      | sigName sig == fallbackName = acc
+      | otherwise =
+          let dataTy = mkNameTy cname (sigName sig)
+              instDef = mkNameInst dataTy (sigName sig)
+           in Set.union (Set.fromList [TDataDef dataTy, TInstDef instDef]) acc
     go acc _ = acc
 
 genMainFn :: Bool -> Contract Name -> Contract Name
-genMainFn addMain (Contract cname tys cdecls)
+genMainFn addMain c@(Contract cname tys cdecls)
   | addMain = Contract cname tys (CFunDecl mainfn : Set.toList cdecls')
   | otherwise = Contract cname tys (Set.toList cdecls')
   where
@@ -69,14 +83,23 @@ genMainFn addMain (Contract cname tys cdecls)
     body = [StmtExp (Call Nothing (QualName "RunContract" "exec") [cdata])]
     cdata = Con "Contract" [methods, fallback]
     methods = tupleExpFromList (fmap mkMethod (mapMaybe unwrapSigs cdecls))
-    fallback =
-      Con
-        "Fallback"
-        [ proxyExp (TyCon "NonPayable" []),
-          proxyExp unit,
-          proxyExp unit,
-          Var "fallback_default_implementation"
-        ]
+    fallback = case findFallback c of
+      Just (FunDef sig _) ->
+        Con
+          "Fallback"
+          [ proxyExp (TyCon (if sigPayable sig then "Payable" else "NonPayable") []),
+            proxyExp (tupleTyFromList (mapMaybe getTy (sigParams sig))),
+            proxyExp (fromMaybe unit (sigReturn sig)),
+            Var fallbackName
+          ]
+      Nothing ->
+        Con
+          "Fallback"
+          [ proxyExp (TyCon "NonPayable" []),
+            proxyExp unit,
+            proxyExp unit,
+            Var "fallback_default_implementation"
+          ]
 
     mkMethod (Signature _ _ fname fargs (Just ret) payable)
       | all isTyped fargs =
@@ -90,7 +113,10 @@ genMainFn addMain (Contract cname tys cdecls)
             ]
     mkMethod s = error $ "Internal Error: contract methods must be fully typed: " <> show s
 
-    unwrapSigs (CFunDecl (FunDef s _)) = Just s
+    -- skip the optional fallback function in the methods tuple
+    unwrapSigs (CFunDecl (FunDef s _))
+      | sigName s == fallbackName = Nothing
+      | otherwise = Just s
     unwrapSigs _ = Nothing
 
     isTyped (Typed {}) = True

--- a/src/Solcore/Frontend/Lexer/SolcoreLexer.hs
+++ b/src/Solcore/Frontend/Lexer/SolcoreLexer.hs
@@ -59,6 +59,7 @@ reservedWords =
     "assembly",
     "match",
     "function",
+    "fallback",
     "payable",
     "constructor",
     "return",

--- a/src/Solcore/Frontend/Parser/Decl.hs
+++ b/src/Solcore/Frontend/Parser/Decl.hs
@@ -259,6 +259,9 @@ fallbackSignatureP vars ctx = do
   payable <- option False (True <$ keyword "payable")
   keyword "fallback"
   ps <- parens (paramP `sepBy` comma)
+  case ps of
+    [] -> pure ()
+    _ -> fail "fallback function must not declare input parameters"
   ret <- optional (symbol "->" *> typeP)
   return (Signature vars ctx (Name "fallback") ps ret payable)
 

--- a/src/Solcore/Frontend/Parser/Decl.hs
+++ b/src/Solcore/Frontend/Parser/Decl.hs
@@ -248,6 +248,20 @@ signatureP vars ctx = do
   ret <- optional (symbol "->" *> typeP)
   return (Signature vars ctx n ps ret payable)
 
+fallbackDefAfterPrefix :: [Ty] -> [Pred] -> Parser FunDef
+fallbackDefAfterPrefix vars ctx = do
+  sig <- fallbackSignatureP vars ctx
+  body <- braces bodyP
+  return (FunDef sig (implicitReturn body))
+
+fallbackSignatureP :: [Ty] -> [Pred] -> Parser Signature
+fallbackSignatureP vars ctx = do
+  payable <- option False (True <$ keyword "payable")
+  keyword "fallback"
+  ps <- parens (paramP `sepBy` comma)
+  ret <- optional (symbol "->" *> typeP)
+  return (Signature vars ctx (Name "fallback") ps ret payable)
+
 -- | One function signature inside a class body.
 -- Commits to requiring ';' once the signature is parsed, so a missing
 -- semicolon produces "expecting ';' after function signature" rather than
@@ -293,7 +307,11 @@ contractDeclP =
     <$> dataP
       <|> CConstrDecl
     <$> constructorDeclP
-      <|> withSigPrefix (\vars ctx -> CFunDecl <$> funDefAfterPrefix vars ctx)
+      <|> withSigPrefix
+        ( \vars ctx ->
+            CFunDecl
+              <$> (try (funDefAfterPrefix vars ctx) <|> fallbackDefAfterPrefix vars ctx)
+        )
       <|> CFieldDecl
     <$> fieldDeclP
 

--- a/src/Solcore/Frontend/Parser/Decl.hs
+++ b/src/Solcore/Frontend/Parser/Decl.hs
@@ -263,6 +263,10 @@ fallbackSignatureP vars ctx = do
     [] -> pure ()
     _ -> fail "fallback function must not declare input parameters"
   ret <- optional (symbol "->" *> typeP)
+  case ret of
+    Nothing -> pure ()
+    Just (TyCon (Name "()") []) -> pure ()
+    Just _ -> fail "fallback function must return unit (`()`)"
   return (Signature vars ctx (Name "fallback") ps ret payable)
 
 -- | One function signature inside a class body.

--- a/std/dispatch.solc
+++ b/std/dispatch.solc
@@ -280,22 +280,20 @@ forall methods fb . methods:RunDispatch, fb:ExecMethod => instance Contract(meth
 
         // TODO: if all methods are non payable then we should life the callvalue check here
 
-        // check that we have at least 4 bytes of calldata
+        // set free memory pointer to the output of memoryguard
+        // https://docs.soliditylang.org/en/v0.8.30/yul.html#memoryguard
+        // TODO: we will need to consider immutables here at some point...
+        assembly { mstore(0x40, memoryguard(128)); }
+
+        // calldata shorter than 4 bytes can't contain a selector — skip
+        // dispatch and invoke the fallback directly (matches Solidity)
         let cdsz: word;
         assembly {
           cdsz := calldatasize()
         }
         match cdsz < 4 {
-          | true =>
-            let SelectorTooShort = Error(0x35ffc70e);
-            revertWithError(SelectorTooShort);
+          | true => ExecMethod.exec(fb);
           | false =>
-            // set free memory pointer to the output of memoryguard
-            // https://docs.soliditylang.org/en/v0.8.30/yul.html#memoryguard
-            // TODO: we will need to consider immutables here at some point...
-            assembly { mstore(0x40, memoryguard(128)); }
-
-            // dispatch to method based on selector
             RunDispatch.go(ms);
             // run fallback if no methods matched
             ExecMethod.exec(fb);

--- a/std/dispatch.solc
+++ b/std/dispatch.solc
@@ -291,13 +291,12 @@ forall methods fb . methods:RunDispatch, fb:ExecMethod => instance Contract(meth
         assembly {
           cdsz := calldatasize()
         }
-        match cdsz < 4 {
-          | true => ExecMethod.exec(fb);
-          | false =>
+        if (cdsz >= 4) {
             RunDispatch.go(ms);
-            // run fallback if no methods matched
-            ExecMethod.exec(fb);
         }
+        // fallthrough to fallback -- this will be reached upon short input
+        //                            or no matching selector
+        ExecMethod.exec(fb);
     }
   }
 }

--- a/std/dispatch.solc
+++ b/std/dispatch.solc
@@ -27,7 +27,7 @@ pragma no-bounded-variable-condition ;
 
 // A contract contains a tuple of methods and a single fallback
 // TODO: implement receive()
-data Contract(methods, fallback) = Contract(methods,fallback);
+data Contract(methods, fb) = Contract(methods,fb);
 
 // A method contains an implementation (fn) as well as it's name and type signature
 data Method(name, payability, args, rets, fn) = Method(Proxy(name), Proxy(payability), Proxy(args), Proxy(rets), fn);
@@ -273,8 +273,8 @@ forall c . class c:RunContract {
 }
 
 // If we have a dispatch for the contracts methods, and we know how to execute it's fallback, then we can define an entrypoint
-forall methods fallback . methods:RunDispatch, fallback:ExecMethod => instance Contract(methods, fallback):RunContract {
-  function exec(c : Contract(methods, fallback)) -> () {
+forall methods fb . methods:RunDispatch, fb:ExecMethod => instance Contract(methods, fb):RunContract {
+  function exec(c : Contract(methods, fb)) -> () {
     match c {
       | Contract(ms, fb) =>
 

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -270,6 +270,7 @@ cases =
       runTestForFile "EqQual.solc" caseFolder,
       runTestForFile "EvenOdd.solc" caseFolder,
       runTestExpectingFailure "fallback-with-args.solc" caseFolder,
+      runTestExpectingFailure "fallback-with-return.solc" caseFolder,
       runTestExpectingFailure "Filter.solc" caseFolder,
       runTestForFile "foo-class.solc" caseFolder,
       runTestForFile "Foo.solc" caseFolder,

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -269,6 +269,7 @@ cases =
       runTestExpectingFailure "Eq.solc" caseFolder,
       runTestForFile "EqQual.solc" caseFolder,
       runTestForFile "EvenOdd.solc" caseFolder,
+      runTestExpectingFailure "fallback-with-args.solc" caseFolder,
       runTestExpectingFailure "Filter.solc" caseFolder,
       runTestForFile "foo-class.solc" caseFolder,
       runTestForFile "Foo.solc" caseFolder,

--- a/test/examples/cases/dispatch.solc
+++ b/test/examples/cases/dispatch.solc
@@ -8,7 +8,7 @@ data Proxy(a) = Proxy;
 
 // A contract contains a tuple of methods and a single fallback
 // TODO: implement receive()
-data Contract(methods, fallback) = Contract(methods,fallback);
+data Contract(methods, fb) = Contract(methods,fb);
 
 // A method contains an implementation (fn) as well as it's name and type signature
 data Method(name, args, rets, fn) = Method(name, args, rets, fn);
@@ -202,8 +202,8 @@ forall c . class c:RunContract {
 }
 
 // If we have a dispatch for the contracts methods, and we know how to execute it's fallback, then we can define an entrypoint
-forall methods fallback . methods:RunDispatch, fallback:ExecMethod => instance Contract(methods, fallback):RunContract {
-  function exec(c : Contract(methods, fallback)) -> () {
+forall methods fb . methods:RunDispatch, fb:ExecMethod => instance Contract(methods, fb):RunContract {
+  function exec(c : Contract(methods, fb)) -> () {
     match c {
       | Contract(ms, fb) =>
         // set free memory pointer to the output of memoryguard
@@ -212,7 +212,7 @@ forall methods fallback . methods:RunDispatch, fallback:ExecMethod => instance C
         // assembly { mstore(0x40, memoryguard(128)); }
 
         // if all methods are non payable then check callvalue
-        let callvalueChecked = TopLevelCallvalueCheck.checkCallvalue(Proxy : Proxy((fallback, methods)));
+        let callvalueChecked = TopLevelCallvalueCheck.checkCallvalue(Proxy : Proxy((fb, methods)));
 
         // check that we have at least 4 bytes of calldata
         let haveSelector : word;

--- a/test/examples/cases/fallback-with-args.solc
+++ b/test/examples/cases/fallback-with-args.solc
@@ -1,0 +1,10 @@
+import std.{*};
+import std.dispatch.{*};
+
+contract BadFallback {
+    constructor() {}
+
+    fallback(x: uint256) -> () {
+        revert("fallback-was-called");
+    }
+}

--- a/test/examples/cases/fallback-with-return.solc
+++ b/test/examples/cases/fallback-with-return.solc
@@ -1,0 +1,10 @@
+import std.{*};
+import std.dispatch.{*};
+
+contract BadFallback {
+    constructor() {}
+
+    fallback() -> uint256 {
+        return uint256(0);
+    }
+}

--- a/test/examples/dispatch/basic.json
+++ b/test/examples/dispatch/basic.json
@@ -72,13 +72,13 @@
       },
       {
         "input": {
-          "text-calldata": "selector too short",
+          "text-calldata": "selector too short (same error as missing fallback)",
           "calldata":"c0de",
           "value": "0"
         },
         "kind": "call",
         "output": {
-          "returndata":"35ffc70e",
+          "returndata":"4924aef0",
           "status": "failure"
         }
       },

--- a/test/examples/dispatch/fallback.json
+++ b/test/examples/dispatch/fallback.json
@@ -1,0 +1,63 @@
+{
+  "WithFallback": {
+    "bytecode": "",
+    "contract": "WithFallback",
+    "tests": [
+      {
+        "input": {
+          "calldata": "",
+          "value": "0"
+        },
+        "kind": "constructor"
+      },
+      {
+        "input": {
+          "text-calldata": "answer()(uint256)",
+          "calldata": "85bb7d69",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "000000000000000000000000000000000000000000000000000000000000002a",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "text-calldata": "no selector -- user-defined fallback runs and reverts",
+          "calldata": "",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "66616c6c6261636b2d7761732d63616c6c6564",
+          "status": "failure"
+        }
+      },
+      {
+        "input": {
+          "text-calldata": "unknown selector -- user-defined fallback runs and reverts",
+          "calldata": "deadc0de",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "66616c6c6261636b2d7761732d63616c6c6564",
+          "status": "failure"
+        }
+      },
+      {
+        "input": {
+          "text-calldata": "unknown selector with value -- payable fallback runs and reverts",
+          "calldata": "deadc0de",
+          "value": "42"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "b5988ea3",
+          "status": "failure"
+        }
+      }
+    ]
+  }
+}

--- a/test/examples/dispatch/fallback.solc
+++ b/test/examples/dispatch/fallback.solc
@@ -1,0 +1,14 @@
+import std.{*};
+import std.dispatch.{*};
+
+contract WithFallback {
+    constructor() {}
+
+    function answer() -> uint256 {
+        return uint256(42);
+    }
+
+    fallback() -> () {
+        revert("fallback-was-called");
+    }
+}

--- a/test/examples/dispatch/payable.json
+++ b/test/examples/dispatch/payable.json
@@ -57,8 +57,43 @@
           "returndata": "b5988ea3",
           "status": "failure"
         }
+      },
+      {
+        "input": {
+	    "text-calldata": "fallback with value",
+          "calldata": "deadc0de",
+          "value": "42"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+	    "text-calldata": "fallback without value should fail",
+          "calldata": "deadc0de",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "66616c6c6261636b2d7761732d63616c6c65642d6e6f2d76616c7565",
+          "status": "failure"
+        }
+      },
+      {
+        "input": {
+	    "text-calldata": "balance()(uint256)",
+          "calldata": "b69ef8a8",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000054",
+          "status": "success"
+        }
       }
-
     ]
   }
 }

--- a/test/examples/dispatch/payable.solc
+++ b/test/examples/dispatch/payable.solc
@@ -19,4 +19,14 @@ contract PayableTest {
         }
         return uint256(value);
     }
+
+    payable fallback() -> () {
+        let value;
+        assembly {
+            value := callvalue()
+        }
+        if (value == 0) {
+            revert("fallback-was-called-no-value");
+        }
+    }
 }


### PR DESCRIPTION
Introduces a new `fallback` keyword that defines an anonymous, optional function inside a contract — same shape as `function name(...)` but without a name and limited to zero or one per contract. The contract dispatch desugarer wires the user-defined fallback into the generated `Contract` value (replacing `fallback_default_implementation`) so it runs when no selector matches. The default implementation is retained when no fallback is declared.

Also renames the `fallback` type variables in dispatch.solc to `fb` since `fallback` is now a reserved keyword.

Testing cases:
- `basic.json` has the missing fallback case
- `fallback.json` has the non-payable fallback cases
- `payable.json` has the payable fallback cases

This was aided by Claude.