### PR TITLE
Type-check Yul assignment arity against builtin return count

### DIFF
--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -1547,7 +1547,7 @@ tcYulBlock (s : ss) =
     pure (ns ++ nss, t)
 
 tcYulStmt :: YulStmt -> TcM ([Name], Ty)
-tcYulStmt (YAssign ns e) =
+tcYulStmt s@(YAssign ns e) =
   do
     forM_ ns $ \n -> do
       msch <- maybeAskEnv n
@@ -1559,16 +1559,18 @@ tcYulStmt (YAssign ns e) =
           case t' of
             Meta _ -> unify t' word >> pure ()
             _ -> pure ()
-    _ <- tcYulExp e
+    t <- tcYulExp e
+    checkYulAssignArity s ns e t
     pure ([], unit)
 tcYulStmt (YBlock yblk) =
   do
     _ <- tcYulBlock yblk
     -- names defined in should not return
     pure ([], unit)
-tcYulStmt (YLet ns (Just e)) =
+tcYulStmt s@(YLet ns (Just e)) =
   do
-    _ <- tcYulExp e
+    t <- tcYulExp e
+    checkYulAssignArity s ns e t
     mapM_ (flip extEnv mword) ns
     pure (ns, unit)
 tcYulStmt (YExp e) =
@@ -1597,6 +1599,33 @@ tcYulStmt (YFor initBlk e bdy upd) =
       pure ()
     pure ([], unit)
 tcYulStmt _ = pure ([], unit)
+
+-- Yul builtins/opcodes return either 0 values (type 'unit') or 1 value
+-- (any other type). Compare the number of names on the left-hand side of
+-- an assignment with the actual return arity of the right-hand side.
+yulReturnArity :: Ty -> Int
+yulReturnArity t
+  | t == unit = 0
+  | otherwise = 1
+
+checkYulAssignArity :: YulStmt -> [Name] -> YulExp -> Ty -> TcM ()
+checkYulAssignArity s ns e t =
+  do
+    t' <- withCurrentSubst t
+    let expected = length ns
+        actual = yulReturnArity t'
+    when (expected /= actual) $
+      tcmError
+        ( unlines
+            [ "In Yul statement:",
+              pretty s,
+              "the right-hand side:",
+              pretty e,
+              "produces " ++ show actual ++ " value(s),",
+              "but " ++ show expected ++ " value(s) are being assigned."
+            ]
+        )
+        `wrapError` s
 
 tcYulExp :: YulExp -> TcM Ty
 tcYulExp (YLit l) =

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -217,6 +217,8 @@ cases =
       runTestForFileWith noDesugarOpt "app.solc" caseFolder,
       runTestForFile "array.solc" caseFolder,
       runTestForFile "assembly.solc" caseFolder,
+      runTestExpectingFailure "asm-assign-no-return.solc" caseFolder,
+      runTestExpectingFailure "asm-let-no-return.solc" caseFolder,
       runTestForFile "bal.solc" caseFolder,
       runTestExpectingFailure "BadInstance.solc" caseFolder,
       runTestForFile "BoolNot.solc" caseFolder,

--- a/test/examples/cases/asm-assign-no-return.solc
+++ b/test/examples/cases/asm-assign-no-return.solc
@@ -1,0 +1,10 @@
+// mstore does not return a value, so it cannot be assigned.
+contract Test {
+  function main() {
+    let x : word;
+    assembly {
+      x := mstore(1, 1)
+    }
+    return x;
+  }
+}

--- a/test/examples/cases/asm-let-no-return.solc
+++ b/test/examples/cases/asm-let-no-return.solc
@@ -1,0 +1,8 @@
+// mstore does not return a value, so it cannot initialize a `let`.
+contract Test {
+  function main() {
+    assembly {
+      let x := mstore(1, 1)
+    }
+  }
+}


### PR DESCRIPTION
Yul builtins/opcodes either return a single value or none at all (when typed as `unit`). The Yul type checker previously accepted `let x := mstore(1, 1)` and similar assignments even though `mstore` does not produce a value. Compare the number of names on the left-hand side of `YAssign`/`YLet` with the actual arity of the right-hand side and report a type error on mismatch.

Fixes #383.

Disclaimer: Mostly created by Claude.