### PR TITLE
Resolve qualified constructor access on same-name-constructor types

### DIFF
--- a/src/Solcore/Frontend/Syntax/NameResolution.hs
+++ b/src/Solcore/Frontend/Syntax/NameResolution.hs
@@ -510,6 +510,17 @@ resolveSameNameConstructorName n =
   where
     leaf = constructorLeafName n
 
+-- A receiver like @Error@ in @Error.Empty@ is first parsed as an expression
+-- on its own and resolved before the outer member-access context is known.
+-- When the type has a same-name constructor (@data Error = Error(...) | ...@),
+-- the inner resolver eagerly produces @Con (QualName Error Error) []@ for the
+-- bare name. Treat that shape as if it were @Var Error@ when it appears in
+-- qualifier position so the outer qualifier-handling cases still match.
+unwrapQualifierReceiver :: Maybe (Exp Name) -> Maybe (Exp Name)
+unwrapQualifierReceiver (Just (Con (QualName d conName) []))
+  | pretty d == conName = Just (Var d)
+unwrapQualifierReceiver me = me
+
 instance Resolve S.Exp where
   type Result S.Exp = Exp Name
 
@@ -528,7 +539,7 @@ instance Resolve S.Exp where
     TyExp <$> resolve e <*> resolve t
   resolve c@(S.ExpVar me n) =
     do
-      me' <- resolve me `wrapError` c
+      me' <- unwrapQualifierReceiver <$> (resolve me `wrapError` c)
       dt <- lookupName n
       case (me', dt) of
         -- local variables
@@ -599,7 +610,7 @@ instance Resolve S.Exp where
                 else undefinedName n
   resolve x@(S.ExpName me n es) =
     do
-      me' <- resolve me `wrapError` x
+      me' <- unwrapQualifierReceiver <$> (resolve me `wrapError` x)
       es' <- resolve es `wrapError` x
       dt <- lookupName n
       case (me', dt) of

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -259,6 +259,7 @@ cases =
       runTestForFile "dot-pattern-constructor.solc" caseFolder,
       runTestForFile "dot-pattern-nested-constructor.solc" caseFolder,
       runTestForFile "dot-primitive-constructor.solc" caseFolder,
+      runTestForFile "same-name-constructor-qualifier.solc" caseFolder,
       runTestExpectingFailure "duplicated-contract-name.solc" caseFolder,
       runTestExpectingFailure "duplicated-type-name.solc" caseFolder,
       runTestForFile "DuplicateFun.solc" caseFolder,

--- a/test/examples/cases/same-name-constructor-qualifier.solc
+++ b/test/examples/cases/same-name-constructor-qualifier.solc
@@ -1,0 +1,23 @@
+// Qualifier access (T.C) must work even when T has a same-name constructor.
+// Regression test for: `Error.Empty` reporting "Unqualified constructor: Empty".
+data Err = Err(word) | Empty | Msg(word);
+
+function pickEmpty() -> Err {
+  return Err.Empty;
+}
+
+function pickMsg(x: word) -> Err {
+  return Err.Msg(x);
+}
+
+function pickErr(x: word) -> Err {
+  return Err.Err(x);
+}
+
+function main() -> word {
+  match pickEmpty() {
+  | Err.Empty => return 1;
+  | Err.Err(_) => return 2;
+  | Err.Msg(_) => return 3;
+  }
+}


### PR DESCRIPTION
When a data type T has a same-name constructor (e.g. `data Error = Error(word) | Empty | ...`), the inner resolver for the bare receiver `@Error@` in `@Error.Empty@` eagerly produced `@Con (QualName Error Error) []@`. The outer ExpVar/ExpName resolver only matched `@Just (Var d)@` for qualifier-style access, so it fell through to the catch-all and reported "Unqualified constructor: Empty. Use Type.Constructor form." — even though the user had used the qualified form.

Treat a same-name no-arg constructor receiver as if it were `@Var d@` before dispatching on the case table, restoring the qualifier-handling paths for `@Error.Empty@` and `@Error.Msg(x)@`.

Fixes #430 
