### PR TITLE
Add precompile hashing wrappers (`keccak256_`, `sha256`, `ripemd160`)

### DIFF
--- a/run_contests.sh
+++ b/run_contests.sh
@@ -10,6 +10,7 @@ bash ./contest.sh test/examples/dispatch/neg.json
 bash ./contest.sh test/examples/dispatch/miniERC20.json
 bash ./contest.sh test/examples/dispatch/Revert.json
 bash ./contest.sh test/examples/dispatch/ownable.json
+bash ./contest.sh test/examples/dispatch/hashes.json
 bash ./contest.sh test/examples/dispatch/payable.json
 bash ./contest.sh test/examples/dispatch/concat.json
 bash ./contest.sh test/examples/dispatch/fallback.json

--- a/std/std.solc
+++ b/std/std.solc
@@ -69,6 +69,7 @@ export {
   gtWord,
   hash1,
   hash2,
+  keccak256_,
   keccakLit,
   le,
   lidx,
@@ -92,9 +93,11 @@ export {
   revertWithError,
   require,
   ridx,
+  ripemd160,
   round_up_to_mul_of_32,
   rval,
   set_free_memory,
+  sha256,
   slice(*),
   sloadViaWord,
   sload_,
@@ -2051,4 +2054,46 @@ function zeroize_memory(ptr: word, len: word) -> () {
         // Zero out trailing bytes. We rely on the zero-slot (0x60-0x7f).
         mcopy(ptr, 0x60, sub(end_ptr, ptr))
     }
+}
+
+// --- Hashing ---
+
+// NOTE: keccak256 name conflicts with assembly namespace
+function keccak256_(input: memory(bytes)) -> bytes32 {
+    let ptr : word = Typedef.rep(input);
+    let res : word;
+    assembly {
+        res := keccak256(add(ptr, 32), mload(ptr))
+    }
+    return bytes32(res);
+}
+
+function sha256(input: memory(bytes)) -> bytes32 {
+    let ptr : word = Typedef.rep(input);
+    let res : word;
+    // We assume the [0, 32] scratch space is reserved.
+    // TODO: add specific error code
+    assembly {
+        let ret := staticcall(gas(), 2, add(ptr, 32), mload(ptr), 0, 32)
+        if iszero(ret) {
+            revert(0, 0)
+        }
+        res := mload(0)
+    }
+    return bytes32(res);
+}
+
+function ripemd160(input: memory(bytes)) -> bytes32 {
+    let ptr : word = Typedef.rep(input);
+    let res : word;
+    // We assume the [0, 32] scratch space is reserved.
+    // TODO: add specific error code
+    assembly {
+        let ret := staticcall(gas(), 3, add(ptr, 32), mload(ptr), 0, 32)
+        if iszero(ret) {
+            revert(0, 0)
+        }
+        res := mload(0)
+    }
+    return bytes32(res);
 }

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -85,7 +85,8 @@ dispatches =
     [ runDispatchTest "basic.solc",
       runDispatchTest "stringid.solc",
       runDispatchTest "miniERC20.solc",
-      runDispatchTest "Revert.solc"
+      runDispatchTest "Revert.solc",
+      runDispatchTest "hashes.solc"
     ]
   where
     runDispatchTest file = runTestForFileWith (emptyOption mempty) file "./test/examples/dispatch"

--- a/test/examples/dispatch/hashes.json
+++ b/test/examples/dispatch/hashes.json
@@ -1,0 +1,51 @@
+{
+  "hashes": {
+    "bytecode": "",
+    "contract": "C",
+    "tests": [
+      {
+        "input": {
+          "calldata": "",
+          "value": "0"
+        },
+        "kind": "constructor"
+      },
+      {
+        "input": {
+          "text-calldata": "keccak()(bytes32)",
+          "calldata": "775dec49",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "text-calldata": "sha()(bytes32)",
+          "calldata": "65707d6f",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "text-calldata": "ripemd()(bytes32)",
+          "calldata": "a1e754ea",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000008eb208f7e05d987a9b044a8e98c6b087f15a0bfc",
+          "status": "success"
+        }
+      }
+    ]
+  }
+}

--- a/test/examples/dispatch/hashes.solc
+++ b/test/examples/dispatch/hashes.solc
@@ -1,0 +1,26 @@
+import std.{*};
+import std.dispatch.{*};
+
+// Build a memory(bytes) holding the three-byte string "abc".
+function abcBytes() -> memory(bytes) {
+    let p = allocate_memory(64);
+    mstore(p, 3);
+    mstore(p + 32, 0x6162630000000000000000000000000000000000000000000000000000000000);
+    return memory(p);
+}
+
+contract C {
+    constructor() {}
+
+    function keccak() -> bytes32 {
+        return keccak256_(abcBytes());
+    }
+
+    function sha() -> bytes32 {
+        return sha256(abcBytes());
+    }
+
+    function ripemd() -> bytes32 {
+        return ripemd160(abcBytes());
+    }
+}

--- a/test/testrunner/EVMHost.cpp
+++ b/test/testrunner/EVMHost.cpp
@@ -650,6 +650,13 @@ evmc::Result EVMHost::precompileRipeMD160(evmc_message const& _message) noexcept
 				fromHex("000000000000000000000000ac5ab22e07b0fb80c69b6207902f725e2507e546"),
 				calc_cost(32)
 			}
+		},
+		{
+			fromHex("616263"),
+			{
+				fromHex("0000000000000000000000008eb208f7e05d987a9b044a8e98c6b087f15a0bfc"),
+				calc_cost(32)
+			}
 		}
 	};
 	return precompileGeneric(_message, inputOutput);


### PR DESCRIPTION
They all take `memory(bytes)` as input and return `bytes32`.