### PR TITLE
Force UTF-8 locale in the compiler

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,9 @@
 module Main where
 
+import GHC.IO.Encoding (setLocaleEncoding, utf8)
 import Solcore.Pipeline.SolcorePipeline
 
 main :: IO ()
-main = pipeline
+main = do
+  setLocaleEncoding utf8
+  pipeline

--- a/test/examples/dispatch/miniERC20.solc
+++ b/test/examples/dispatch/miniERC20.solc
@@ -54,6 +54,7 @@ contract MiniERC20 {
     return totalSupply;
   }
 
+  // Note that this is not access guarded — the minting always goes to the owner
   function mint(amount:uint256) -> () {
     balances[owner] = Num.add(balances[owner], amount);
     totalSupply = Num.add(totalSupply, amount);

--- a/yule/Main.hs
+++ b/yule/Main.hs
@@ -9,6 +9,7 @@ import Builtins (yulBuiltins)
 import Common.Pretty
 import Compress
 import Control.Monad (unless, when)
+import GHC.IO.Encoding (setLocaleEncoding, utf8)
 import Language.Hull.Parser (parseObject)
 import Language.Hull.TcEnv (emptyHullTcEnv)
 import Language.Hull.TcMonad (runHullTcM)
@@ -24,6 +25,7 @@ import Translate
 
 main :: IO ()
 main = do
+  setLocaleEncoding utf8
   options <- parseOptions
   -- print options
   let filename = Options.input options


### PR DESCRIPTION
This matches Solidity, which states the source code inputs are considered UTF-8.