### PR TITLE
Add `public` visibility modifier for contract functions

### DIFF
--- a/src/Solcore/Backend/Specialise.hs
+++ b/src/Solcore/Backend/Specialise.hs
@@ -297,7 +297,7 @@ addMethodResolution cname ty fd = do
         Name s -> QualName cname s
   let name' = specName qname [ty]
   let funType = typeOfTcFunDef fd
-  let fd' = FunDef sig {sigName = name'} (funDefBody fd)
+  let fd' = FunDef (funIsPublic fd) sig {sigName = name'} (funDefBody fd)
   addResolution qname funType fd'
   debug ["+ addMethodResolution: ", show qname, " / ", show name', " : ", pretty funType]
 
@@ -438,10 +438,10 @@ specFunDef fd0 = withLocalState do
     Nothing -> do
       let sig' = applytv subst (funSignature fd)
       -- add a placeholder first to break loops
-      let placeholder = FunDef sig' []
+      let placeholder = FunDef (funIsPublic fd) sig' []
       addSpecialisation name' placeholder
       body' <- specBody (funDefBody fd)
-      let fd' = FunDef sig' {sigName = name'} body'
+      let fd' = FunDef (funIsPublic fd) sig' {sigName = name'} body'
       debug ["+ specFunDef: adding specialisation ", show name', " : ", pretty ty']
       addSpecialisation name' fd'
       return name'
@@ -664,7 +664,7 @@ schemeOfTcSignature sig@(Signature vs ps _n args _ (Just rt) _) =
 schemeOfTcSignature sig = error ("no return type in signature of: " ++ show (sigName sig))
 
 typeOfTcFunDef :: TcFunDef -> Ty
-typeOfTcFunDef (FunDef sig _) = typeOfTcSignature sig
+typeOfTcFunDef (FunDef _ sig _) = typeOfTcSignature sig
 
 pprRes :: Resolution -> Doc
 -- type Resolution = (Ty, FunDef Id)
@@ -816,7 +816,7 @@ instance HasTV (FunDef Id) where
     subst <- foldM addRenaming mempty (sigVars sig)
     let sig' = applytv subst sig
     let body' = applytv subst (funDefBody fd)
-    pure (FunDef sig' body', subst)
+    pure (FunDef (funIsPublic fd) sig' body', subst)
 
 addRenaming :: TVSubst -> Tyvar -> SM TVSubst
 addRenaming b a = do
@@ -873,7 +873,7 @@ toMastContractDecl (CMutualDecl ds) = MastCMutualDecl (map toMastContractDecl ds
 toMastContractDecl d = error $ "toMastContractDecl: unexpected " ++ show d
 
 toMastFunDef :: FunDef Id -> MastFunDef
-toMastFunDef (FunDef sig body) =
+toMastFunDef (FunDef _ sig body) =
   MastFunDef
     { mastFunName = sigName sig,
       mastFunParams = map toMastParam (sigParams sig),

--- a/src/Solcore/Desugarer/ContractDispatch.hs
+++ b/src/Solcore/Desugarer/ContractDispatch.hs
@@ -63,7 +63,7 @@ findFallback c = listToMaybe [fd | CFunDecl fd <- decls c, isFallback fd]
 genNameDecls :: Contract Name -> Set (TopDecl Name)
 genNameDecls (Contract cname _ cdecls) = foldl go Set.empty cdecls
   where
-    go acc (CFunDecl (FunDef sig _))
+    go acc (CFunDecl (FunDef True sig _))
       | sigName sig == fallbackName = acc
       | otherwise =
           let dataTy = mkNameTy cname (sigName sig)
@@ -79,12 +79,12 @@ genMainFn addMain c@(Contract cname tys cdecls)
     cdecls'' = if hasConstructor cdecls then cdecls else cdecls ++ [defaultConstructor]
     cdecls' = Set.unions (map (transformCDecl cname) cdecls'')
     defaultConstructor = CConstrDecl (Constructor {constrParams = [], constrBody = []})
-    mainfn = FunDef (Signature [] [] "main" [] False (Just unit) False) body
+    mainfn = FunDef False (Signature [] [] "main" [] False (Just unit) False) body
     body = [StmtExp (Call Nothing (QualName "RunContract" "exec") [cdata])]
     cdata = Con "Contract" [methods, fallback]
     methods = tupleExpFromList (fmap mkMethod (mapMaybe unwrapSigs cdecls))
     fallback = case findFallback c of
-      Just (FunDef sig _) ->
+      Just (FunDef _ sig _) ->
         Con
           "Fallback"
           [ proxyExp (TyCon (if sigPayable sig then "Payable" else "NonPayable") []),
@@ -113,8 +113,8 @@ genMainFn addMain c@(Contract cname tys cdecls)
             ]
     mkMethod s = error $ "Internal Error: contract methods must be fully typed: " <> show s
 
-    -- skip the optional fallback function in the methods tuple
-    unwrapSigs (CFunDecl (FunDef s _))
+    -- skip the optional fallback function and non-public methods in the methods tuple
+    unwrapSigs (CFunDecl (FunDef True s _))
       | sigName s == fallbackName = Nothing
       | otherwise = Just s
     unwrapSigs _ = Nothing
@@ -136,7 +136,7 @@ transformConstructor contractName cons
   where
     params = constrParams cons
     argsTuple = (tupleTyFromList (mapMaybe getTy params))
-    initFun = CFunDecl (FunDef initSig (constrBody cons))
+    initFun = CFunDecl (FunDef False initSig (constrBody cons))
     initSig =
       Signature
         { sigVars = mempty,
@@ -188,7 +188,7 @@ transformConstructor contractName cons
     memoryT t = TyCon "memory" [t]
     memoryE e = Con "memory" [e]
     bytesT = TyCon "bytes" []
-    copyArgsFun = CFunDecl (FunDef copySig copyBody)
+    copyArgsFun = CFunDecl (FunDef False copySig copyBody)
 
     startSig =
       Signature
@@ -213,7 +213,7 @@ transformConstructor contractName cons
             return(0, size)
           }|]
       ]
-    startFun = CFunDecl (FunDef startSig startBody)
+    startFun = CFunDecl (FunDef False startSig startBody)
 
     isTyped (Typed {}) = True
     isTyped (Untyped {}) = False
@@ -239,7 +239,7 @@ mkNameInst (DataTy dname [] []) fname =
           instName = "SigString",
           paramsTy = [],
           mainTy = nameTy,
-          instFunctions = [FunDef sig body]
+          instFunctions = [FunDef False sig body]
         }
 mkNameInst dt _ = error ("Internal Error: unexpected name type structure: " <> show dt)
 

--- a/src/Solcore/Desugarer/DecisionTreeCompiler.hs
+++ b/src/Solcore/Desugarer/DecisionTreeCompiler.hs
@@ -82,8 +82,8 @@ instance Compile (Constructor Id) where
     Constructor ps <$> compile bd
 
 instance Compile (FunDef Id) where
-  compile (FunDef sig bd) =
-    FunDef sig <$> pushCtx ("function " ++ pretty (sigName sig)) (compile bd)
+  compile (FunDef p sig bd) =
+    FunDef p sig <$> pushCtx ("function " ++ pretty (sigName sig)) (compile bd)
 
 instance Compile (Stmt Id) where
   compile (e1 := e2) =

--- a/src/Solcore/Desugarer/IndirectCall.hs
+++ b/src/Solcore/Desugarer/IndirectCall.hs
@@ -58,8 +58,8 @@ instance Desugar (Contract Name) where
     Contract n vs <$> desugar ds
 
 instance Desugar (FunDef Name) where
-  desugar (FunDef sig bdy) =
-    FunDef sig <$> desugar bdy
+  desugar (FunDef p sig bdy) =
+    FunDef p sig <$> desugar bdy
 
 instance Desugar (ContractDecl Name) where
   desugar (CFieldDecl fd) =

--- a/src/Solcore/Desugarer/UniqueTypeGen.hs
+++ b/src/Solcore/Desugarer/UniqueTypeGen.hs
@@ -33,7 +33,7 @@ instance UniqueTypeGen (TopDecl Name) where
   uniqueTyGen _ = pure ()
 
 instance UniqueTypeGen (FunDef Name) where
-  uniqueTyGen (FunDef sig _) = uniqueTyGen sig
+  uniqueTyGen (FunDef _ sig _) = uniqueTyGen sig
 
 instance UniqueTypeGen (Signature Name) where
   uniqueTyGen sig =

--- a/src/Solcore/Frontend/Lexer/SolcoreLexer.hs
+++ b/src/Solcore/Frontend/Lexer/SolcoreLexer.hs
@@ -61,6 +61,7 @@ reservedWords =
     "function",
     "fallback",
     "payable",
+    "public",
     "constructor",
     "return",
     "lam",

--- a/src/Solcore/Frontend/Module/Loader.hs
+++ b/src/Solcore/Frontend/Module/Loader.hs
@@ -496,8 +496,8 @@ stubContractDeclBody decl =
   decl
 
 stubFunDefBody :: FunDef -> FunDef
-stubFunDefBody (FunDef sig _body) =
-  FunDef sig []
+stubFunDefBody (FunDef p sig _body) =
+  FunDef p sig []
 
 moduleValidationTopDeclSegments :: ModuleGraph -> Mod.ModuleId -> Either String ([Import], [[TopDecl]])
 moduleValidationTopDeclSegments graph modulePath = do
@@ -1200,7 +1200,7 @@ isImportableTopDecl (TExportDecl _) = False
 isImportableTopDecl _ = True
 
 topDeclNames :: TopDecl -> [Name]
-topDeclNames (TFunDef (FunDef sig _)) = [sigName sig]
+topDeclNames (TFunDef (FunDef _ sig _)) = [sigName sig]
 topDeclNames (TSym (TySym n _ _)) = [n]
 topDeclNames (TClassDef (Class _ _ n _ _ _)) = [n]
 topDeclNames (TContr (Contract n _ _)) = [n]
@@ -1232,8 +1232,9 @@ qualifiedImportStubDecls graph (imp, modulePath) =
       stubDecls (QualName qualifier (show bindingName)) targetModule
 
 qualifyFunctionSignature :: Name -> FunDef -> FunDef
-qualifyFunctionSignature qualifier (FunDef sig body) =
+qualifyFunctionSignature qualifier (FunDef p sig body) =
   FunDef
+    p
     (sig {sigName = QualName qualifier (show (sigName sig))})
     body
 
@@ -1268,8 +1269,9 @@ renameTopDeclTypeRefs renameMap (TSym s) =
 renameTopDeclTypeRefs _ d = d
 
 renameFunDefTypeRefs :: Map Name Name -> FunDef -> FunDef
-renameFunDefTypeRefs renameMap (FunDef sig body) =
+renameFunDefTypeRefs renameMap (FunDef p sig body) =
   FunDef
+    p
     (renameSignatureTypeRefs renameMap sig)
     (renameBodyTypeRefs renameMap body)
 
@@ -1574,6 +1576,7 @@ stubType n =
 stubFunction :: Name -> FunDef
 stubFunction n =
   FunDef
+    False
     (Signature [] [] n [] False Nothing False)
     []
 
@@ -1590,7 +1593,7 @@ validationImportedDecls graph (imp, modulePath) =
       Right []
 
 toValidationImportStub :: TopDecl -> Maybe TopDecl
-toValidationImportStub (TFunDef (FunDef sig _)) =
+toValidationImportStub (TFunDef (FunDef _ sig _)) =
   Just (TFunDef (stubFunction (sigName sig)))
 toValidationImportStub (TSym (TySym n _ _)) =
   Just (TSym (stubType n))
@@ -1831,7 +1834,7 @@ shadowImportedDecls localDecls =
         (seen', Just decl') -> (seen', decl' : acc)
         (seen', Nothing) -> (seen', acc)
 
-    filterDecl (termNames, typeNames, classNames, instDecls) d@(TFunDef (FunDef sig _))
+    filterDecl (termNames, typeNames, classNames, instDecls) d@(TFunDef (FunDef _ sig _))
       | sigName sig `elem` termNames = ((termNames, typeNames, classNames, instDecls), Nothing)
       | otherwise =
           ( (sigName sig : termNames, typeNames, classNames, instDecls),
@@ -1896,7 +1899,7 @@ instanceDeclHeadKey inst =
   (instDefault inst, instName inst, paramsTy inst, mainTy inst)
 
 topDeclTermNames :: TopDecl -> [Name]
-topDeclTermNames (TFunDef (FunDef sig _)) = [sigName sig]
+topDeclTermNames (TFunDef (FunDef _ sig _)) = [sigName sig]
 topDeclTermNames _ = []
 
 topDeclTypeNames :: TopDecl -> [Name]
@@ -1924,9 +1927,9 @@ renameTopDeclName oldName newName decl
   | oldName == newName = decl
   | otherwise =
       case decl of
-        TFunDef (FunDef sig body)
+        TFunDef (FunDef p sig body)
           | sigName sig == oldName ->
-              TFunDef (FunDef (sig {sigName = newName}) body)
+              TFunDef (FunDef p (sig {sigName = newName}) body)
         TSym sym@(TySym n _ _)
           | n == oldName ->
               TSym (sym {symName = newName})
@@ -1943,7 +1946,7 @@ renameTopDeclName oldName newName decl
           decl
 
 selectTopDeclForExportRef :: ExportedItemRef -> TopDecl -> Maybe TopDecl
-selectTopDeclForExportRef itemRef d@(TFunDef (FunDef sig _))
+selectTopDeclForExportRef itemRef d@(TFunDef (FunDef _ sig _))
   | exportedItemSourceName itemRef == sigName sig,
     exportedItemConstructors itemRef == Nothing =
       Just (renameTopDeclName (exportedItemSourceName itemRef) (exportedItemName itemRef) d)

--- a/src/Solcore/Frontend/Parser/Decl.hs
+++ b/src/Solcore/Frontend/Parser/Decl.hs
@@ -6,7 +6,7 @@ module Solcore.Frontend.Parser.Decl
 where
 
 import Common.LightYear
-import Control.Monad (void)
+import Control.Monad (void, when)
 import Data.List.NonEmpty qualified as NE
 import Solcore.Frontend.Lexer.SolcoreLexer
 import Solcore.Frontend.Parser.Expr (exprP)
@@ -227,14 +227,28 @@ tySymP = do
   return (TySym n params t)
 
 funDefP :: Parser FunDef
-funDefP = try $ withSigPrefix funDefAfterPrefix
+funDefP = try $ withSigPrefix (funDefAfterPrefix False)
 
-funDefAfterPrefix :: [Ty] -> [Pred] -> Parser FunDef
-funDefAfterPrefix vars ctx = do
-  isPub <- option False (True <$ try (keyword "public"))
+-- | Parse a function definition after its optional signature prefix.
+-- 'allowPublic' controls whether a leading `public` visibility modifier is
+-- accepted: it is only meaningful inside a `contract { … }` body, so callers
+-- outside a contract (top-level functions, instance methods) pass 'False'.
+funDefAfterPrefix :: Bool -> [Ty] -> [Pred] -> Parser FunDef
+funDefAfterPrefix allowPublic vars ctx = do
+  isPub <- publicModifierP allowPublic
   sig <- signatureP vars ctx
   body <- braces bodyP
   return (FunDef isPub sig (implicitReturn body))
+
+-- | Parse an optional `public` visibility modifier. When 'allowPublic' is
+-- 'False' (anywhere outside a contract body), an explicit `public` is rejected
+-- with a clear error rather than being silently accepted.
+publicModifierP :: Bool -> Parser Bool
+publicModifierP allowPublic = do
+  isPub <- option False (True <$ try (keyword "public"))
+  when (isPub && not allowPublic) $
+    fail "'public' is only allowed on functions declared inside a contract"
+  return isPub
 
 implicitReturn :: Body -> Body
 implicitReturn [StmtExp e] = [Return e]
@@ -323,7 +337,7 @@ contractDeclP =
       <|> withSigPrefix
         ( \vars ctx ->
             CFunDecl
-              <$> (try (funDefAfterPrefix vars ctx) <|> fallbackDefAfterPrefix vars ctx)
+              <$> (try (funDefAfterPrefix True vars ctx) <|> fallbackDefAfterPrefix vars ctx)
         )
       <|> CFieldDecl
     <$> fieldDeclP
@@ -366,7 +380,7 @@ topDeclP =
       withSigPrefix
         ( \vars ctx ->
             choice
-              [ TFunDef <$> funDefAfterPrefix vars ctx,
+              [ TFunDef <$> funDefAfterPrefix False vars ctx,
                 TClassDef <$> classAfterPrefix vars ctx,
                 TInstDef <$> instanceAfterPrefix vars ctx
               ]

--- a/src/Solcore/Frontend/Parser/Decl.hs
+++ b/src/Solcore/Frontend/Parser/Decl.hs
@@ -231,9 +231,10 @@ funDefP = try $ withSigPrefix funDefAfterPrefix
 
 funDefAfterPrefix :: [Ty] -> [Pred] -> Parser FunDef
 funDefAfterPrefix vars ctx = do
+  isPub <- option False (True <$ try (keyword "public"))
   sig <- signatureP vars ctx
   body <- braces bodyP
-  return (FunDef sig (implicitReturn body))
+  return (FunDef isPub sig (implicitReturn body))
 
 implicitReturn :: Body -> Body
 implicitReturn [StmtExp e] = [Return e]
@@ -256,7 +257,7 @@ fallbackDefAfterPrefix :: [Ty] -> [Pred] -> Parser FunDef
 fallbackDefAfterPrefix vars ctx = do
   sig <- fallbackSignatureP vars ctx
   body <- braces bodyP
-  return (FunDef sig (implicitReturn body))
+  return (FunDef False sig (implicitReturn body))
 
 fallbackSignatureP :: [Ty] -> [Pred] -> Parser Signature
 fallbackSignatureP vars ctx = do

--- a/src/Solcore/Frontend/Parser/Decl.hs
+++ b/src/Solcore/Frontend/Parser/Decl.hs
@@ -319,6 +319,7 @@ contractDeclP =
     <$> dataP
       <|> CConstrDecl
     <$> constructorDeclP
+      <|> rejectPublicOnImplicitlyPublicP
       <|> withSigPrefix
         ( \vars ctx ->
             CFunDecl
@@ -326,6 +327,17 @@ contractDeclP =
         )
       <|> CFieldDecl
     <$> fieldDeclP
+
+-- | `fallback` and `constructor` are implicitly public; reject an explicit
+-- `public` modifier on them with a clear error rather than a confusing
+-- parser failure.
+rejectPublicOnImplicitlyPublicP :: Parser a
+rejectPublicOnImplicitlyPublicP = do
+  kw <- try $ do
+    _ <- keyword "public"
+    _ <- optional (keyword "payable")
+    ("fallback" <$ keyword "fallback") <|> ("constructor" <$ keyword "constructor")
+  fail (kw ++ " is implicitly public; remove the 'public' keyword")
 
 fieldDeclP :: Parser Field
 fieldDeclP = do

--- a/src/Solcore/Frontend/Pretty/SolcorePretty.hs
+++ b/src/Solcore/Frontend/Pretty/SolcorePretty.hs
@@ -268,8 +268,8 @@ instance (Pretty a) => Pretty (Body a) where
   ppr = vcat . map ppr
 
 instance (Pretty a) => Pretty (FunDef a) where
-  ppr (FunDef sig bd) =
-    ppr sig
+  ppr (FunDef isPub sig bd) =
+    ((if isPub then text "public " else empty) <> ppr sig)
       <+> lbrace
       $$ nest 3 (vcat (map ppr bd))
       $$ rbrace

--- a/src/Solcore/Frontend/Pretty/TreePretty.hs
+++ b/src/Solcore/Frontend/Pretty/TreePretty.hs
@@ -244,8 +244,8 @@ instance Pretty Body where
   ppr = vcat . map ppr
 
 instance Pretty FunDef where
-  ppr (FunDef sig bd) =
-    ppr sig
+  ppr (FunDef isPub sig bd) =
+    ((if isPub then text "public " else empty) <> ppr sig)
       <+> lbrace
       $$ nest 3 (vcat (map ppr bd))
       $$ rbrace

--- a/src/Solcore/Frontend/Syntax/Contract.hs
+++ b/src/Solcore/Frontend/Syntax/Contract.hs
@@ -220,7 +220,8 @@ data Field a
 
 data FunDef a
   = FunDef
-  { funSignature :: Signature a,
+  { funIsPublic :: Bool,
+    funSignature :: Signature a,
     funDefBody :: Body a
   }
   deriving (Eq, Ord, Show, Data, Typeable)

--- a/src/Solcore/Frontend/Syntax/NameResolution.hs
+++ b/src/Solcore/Frontend/Syntax/NameResolution.hs
@@ -116,7 +116,7 @@ topLevelTypeNames = concatMap collect
 topLevelTermNames :: [S.TopDecl] -> [Name]
 topLevelTermNames = concatMap collect
   where
-    collect (S.TFunDef (S.FunDef sig _)) = [S.sigName sig]
+    collect (S.TFunDef (S.FunDef _ sig _)) = [S.sigName sig]
     collect (S.TDataDef (S.DataTy tyCon _ cons)) =
       map (qualifiedConstructorName tyCon . S.constrName) cons
     collect _ = []
@@ -124,7 +124,7 @@ topLevelTermNames = concatMap collect
 contractTermNames :: [S.ContractDecl] -> [Name]
 contractTermNames = concatMap collect
   where
-    collect (S.CFunDecl (S.FunDef sig _)) = [S.sigName sig]
+    collect (S.CFunDecl (S.FunDef _ sig _)) = [S.sigName sig]
     collect (S.CDataDecl (S.DataTy tyCon _ cons)) =
       map (qualifiedConstructorName tyCon . S.constrName) cons
     collect _ = []
@@ -219,7 +219,7 @@ addContractDecl (S.CDataDecl (S.DataTy n _ cons)) =
     mapM_ (addDataCon n . S.constrName) cons
 addContractDecl (S.CFieldDecl (S.Field n _ _)) =
   addField n
-addContractDecl (S.CFunDecl (S.FunDef sig _)) =
+addContractDecl (S.CFunDecl (S.FunDef _ sig _)) =
   addFunctionName (S.sigName sig)
 addContractDecl _ = pure ()
 
@@ -338,7 +338,7 @@ instance Resolve S.PragmaStatus where
 instance Resolve S.FunDef where
   type Result S.FunDef = FunDef Name
 
-  resolve f@(S.FunDef (S.Signature vs ctx n ps rc mt pay) bds) =
+  resolve f@(S.FunDef isPub (S.Signature vs ctx n ps rc mt pay) bds) =
     do
       let ns = map tyconName vs
       withLocalCtx $ do
@@ -351,7 +351,7 @@ instance Resolve S.FunDef where
         bds' <- resolve bds `wrapError` f
         let vs' = map TVar ns
             sig = Signature vs' ctx' n ps' rc mt' pay
-        pure (FunDef sig bds')
+        pure (FunDef isPub sig bds')
 
 instance Resolve S.Stmt where
   type Result S.Stmt = Stmt Name
@@ -939,7 +939,7 @@ addTopDecl :: S.TopDecl -> Env -> Env
 addTopDecl (S.TContr (S.Contract n _ _)) env =
   addQualifiedModules n $
     env {typeEnv = Map.insert n TContract (typeEnv env)}
-addTopDecl (S.TFunDef (S.FunDef sig _)) env =
+addTopDecl (S.TFunDef (S.FunDef _ sig _)) env =
   addQualifiedModules (S.sigName sig) $
     env {scopeEnv = Map.insert (S.sigName sig) TFunction (scopeEnv env)}
 addTopDecl (S.TClassDef (S.Class _ _ n _ _ sigs)) env =

--- a/src/Solcore/Frontend/Syntax/SyntaxTree.hs
+++ b/src/Solcore/Frontend/Syntax/SyntaxTree.hs
@@ -219,7 +219,8 @@ data Field
 
 data FunDef
   = FunDef
-  { funSignature :: Signature,
+  { funIsPublic :: Bool,
+    funSignature :: Signature,
     funDefBody :: Body
   }
   deriving (Eq, Ord, Show, Data, Typeable)

--- a/src/Solcore/Frontend/TypeInference/Erase.hs
+++ b/src/Solcore/Frontend/TypeInference/Erase.hs
@@ -31,8 +31,8 @@ instance Erase (Instance Id) where
 instance Erase (FunDef Id) where
   type EraseRes (FunDef Id) = FunDef Name
 
-  erase (FunDef sig bd) =
-    FunDef (erase sig) (erase bd)
+  erase (FunDef p sig bd) =
+    FunDef p (erase sig) (erase bd)
 
 instance Erase (Signature Id) where
   type EraseRes (Signature Id) = Signature Name

--- a/src/Solcore/Frontend/TypeInference/InvokeGen.hs
+++ b/src/Solcore/Frontend/TypeInference/InvokeGen.hs
@@ -67,7 +67,7 @@ createInstance udt fd sch =
         ssargs = take (length args) (svs ++ sarg)
         scall = Return (Call Nothing fname ssargs)
         bdy = Match [discr] [([foldr1 ppair (spvs : sargs)], [scall])]
-        ifd = FunDef isig [bdy]
+        ifd = FunDef False isig [bdy]
         vs' = bv qs `union` bv [tupleArgTy, returnTy, selfTy] `union` bv ifd
         instd = Instance False vs' qs invokableName [tupleArgTy, returnTy] selfTy [ifd]
     info [">> Generated invokable instance:\n", pretty instd]

--- a/src/Solcore/Frontend/TypeInference/SccAnalysis.hs
+++ b/src/Solcore/Frontend/TypeInference/SccAnalysis.hs
@@ -124,7 +124,7 @@ instance Decl (Signature Name) where
   decl s = [sigName s]
 
 instance Decl (FunDef Name) where
-  decl (FunDef sig _) = decl sig
+  decl (FunDef _ sig _) = decl sig
 
 instance Decl (Contract Name) where
   decl (Contract n _ ds) = n : concatMap decl ds
@@ -217,7 +217,7 @@ instance Names (Signature Name) where
     names ctx `union` names ps `union` names mret
 
 instance Names (FunDef Name) where
-  names (FunDef sig bdy) =
+  names (FunDef _ sig bdy) =
     names sig `union` names bdy
 
 instance Names (Constructor Name) where

--- a/src/Solcore/Frontend/TypeInference/TcContract.hs
+++ b/src/Solcore/Frontend/TypeInference/TcContract.hs
@@ -243,9 +243,9 @@ extImportedFunDefs fds = do
     generateTopDeclsFor (zip typedFds (map snd nmschs))
 
 typedImportedFunDef :: FunDef Name -> TcM (FunDef Id)
-typedImportedFunDef (FunDef sig _body) = do
+typedImportedFunDef (FunDef p sig _body) = do
   params <- mapM tcParam (sigParams sig)
-  pure (FunDef sig {sigParams = params} [])
+  pure (FunDef p sig {sigParams = params} [])
 
 checkTopDecl :: TopDecl Name -> TcM ()
 checkTopDecl (TClassDef c) =
@@ -256,7 +256,7 @@ checkTopDecl (TDataDef dt) =
   checkDataType dt
 checkTopDecl (TSym s) =
   checkSynonym s
-checkTopDecl (TFunDef (FunDef sig _)) =
+checkTopDecl (TFunDef (FunDef _ sig _)) =
   extSignature sig
 checkTopDecl (TExportDecl _) = pure ()
 checkTopDecl _ = pure ()
@@ -291,15 +291,15 @@ initializeEnv (Contract _ _ cdecls) = do
   -- pre-registered; unannotated ones would produce a stale fresh type variable
   -- that could interfere with later inference.
   let fds =
-        [fd | CFunDecl fd@(FunDef sig _) <- cdecls, hasAnn sig]
-          ++ [fd | CMutualDecl ds <- cdecls, CFunDecl fd@(FunDef sig _) <- ds, hasAnn sig]
+        [fd | CFunDecl fd@(FunDef _ sig _) <- cdecls, hasAnn sig]
+          ++ [fd | CMutualDecl ds <- cdecls, CFunDecl fd@(FunDef _ sig _) <- ds, hasAnn sig]
   nmschs <- extractSignatures fds
   mapM_ (uncurry extEnv) nmschs
 
 checkDecl :: ContractDecl Name -> TcM ()
 checkDecl (CDataDecl dt) =
   checkDataType dt
-checkDecl (CFunDecl (FunDef sig _)) =
+checkDecl (CFunDecl (FunDef _ sig _)) =
   extSignature sig
 checkDecl (CFieldDecl fd) =
   tcField fd >> return ()
@@ -393,7 +393,7 @@ tcSig (sig, (Forall _ (_ :=> t))) =
 extractSignatures :: [FunDef Name] -> TcM [(Name, Scheme)]
 extractSignatures fds = forM fds extractSig
   where
-    extractSig (FunDef sig _)
+    extractSig (FunDef _ sig _)
       | hasAnn sig = do
           scheme <- annotatedScheme [] [] sig
           return (sigName sig, scheme)

--- a/src/Solcore/Frontend/TypeInference/TcModule.hs
+++ b/src/Solcore/Frontend/TypeInference/TcModule.hs
@@ -424,13 +424,15 @@ importedModuleLeafName (Name n) = Name n
 importedModuleLeafName (QualName _ n) = Name n
 
 typedForwardingWrapper :: Name -> FunDef Id -> FunDef Id
-typedForwardingWrapper qualifier (FunDef sig body)
+typedForwardingWrapper qualifier (FunDef isPub sig body)
   | originalName == Name "revertLit" =
       FunDef
+        isPub
         (sig {sigName = qualifiedName})
         body
   | otherwise =
       FunDef
+        isPub
         (sig {sigName = qualifiedName})
         [Return (Call Nothing targetId args)]
   where
@@ -440,8 +442,8 @@ typedForwardingWrapper qualifier (FunDef sig body)
     args = map (Var . paramName) (sigParams sig)
 
 typedAliasingWrapper :: Name -> FunDef Id -> FunDef Id
-typedAliasingWrapper aliasName (FunDef sig body) =
-  FunDef (sig {sigName = aliasName}) body
+typedAliasingWrapper aliasName (FunDef isPub sig body) =
+  FunDef isPub (sig {sigName = aliasName}) body
 
 typedSignatureType :: Signature Id -> Ty
 typedSignatureType sig =

--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -549,7 +549,7 @@ createClosureFun fn freeIds cdt args bdy ps ty =
         sig = Signature vs' ps0 fn args' False (Just retTy1) False
     bdy' <- createClosureBody cName cdt freeIds bdy
     sch <- generalize (ps0, ty')
-    pure (everywhere (mkT gen) $ FunDef sig bdy', sch)
+    pure (everywhere (mkT gen) $ FunDef False sig bdy', sch)
 
 closureTyCon :: DataTy -> TcM Ty
 closureTyCon (DataTy dn vs _) =
@@ -576,7 +576,7 @@ createClosureFreeFun fn args bdy ps ty =
     let (_, retTy1) = splitTy ty
         vs = bv ty `union` bv ps
         sig = Signature vs ps fn args False (Just retTy1) False
-    pure (everywhere (mkT gen) $ FunDef sig bdy)
+    pure (everywhere (mkT gen) $ FunDef False sig bdy)
 
 tcArgs :: [Param Name] -> TcM ([Param Id], [(Name, Scheme)], [Ty])
 tcArgs params =
@@ -622,7 +622,7 @@ tiArgs :: [Param Name] -> TcM ([Param Id], [(Name, Scheme)], [Ty])
 tiArgs args = unzip3 <$> mapM tiArg args
 
 tiFunDef :: FunDef Name -> TcM (FunDef Id, Scheme)
-tiFunDef d@(FunDef sig@(Signature _ _ n args _ _ _) bd) =
+tiFunDef d@(FunDef isPub sig@(Signature _ _ n args _ _ _) bd) =
   do
     info ["# tiFunDef:", pretty sig]
     -- getting fresh type variables for arguments
@@ -648,7 +648,7 @@ tiFunDef d@(FunDef sig@(Signature _ _ n args _ _ _) bd) =
       ambiguousTypeError sch sig
     -- elaborating the type signature
     sig' <- elabSignature [] sig sch
-    (fd', sch') <- withCurrentSubst (FunDef sig' bd1, sch)
+    (fd', sch') <- withCurrentSubst (FunDef isPub sig' bd1, sch)
     pure (markIntegerComptime fd', sch')
 
 ambiguityCheck :: Scheme -> TcM Bool
@@ -687,7 +687,7 @@ annotatedScheme vs' qs (Signature vs ps _ args _ rt _) =
     pure (Forall vs1 ((qs ++ ps) :=> (funtype ts t)))
 
 tcFunDef :: Bool -> [Tyvar] -> [Pred] -> FunDef Name -> TcM (FunDef Id, Scheme)
-tcFunDef incl vs' qs d@(FunDef sig@(Signature vs ps n _ _ _ _) _)
+tcFunDef incl vs' qs d@(FunDef isPub sig@(Signature vs ps n _ _ _ _) _)
   | hasAnn sig = do
       info ["\n# tcFunDef ", pretty d]
       let vars = vs `union` vs'
@@ -696,7 +696,7 @@ tcFunDef incl vs' qs d@(FunDef sig@(Signature vs ps n _ _ _ _) _)
       -- instantiate signatures in function definition
       sks <- mapM (const freshTyVar) vars
       let env = zip vars sks
-          FunDef sig1@(Signature _ ps1 _ args1 _ rt1 _) bd1 = everywhere (mkT (insts @Ty env)) d
+          FunDef _ sig1@(Signature _ ps1 _ args1 _ rt1 _) bd1 = everywhere (mkT (insts @Ty env)) d
           qs1 = everywhere (mkT (insts @Ty env)) qs
       -- checking if all constraints have a respective class and are well kinded
       checkConstraints ps `wrapError` d
@@ -738,7 +738,7 @@ tcFunDef incl vs' qs d@(FunDef sig@(Signature vs ps n _ _ _ _) _)
         subsCheck sig inf ann `wrapError` d
       -- elaborating function body
       let ann' = if changeTy then inf else ann
-      fdt <- elabFunDef vs' sig1 bd1' inf ann' `wrapError` d
+      fdt <- elabFunDef isPub vs' sig1 bd1' inf ann' `wrapError` d
       (fd', ann'') <- withCurrentSubst (fdt, ann')
       pure (markIntegerComptime fd', ann'')
   | otherwise = tiFunDef d
@@ -746,19 +746,20 @@ tcFunDef incl vs' qs d@(FunDef sig@(Signature vs ps n _ _ _ _) _)
 -- elaborating function definition
 
 elabFunDef ::
+  Bool -> -- visibility flag (public)
   [Tyvar] -> -- additional variables which came from outer scope
   Signature Name -> -- original function signature
   Body Id -> -- elaborated function body (with fresh variables)
   Scheme -> -- function infered type
   Scheme -> -- function annotated type
   TcM (FunDef Id)
-elabFunDef vs sig bdy (Forall _ (_ :=> tinf)) ann@(Forall _ (_ :=> tann)) =
+elabFunDef isPub vs sig bdy (Forall _ (_ :=> tinf)) ann@(Forall _ (_ :=> tann)) =
   do
     let tinf' = everywhere (mkT toMeta) tinf
         tann' = everywhere (mkT toMeta) tann
     s <- unify tinf' tann'
     sig2 <- elabSignature vs sig ann
-    let fd2 = everywhere (mkT (apply @Ty s)) (FunDef sig2 bdy)
+    let fd2 = everywhere (mkT (apply @Ty s)) (FunDef isPub sig2 bdy)
     pure (everywhere (mkT gen) fd2)
 
 toMeta :: Ty -> Ty
@@ -1058,8 +1059,8 @@ schemeFromSignature sig =
     unwords ["Invalid instance member signature (missing return type):", pretty sig]
 
 updateSignature :: [Tyvar] -> Name -> FunDef Id -> FunDef Id
-updateSignature vs' c (FunDef (Signature vs ps n args rc rt pay) bd) =
-  FunDef (Signature (vs \\ vs') ps (QualName c (pretty n)) args rc rt pay) bd
+updateSignature vs' c (FunDef p (Signature vs ps n args rc rt pay) bd) =
+  FunDef p (Signature (vs \\ vs') ps (QualName c (pretty n)) args rc rt pay) bd
 
 checkDeferedConstraints :: [(FunDef Id, [Pred])] -> TcM ()
 checkDeferedConstraints = mapM_ checkDeferedConstraint
@@ -1238,7 +1239,7 @@ checkCoverage cn ts t =
         )
 
 checkMethod :: Pred -> FunDef Name -> TcM ()
-checkMethod ih@(InCls n _ _) d@(FunDef sig _) =
+checkMethod ih@(InCls n _ _) d@(FunDef _ sig _) =
   do
     -- checking if the signature is fully annotated
     fullSignature sig
@@ -1268,7 +1269,7 @@ fullSignature sig =
     (throwError $ unlines ["Class and instance methods must have complete type signatures:", pretty sig])
 
 requireAnnotations :: FunDef Name -> TcM ()
-requireAnnotations (FunDef sig _) =
+requireAnnotations (FunDef _ sig _) =
   unless (isFullyAnnotated sig) $
     tcmError $
       unlines

--- a/src/Solcore/Frontend/TypeInference/TcSubst.hs
+++ b/src/Solcore/Frontend/TypeInference/TcSubst.hs
@@ -146,13 +146,13 @@ instance (HasType a) => HasType (Param a) where
   bv (Untyped _ i) = bv i
 
 instance (HasType a) => HasType (FunDef a) where
-  apply s (FunDef sig bd) =
-    FunDef (apply s sig) (apply s bd)
-  fv (FunDef sig bd) =
+  apply s (FunDef p sig bd) =
+    FunDef p (apply s sig) (apply s bd)
+  fv (FunDef _ sig bd) =
     fv sig `union` fv bd
-  mv (FunDef sig bd) =
+  mv (FunDef _ sig bd) =
     mv sig `union` mv bd
-  bv (FunDef sig bd) =
+  bv (FunDef _ sig bd) =
     bv sig `union` bv bd
 
 instance (HasType a) => HasType (Instance a) where

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -315,6 +315,8 @@ cases =
       runTestForFile "EvenOdd.solc" caseFolder,
       runTestExpectingFailure "fallback-with-args.solc" caseFolder,
       runTestExpectingFailure "fallback-with-return.solc" caseFolder,
+      runTestExpectingFailure "public-fallback.solc" caseFolder,
+      runTestExpectingFailure "public-constructor.solc" caseFolder,
       runTestExpectingFailure "Filter.solc" caseFolder,
       runTestForFile "foo-class.solc" caseFolder,
       runTestForFile "Foo.solc" caseFolder,

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -317,6 +317,7 @@ cases =
       runTestExpectingFailure "fallback-with-return.solc" caseFolder,
       runTestExpectingFailure "public-fallback.solc" caseFolder,
       runTestExpectingFailure "public-constructor.solc" caseFolder,
+      runTestExpectingFailure "public-top-level-function.solc" caseFolder,
       runTestExpectingFailure "Filter.solc" caseFolder,
       runTestForFile "foo-class.solc" caseFolder,
       runTestForFile "Foo.solc" caseFolder,

--- a/test/ModuleTypeCheckTests.hs
+++ b/test/ModuleTypeCheckTests.hs
@@ -96,7 +96,8 @@ funDecl :: String -> TopDecl Name
 funDecl funName =
   TFunDef
     FunDef
-      { funSignature =
+      { funIsPublic = False,
+        funSignature =
           wordSignature funName,
         funDefBody = [Return (Lit (IntLit 0))]
       }
@@ -109,7 +110,8 @@ badImportedFun :: TopDecl Name
 badImportedFun =
   TFunDef
     FunDef
-      { funSignature = wordSignature "badImported",
+      { funIsPublic = False,
+        funSignature = wordSignature "badImported",
         funDefBody = [Return (Var (Name "missing"))]
       }
 
@@ -117,7 +119,8 @@ usesImportedFun :: TopDecl Name
 usesImportedFun =
   TFunDef
     FunDef
-      { funSignature = wordSignature "usesImported",
+      { funIsPublic = False,
+        funSignature = wordSignature "usesImported",
         funDefBody = [Return (Call Nothing (Name "badImported") [])]
       }
 

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -621,5 +621,12 @@ declTests =
                       )
                   ]
               )
-          )
+          ),
+      -- `public` is only meaningful inside a contract; reject it elsewhere.
+      testCase "top-level public function fails" $
+        parseFails topDeclP "public function get() -> word { return 0; }",
+      testCase "public instance method fails" $
+        parseFails
+          topDeclP
+          "instance word:Eq { public function eq(x:word, y:word) -> bool { return x == y; } }"
     ]

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -379,6 +379,7 @@ declTests =
           "function answer() -> word { return 42; }"
           ( TFunDef
               ( FunDef
+                  False
                   (Signature [] [] "answer" [] False (Just word) False)
                   [Return (lit 42)]
               )
@@ -389,6 +390,7 @@ declTests =
           "function id(x:word) -> word { return x; }"
           ( TFunDef
               ( FunDef
+                  False
                   (Signature [] [] "id" [Typed False "x" word] False (Just word) False)
                   [Return (var "x")]
               )
@@ -399,6 +401,7 @@ declTests =
           "function answer() -> word { 42 }"
           ( TFunDef
               ( FunDef
+                  False
                   (Signature [] [] "answer" [] False (Just word) False)
                   [Return (lit 42)]
               )
@@ -409,6 +412,7 @@ declTests =
           "forall a. function id(x:a) -> a { return x; }"
           ( TFunDef
               ( FunDef
+                  False
                   ( Signature
                       [TyCon "a" []]
                       []
@@ -427,6 +431,7 @@ declTests =
           "forall a. a:Eq => function eqSelf(x:a) -> bool { return x == x; }"
           ( TFunDef
               ( FunDef
+                  False
                   ( Signature
                       [TyCon "a" []]
                       [InCls "Eq" (TyCon "a" []) []]
@@ -533,6 +538,7 @@ declTests =
                   []
                   word
                   [ FunDef
+                      False
                       (Signature [] [] "eq" [Typed False "x" word, Typed False "y" word] False (Just bool) False)
                       [Return (ExpEE (var "x") (var "y"))]
                   ]
@@ -551,6 +557,7 @@ declTests =
                   []
                   (TyCon "pair" [TyCon "a" [], TyCon "a" []])
                   [ FunDef
+                      False
                       ( Signature
                           []
                           []
@@ -591,6 +598,24 @@ declTests =
                   []
                   [ CFunDecl
                       ( FunDef
+                          False
+                          (Signature [] [] "get" [] False (Just word) False)
+                          [Return (var "x")]
+                      )
+                  ]
+              )
+          ),
+      testCase "contract with public function" $
+        parsesAs
+          topDeclP
+          "contract C { public function get() -> word { return x; } }"
+          ( TContr
+              ( Contract
+                  "C"
+                  []
+                  [ CFunDecl
+                      ( FunDef
+                          True
                           (Signature [] [] "get" [] False (Just word) False)
                           [Return (var "x")]
                       )

--- a/test/examples/Convertible.solc
+++ b/test/examples/Convertible.solc
@@ -109,7 +109,7 @@ instance Pair(uint16,Proxy(uint256)):Convertible(uint256) {
 
 contract Bar {
 
-function main() -> word {
+public function main() -> word {
   let x = Unit;
   let y : word = convert(x);
   return y;

--- a/test/examples/cases/Add1.solc
+++ b/test/examples/cases/Add1.solc
@@ -1,5 +1,5 @@
 contract Add1 {
-  function main() -> word {
+  public function main() -> word {
     let res: word;
     assembly {
        res := add(40, 2)

--- a/test/examples/cases/Compose.solc
+++ b/test/examples/cases/Compose.solc
@@ -1,7 +1,7 @@
 contract Compose {
-  function id(x : word) -> word { return x; }
+  public function id(x : word) -> word { return x; }
 
-  function main() -> word {
+  public function main() -> word {
     return id(id(42));
   }
 }

--- a/test/examples/cases/Compose3.solc
+++ b/test/examples/cases/Compose3.solc
@@ -1,11 +1,11 @@
 contract Compose {
-  forall a . function id(x : a) -> a { return x; }
+  forall a . public function id(x : a) -> a { return x; }
 
-  function apply1(f : (word) -> word, a : word) -> word { return f(a); }
+  public function apply1(f : (word) -> word, a : word) -> word { return f(a); }
 
-  function idThenId(x : word) -> word { return id(id(x)); }
+  public function idThenId(x : word) -> word { return id(id(x)); }
 
-  function main() -> word {
+  public function main() -> word {
     return apply1(idThenId, 42);
   }
 }

--- a/test/examples/cases/CondExp.solc
+++ b/test/examples/cases/CondExp.solc
@@ -1,5 +1,5 @@
 contract CondExp {
-   function main() -> word {
+   public function main() -> word {
      return
        if if true then false else true
        then if false then 1 else 2

--- a/test/examples/cases/EitherModule.solc
+++ b/test/examples/cases/EitherModule.solc
@@ -2,7 +2,7 @@ contract EitherModule {
   data Either(a,b) = Left(a) | Right(b);
   data List(a) = Nil | Cons(a,List(a));
 
-  function lefts(xs : List(Either(word,word))) -> List(word) {
+  public function lefts(xs : List(Either(word,word))) -> List(word) {
     match xs {
     | List.Nil => return List.Nil ;
     | List.Cons(y,ys) =>
@@ -13,5 +13,5 @@ contract EitherModule {
     }
   }
 
-  function main() -> word { return 0; }
+  public function main() -> word { return 0; }
 }

--- a/test/examples/cases/Enum.solc
+++ b/test/examples/cases/Enum.solc
@@ -15,7 +15,7 @@ instance Food : Enum {
 }
 
 contract Food {
-  function main() -> word {
+  public function main() -> word {
     return Enum.fromEnum(Food.Beans);
   }
 }

--- a/test/examples/cases/EvenOdd.solc
+++ b/test/examples/cases/EvenOdd.solc
@@ -2,19 +2,19 @@ contract EvenOdd {
   data Nat = Zero | Succ(Nat);
   data Bool = False | True;
 
-  function even (n : Nat) -> Bool {
+  public function even (n : Nat) -> Bool {
     match n {
     | Nat.Zero => return Bool.True;
     | Nat.Succ(m) => return odd(m);
     }
   }
 
-  function odd(n : Nat) -> Bool {
+  public function odd(n : Nat) -> Bool {
     match n {
     | Nat.Zero => return Bool.False;
     | Nat.Succ(m) => return even(m);
     }
   }
 
-  function main() -> word { return 0; }
+  public function main() -> word { return 0; }
 }

--- a/test/examples/cases/GetSet.solc
+++ b/test/examples/cases/GetSet.solc
@@ -1,11 +1,11 @@
 contract GetSet {
   value : Word ;
 
-  function setValue (x) {
+  public function setValue (x) {
     value = x ;
   }
 
-  function getValue () {
+  public function getValue () {
     return value ;
   }
 }

--- a/test/examples/cases/GoodInstance.solc
+++ b/test/examples/cases/GoodInstance.solc
@@ -27,5 +27,5 @@ instance Bool : Enum {
 }
 
 contract GoodInstance {
-  function main() -> Word { return fromEnum(Bool.True);}
+  public function main() -> Word { return fromEnum(Bool.True);}
 }

--- a/test/examples/cases/Id.solc
+++ b/test/examples/cases/Id.solc
@@ -3,7 +3,7 @@ function id (x : word) -> word {
 }
 
 contract Id {
-  function main () -> word {
+  public function main () -> word {
     return id(0);
   }
 }

--- a/test/examples/cases/ListModule.solc
+++ b/test/examples/cases/ListModule.solc
@@ -3,7 +3,7 @@ contract ListModule {
   data Bool = True | False;
 
 
-  forall a b c . function zipWith (f : (a,b) -> c,xs : List(a),ys : List(b)) -> List(c) {
+  forall a b c . public function zipWith (f : (a,b) -> c,xs : List(a),ys : List(b)) -> List(c) {
     match xs, ys {
     | List.Nil, List.Nil => return List.Nil ;
     | List.Cons(x1,xs1), List.Cons(y1,ys1) =>
@@ -12,7 +12,7 @@ contract ListModule {
     }
   }
 
-  forall a b . function foldr(f : (a,b) -> b, v : b, xs : List(a)) -> b {
+  forall a b . public function foldr(f : (a,b) -> b, v : b, xs : List(a)) -> b {
     match xs {
     | List.Nil => return v;
     | List.Cons(y,ys) =>
@@ -20,7 +20,7 @@ contract ListModule {
     }
   }
 
-  function main () -> word {
+  public function main () -> word {
     return 0;
   }
 }

--- a/test/examples/cases/Logic.solc
+++ b/test/examples/cases/Logic.solc
@@ -1,21 +1,21 @@
 contract Logic {
   data Bool = True | False;
 
-  function not (x : Bool) -> Bool {
+  public function not (x : Bool) -> Bool {
     match x {
     | Bool.True => return Bool.False ;
     | Bool.False => return Bool.True ;
     }
   }
 
-  function and(x : Bool, y : Bool) -> Bool {
+  public function and(x : Bool, y : Bool) -> Bool {
     match x, y {
     | Bool.False, _ => return Bool.False ;
     | Bool.True , _ => return y ;
     }
   }
 
-  function and1 (x : Bool, y : Bool) -> Bool {
+  public function and1 (x : Bool, y : Bool) -> Bool {
     match x, y {
     | Bool.False, Bool.False => return Bool.False ;
     | Bool.True , Bool.False => return Bool.False;
@@ -24,12 +24,12 @@ contract Logic {
     }
   }
 
-  function elim (f : word, g : word, x : Bool) -> word {
+  public function elim (f : word, g : word, x : Bool) -> word {
     match x {
     | Bool.True => return f;
     | Bool.False => return g;
     }
   }
 
-  function main() -> word { return 0; }
+  public function main() -> word { return 0; }
 }

--- a/test/examples/cases/MatchCall.solc
+++ b/test/examples/cases/MatchCall.solc
@@ -1,11 +1,11 @@
 data Bool = False | True;
 
 contract MatchCall {
-  function f() -> Bool {
+  public function f() -> Bool {
     return Bool.True;
   }
 
-  function main() -> word {
+  public function main() -> word {
     match f() {
      | Bool.True => return 42;
      | Bool.False => return 0;

--- a/test/examples/cases/Mutuals.solc
+++ b/test/examples/cases/Mutuals.solc
@@ -1,8 +1,8 @@
 contract Mutual {
-   function main () -> word {
+   public function main () -> word {
       return f();
    }
-   function f () -> word {
+   public function f () -> word {
       return 42;
    }
 }

--- a/test/examples/cases/NegPair.solc
+++ b/test/examples/cases/NegPair.solc
@@ -35,19 +35,19 @@ forall a b . a : Neg, b : Neg => instance (a,b):Neg {
 
 contract NegPair {
 
- function bnot(x : B) -> B {
+ public function bnot(x : B) -> B {
    match x {
      | B.T => return B.F;
      | B.F => return B.T;
    }
 }
 
- function fromB(b : B) -> word {
+ public function fromB(b : B) -> word {
   match b  {
     | B.F => return 0;
     | B.T => return 1;
   }
 }
 
- function main() -> word { return  fromB(fst(Neg.neg((B.F,B.T)))); }
+ public function main() -> word { return  fromB(fst(Neg.neg((B.F,B.T)))); }
 }

--- a/test/examples/cases/Option.solc
+++ b/test/examples/cases/Option.solc
@@ -1,7 +1,7 @@
 contract Option {
   data Option(a) = None | Some(a);
 
-  function join(mmx : Option(Option(word))) -> Option(word) {
+  public function join(mmx : Option(Option(word))) -> Option(word) {
     match mmx {
     | Option.None => return Option.None;
     | Option.Some(Option.Some(x)) => return Option.Some(x);
@@ -9,5 +9,5 @@ contract Option {
     }
   }
 
-  function main() -> word { return 0; }
+  public function main() -> word { return 0; }
  }

--- a/test/examples/cases/SimpleInvoke.solc
+++ b/test/examples/cases/SimpleInvoke.solc
@@ -11,7 +11,7 @@ instance LambdaTy0(a) : invokable (a, a) {
   }
 }
 contract SimpleLambda {
-   function f () {
+   public function f () {
       let n = LambdaTy0 ;
       return invokable.invoke(n, 0);
    }

--- a/test/examples/cases/SimpleLambda.solc
+++ b/test/examples/cases/SimpleLambda.solc
@@ -7,7 +7,7 @@ function addWord(x : word, y : word) -> word {
 }
 
 contract SimpleLambda{
-  function f (z : word) -> word {
+  public function f (z : word) -> word {
     let n = lam (x : word, y : word) {
       return addWord(x,addWord(y,1));
     } ;
@@ -16,7 +16,7 @@ contract SimpleLambda{
     } ;
     return m(n(1,0));
   }
-  function main() -> word {
+  public function main() -> word {
     return f(40);
   }
 }

--- a/test/examples/cases/add-moritz.solc
+++ b/test/examples/cases/add-moritz.solc
@@ -61,7 +61,7 @@ function fun(a : (B, B), b : (B, B)) -> (B, B) { //  -> c
 
 contract Compose {
 
-  function main() -> word {
+  public function main() -> word {
     let res = fun ((B.T, B.T, B.F), (B.F, B.F, B.T));
     match res {
       | (r1, r2, r3) => return Typedef.rep(r1);

--- a/test/examples/cases/app.solc
+++ b/test/examples/cases/app.solc
@@ -15,7 +15,7 @@ function foo() -> word {
 }
 
 contract C {
-  function main () -> word {
+  public function main () -> word {
     return foo();
   }
 }

--- a/test/examples/cases/array.solc
+++ b/test/examples/cases/array.solc
@@ -105,7 +105,7 @@ forall size elem . size : ToWord, elem:MemoryType => instance memory(array(size,
 
 contract Array {
 
-    function main() -> word {
+    public function main() -> word {
         let arr : memory(array(Succ(Succ(Succ(Succ(Zero)))), word)) = memory(42);  // = (1,2,3,4,5,6,7,8,9,10);
         IndexAccessible.set(arr, 3, 33);
 

--- a/test/examples/cases/asm-assign-no-return.solc
+++ b/test/examples/cases/asm-assign-no-return.solc
@@ -1,6 +1,6 @@
 // mstore does not return a value, so it cannot be assigned.
 contract Test {
-  function main() {
+  public function main() {
     let x : word;
     assembly {
       x := mstore(1, 1)

--- a/test/examples/cases/asm-let-no-return.solc
+++ b/test/examples/cases/asm-let-no-return.solc
@@ -1,6 +1,6 @@
 // mstore does not return a value, so it cannot initialize a `let`.
 contract Test {
-  function main() {
+  public function main() {
     assembly {
       let x := mstore(1, 1)
     }

--- a/test/examples/cases/bool-elim.solc
+++ b/test/examples/cases/bool-elim.solc
@@ -8,7 +8,7 @@ data Bool = False | True;
   }
 
 contract Second {
-  function main() -> word {
+  public function main() -> word {
     second(Bool.True, 42)
   }
 }

--- a/test/examples/cases/catch-all.solc
+++ b/test/examples/cases/catch-all.solc
@@ -1,14 +1,14 @@
 data Bool = False | True;
 
 contract CatchAll {
-    function catchAll(x : Bool, y : Bool) -> Bool{
+    public function catchAll(x : Bool, y : Bool) -> Bool{
       match x, y {
       | Bool.True, Bool.True => return Bool.True;
       | z, w      => return z;
       }
     }
 
-  function main() -> Bool {
+  public function main() -> Bool {
     catchAll(Bool.True, Bool.False)
   }
 }

--- a/test/examples/cases/closure-free-var-local.solc
+++ b/test/examples/cases/closure-free-var-local.solc
@@ -7,7 +7,7 @@ function test() -> word {
 }
 
 contract C {
-    function main() -> word {
+    public function main() -> word {
         return test();
     }
 }

--- a/test/examples/cases/closure-free-var-std.solc
+++ b/test/examples/cases/closure-free-var-std.solc
@@ -4,11 +4,11 @@ pragma no-coverage-condition ;
 pragma no-bounded-variable-condition ;
 
 contract Bug {
-    function main() -> word {
+    public function main() -> word {
         return makeClosure(42);
     }
 
-    function makeClosure(e : word) -> word {
+    public function makeClosure(e : word) -> word {
         let f = lam (x : word) {
             return e + x;  // Uses Add.add typeclass method
         };

--- a/test/examples/cases/closure-free-var.solc
+++ b/test/examples/cases/closure-free-var.solc
@@ -15,11 +15,11 @@ instance word:Add {
 }
 
 contract Bug {
-    function main() -> word {
+    public function main() -> word {
         return makeClosure(42);
     }
 
-    function makeClosure(e : word) -> word {
+    public function makeClosure(e : word) -> word {
         let f = lam (x : word) {
             return Add.add(x,e);  // this crashes
 	    // return addW(e,x);  // this works

--- a/test/examples/cases/comparisons.solc
+++ b/test/examples/cases/comparisons.solc
@@ -13,5 +13,5 @@ function f(x: word, y:word) -> bool {
 }
 
 contract Comparisons {
-  function main() -> bool { return f(0,1); }
+  public function main() -> bool { return f(0,1); }
 }

--- a/test/examples/cases/complexproxy.solc
+++ b/test/examples/cases/complexproxy.solc
@@ -29,7 +29,7 @@ forall t. function morefun(p:Proxy(t)) -> word {
 }
 
 contract TestMemoryType {
-  function main() -> word {
+  public function main() -> word {
     return BaseMemoryType.memorySize(Proxy:Proxy( (word,word) ));
   }
 }

--- a/test/examples/cases/compose_desugared.solc
+++ b/test/examples/cases/compose_desugared.solc
@@ -37,7 +37,7 @@ forall a . instance t_id3(a) : invokable(a,a) {
 }
 
 contract Foo {
-  function main() -> word {
+  public function main() -> word {
     let f = compose(t_id3, t_id3);
     return invokable.invoke(f, 0);
   }

--- a/test/examples/cases/const-array.solc
+++ b/test/examples/cases/const-array.solc
@@ -102,7 +102,7 @@ forall size elem . size : ToWord, elem:MemoryType => instance memory(array(size,
 
 contract Array {
 
-    function main() {
+    public function main() {
         let arr : memory(array(Succ(Succ(Succ(Succ(Zero)))), word)) = memory(42);  // = (1,2,3,4,5,6,7,8,9,10);
         IndexAccessible.set(arr, 4, 33);
 

--- a/test/examples/cases/const.solc
+++ b/test/examples/cases/const.solc
@@ -3,7 +3,7 @@ function constApplied(x : word, y : word) -> word {
 }
 
 contract Foo {
-  function main () -> word {
+  public function main () -> word {
     return constApplied(0,1);
   }
 }

--- a/test/examples/cases/copytomem.solc
+++ b/test/examples/cases/copytomem.solc
@@ -7,7 +7,7 @@ function copyToMem(reader:MemoryWordReader, dst:word, cnt: word) -> () {
 }
 
 contract Main {
-  function main() -> () {
+  public function main() -> () {
     let r : MemoryWordReader = MemoryWordReader(42);
     copyToMem(r, 0, 32);
   }

--- a/test/examples/cases/cyclical-defs-inferred.solc
+++ b/test/examples/cases/cyclical-defs-inferred.solc
@@ -6,7 +6,7 @@ function bar(x : word) -> word {
 }
 
 contract C {
-  function main() -> word {
+  public function main() -> word {
     return foo(1);
   }
 }

--- a/test/examples/cases/cyclical-defs.solc
+++ b/test/examples/cases/cyclical-defs.solc
@@ -6,13 +6,13 @@ function bar(x : word) -> word {
 }
 
 contract C {
-  function m(x : word) -> word {
+  public function m(x : word) -> word {
     return n(x);
   }
-  function n(x : word) -> word {
+  public function n(x : word) -> word {
     return m(x);
   }
-  function main() -> word {
+  public function main() -> word {
     return m(1);
   }
 }

--- a/test/examples/cases/dispatch.solc
+++ b/test/examples/cases/dispatch.solc
@@ -253,13 +253,13 @@ instance C_Add2_Selector:Selector {
 // transform
 
 contract C {
-  function add2(x : word, y : word) -> word {
+  public function add2(x : word, y : word) -> word {
     let ret : word;
     assembly { ret := add(x,y) }
     return ret;
   }
 
-  function main() -> word {
+  public function main() -> word {
     let c = Contract(
       Method(C_Add2_Selector, Proxy : Proxy((word,word)), Proxy : Proxy(word), add2),
       Fallback(Proxy : Proxy(()),Proxy : Proxy(()),revert_handler)

--- a/test/examples/cases/false-redundant-warning.solc
+++ b/test/examples/cases/false-redundant-warning.solc
@@ -9,7 +9,7 @@ function test(x : Bool, y : Bool) -> Bool {
 }
 
 contract FalseRedundantWarning {
-  function main() -> Bool {
+  public function main() -> Bool {
     test(Bool.False, Bool.True)
   }
 }

--- a/test/examples/cases/field-access.solc
+++ b/test/examples/cases/field-access.solc
@@ -3,16 +3,16 @@ import std.{*};
 contract PoC {
     field : word;
 
-    function set_x(b: bool) -> bool {
+    public function set_x(b: bool) -> bool {
         field = b;   // BUG: `word` shouldn't be unified with `bool`.
         return b;
     }
 
-    function init(foo: bool) -> () {
+    public function init(foo: bool) -> () {
        field = 2;
     }
 
-    function main () -> () {
+    public function main () -> () {
 
     }
 }

--- a/test/examples/cases/field-helper-cxt-collision.solc
+++ b/test/examples/cases/field-helper-cxt-collision.solc
@@ -8,7 +8,7 @@ data FooCxt = FooCxt;
 contract Foo {
   x: word;
 
-  function get() -> word {
+  public function get() -> word {
     return x;
   }
 }

--- a/test/examples/cases/field-name-error.solc
+++ b/test/examples/cases/field-name-error.solc
@@ -6,7 +6,7 @@ pragma no-bounded-variable-condition ;
 contract PoC {
     x : word;
 
-    function main () -> word {
+    public function main () -> word {
       return 0;
     }
 }

--- a/test/examples/cases/for-body-shadow.solc
+++ b/test/examples/cases/for-body-shadow.solc
@@ -1,7 +1,7 @@
 import std.{Num,Add,Sub,Eq,Ord,Bounded,Typedef,le};
 
 contract C {
-    function main() -> word {
+    public function main() -> word {
         let x : word = 100;
         let i : word = 0;
         let s : word = 0;

--- a/test/examples/cases/for-init-shadow.solc
+++ b/test/examples/cases/for-init-shadow.solc
@@ -1,7 +1,7 @@
 import std.{Num,Add,Sub,Eq,Ord,Bounded,Typedef,le};
 
 contract Prefor {
-    function main() -> word {
+    public function main() -> word {
         let i : word = 100;
         let s : word = 0;
         for(let i=1;i<=10;i=i+1) { s = s + i; }

--- a/test/examples/cases/for-inner-block.solc
+++ b/test/examples/cases/for-inner-block.solc
@@ -1,6 +1,6 @@
 import std.{lt,Ord,Add,Sub,Bounded,Num,Eq,Typedef};
 contract ForInner {
-  function main() -> word {
+  public function main() -> word {
       let result : word = 0;
       for (let height : word = 0; height < 7; height = height + 1) {
 	      if (true) { result = height;  } else {}

--- a/test/examples/cases/for-let-post.solc
+++ b/test/examples/cases/for-let-post.solc
@@ -1,7 +1,7 @@
 import std.{Num,Add,Sub,Eq,Ord,Bounded,Typedef,le};
 
 contract C {
-    function main() -> word {
+    public function main() -> word {
         let i : word = 0;
         let s : word = 99;
         for(i=0;i<=0;let j=1) { s = j; i = i + 1; }

--- a/test/examples/cases/for-let.solc
+++ b/test/examples/cases/for-let.solc
@@ -1,7 +1,7 @@
 import std.{Num,Add,Sub,Eq,Ord,Bounded,Typedef,le};
 
 contract Prefor {
-    function main() -> word {
+    public function main() -> word {
         let s : word = 0;
         for(let i=1;i<=10;i=i+1) { s = s + i;}
 

--- a/test/examples/cases/for-loop.solc
+++ b/test/examples/cases/for-loop.solc
@@ -1,7 +1,7 @@
 import std.{Num,Add,Sub,Eq,Ord,Bounded,Typedef,le};
 
 contract Prefor {
-    function main() -> word {
+    public function main() -> word {
         let i:word;
         let s : word = 0;
         for(i=1;i<=10;i=i+1) { s = s + i;}

--- a/test/examples/cases/fresh-pat-arg-synonym.solc
+++ b/test/examples/cases/fresh-pat-arg-synonym.solc
@@ -4,7 +4,7 @@ function f(x:W) -> W { x }
 
 contract C {
 
-  function main () -> word {
+  public function main () -> word {
     return f(42);
   }
 }

--- a/test/examples/cases/fresh-pat-arg.solc
+++ b/test/examples/cases/fresh-pat-arg.solc
@@ -3,5 +3,5 @@ function g(x:word) -> word { x }
 forall a. function h(x:a) -> a { x }
 
 contract C {
-  function main() -> word { g(h(42)) }
+  public function main() -> word { g(h(42)) }
 }

--- a/test/examples/cases/fresh-variable-shadowing.solc
+++ b/test/examples/cases/fresh-variable-shadowing.solc
@@ -8,7 +8,7 @@ function test(v0 : Bool, p : Bool) -> Bool {
 }
 
 contract FreshVariableShadowing {
-  function main() -> Bool {
+  public function main() -> Bool {
     test(Bool.True, Bool.False)
   }
 }

--- a/test/examples/cases/if-examples.solc
+++ b/test/examples/cases/if-examples.solc
@@ -37,7 +37,7 @@ function foo(x : word) -> bool {
 
 
 contract IfExamples {
-	 function main() -> word {
+	 public function main() -> word {
 	   return (if not(foo(42)) then 0 else 1);
 	 }
 }

--- a/test/examples/cases/import-std.solc
+++ b/test/examples/cases/import-std.solc
@@ -4,7 +4,7 @@ pragma no-coverage-condition ;
 pragma no-bounded-variable-condition ;
 
 contract Test {
-  function main() -> word {
+  public function main() -> word {
     return std.addWord(21, 21);
   }
 }

--- a/test/examples/cases/inc-closure.solc
+++ b/test/examples/cases/inc-closure.solc
@@ -11,7 +11,7 @@ function inc(x : word) -> word {
 
 contract Foo {
 
-  function main () -> word {
+  public function main () -> word {
     return inc(0);
   }  
 }

--- a/test/examples/cases/instance-synonym-int.solc
+++ b/test/examples/cases/instance-synonym-int.solc
@@ -11,7 +11,7 @@ instance word : FromWord {
 
 contract C {
 
-  function main () -> W {
+  public function main () -> W {
     let r : W = FromWord.fromWord(42);
     return r;
   }

--- a/test/examples/cases/instance-synonym.solc
+++ b/test/examples/cases/instance-synonym.solc
@@ -11,7 +11,7 @@ instance W:IdTy {
 }
 
 contract C {
-  function main() -> word {
+  public function main() -> word {
     return IdTy.id(42);
   }
 }

--- a/test/examples/cases/join.solc
+++ b/test/examples/cases/join.solc
@@ -2,14 +2,14 @@ contract Option {
   data Option(a) = None | Some(a);
   data Bool = False | True;
 
-  function maybe(n : word, o : Option(word)) -> word {
+  public function maybe(n : word, o : Option(word)) -> word {
     match o {
       | Option.None => return n;
       | Option.Some(x) => return x;
     }
   }
 
-  function join(mmx : Option(Option(word))) -> Option(word) {
+  public function join(mmx : Option(Option(word))) -> Option(word) {
     let result = Option.None;
     match mmx {
       | Option.Some(Option.Some(x)) => result = Option.Some(x);
@@ -20,7 +20,7 @@ contract Option {
     return result;
   }
 
-  function main() -> word {
+  public function main() -> word {
     return maybe(0, join(Option.Some(Option.Some(0))));
   }
 }

--- a/test/examples/cases/joinErr.solc
+++ b/test/examples/cases/joinErr.solc
@@ -2,14 +2,14 @@ contract Option {
   data Option(a) = None | Some(a);
   data Bool = False | True;
 
-  function maybe(n : word, o : Option(word)) -> word {
+  public function maybe(n : word, o : Option(word)) -> word {
     match o {
       | Option.None => return n;
       | Option.Some(x) => return x;
     }
   }
 
-  function join(mmx : Option(Option(word))) -> Option(word) {
+  public function join(mmx : Option(Option(word))) -> Option(word) {
     let result = Option.None;
     match mmx {
       | Option.Some(Option.Some(x)) => result = Option.Some(x);
@@ -19,7 +19,7 @@ contract Option {
   }
 
 
-  function main() -> word {
+  public function main() -> word {
     return maybe(0, join(Option.Some(Option.Some(Bool.False))));
   }
 }

--- a/test/examples/cases/ltimp.solc
+++ b/test/examples/cases/ltimp.solc
@@ -1,5 +1,5 @@
 import ltproxy.{ltproxy};
 
 contract LtImp {
-  function main() -> bool { ltproxy() }
+  public function main() -> bool { ltproxy() }
 }

--- a/test/examples/cases/mainproxy.solc
+++ b/test/examples/cases/mainproxy.solc
@@ -16,7 +16,7 @@ function morefun(p:Proxy(t)) -> word { return BaseMemoryType.memorySize(Proxy:Pr
 }
 
 contract TestMemoryType {
-  function main() -> word {
+  public function main() -> word {
     return morefun(Proxy:Proxy(word));
   }
 }

--- a/test/examples/cases/match-compiler-undef-asm.solc
+++ b/test/examples/cases/match-compiler-undef-asm.solc
@@ -13,7 +13,7 @@ forall a . function read(x : Foo(a)) -> word {
 
 contract Bla {
 
-  function main () -> word {
+  public function main () -> word {
     return read(Foo(42));
   }
 }

--- a/test/examples/cases/match-yul.solc
+++ b/test/examples/cases/match-yul.solc
@@ -1,9 +1,9 @@
 data Wrapper = Wrapper(word);
 contract C {
-    function main() -> word {
+    public function main() -> word {
         return foo(Wrapper(1));
     }
-    function foo(w:Wrapper) -> word {
+    public function foo(w:Wrapper) -> word {
         let result : word;
         match w {
             | Wrapper(ptr) =>

--- a/test/examples/cases/missing-instance.solc
+++ b/test/examples/cases/missing-instance.solc
@@ -17,7 +17,7 @@ instance word:MemoryType {
 }
 
 contract C {
-  function main() -> word {
+  public function main() -> word {
       let ptr : word = 0;
       // if we inline the let below into return then another bug occurs: main is typed as forall a. () -> a
       // let w:word = MemoryType.load(0);

--- a/test/examples/cases/modifier.solc
+++ b/test/examples/cases/modifier.solc
@@ -1,5 +1,5 @@
 contract C {
-	function add(x: word, y:word) -> word {
+	public function add(x: word, y:word) -> word {
 		let r : word;
 		assembly {
 			r := add(x, y)
@@ -8,14 +8,14 @@ contract C {
 	}
 
 	// modifier pattern: wrap add with before/after code
-	function modifiedAdd(x : word, y : word) -> word {
+	public function modifiedAdd(x : word, y : word) -> word {
 		// before solidity placeholder
 		let result = add(x, y); // Solidity's placeholder: _;
 		// after solidity placeholder
 		return result;
 	}
 
-	function main() -> word {
+	public function main() -> word {
 		return modifiedAdd(2, 1);
 	}
 }

--- a/test/examples/cases/monomorphic-require.solc
+++ b/test/examples/cases/monomorphic-require.solc
@@ -25,12 +25,12 @@ function callvalue() -> uint256 {
 }
 
 contract Deposit {
-function deposit() -> () {
+public function deposit() -> () {
     require(callvalue() != uint256(0));
     return ();
   }
 
-function main() -> () {
+public function main() -> () {
   deposit();
 }
 }

--- a/test/examples/cases/multi-stmt-var-leaf.solc
+++ b/test/examples/cases/multi-stmt-var-leaf.solc
@@ -1,7 +1,7 @@
 data Bool = False | True;
 
 contract MultiStmtVarLeaf {
-  function main(x:Bool) -> Bool {
+  public function main(x:Bool) -> Bool {
     match x {
       | y =>
         let z = y;

--- a/test/examples/cases/nano-desugared.solc
+++ b/test/examples/cases/nano-desugared.solc
@@ -405,28 +405,28 @@ data balances_sel = balances_sel  ;
 instance StructField(ContractStorage(UintCxt), balances_sel) :CStructField(mapping(address, uint), (word, (address, (address, (uint, (uint, ())))))) {
 }
 contract Uint {
-   function mint (amount : uint) {
+   public function mint (amount : uint) {
       Assign.assign(LValueMemberAccess.memberAccess(IndexAccessProxy(LValueMemberAccess.memberAccess(MemberAccessProxy(ContractStorage(UintCxt), balances_sel)), rval(MemberAccessProxy(ContractStorage(UintCxt), owner_sel)))), Num.add(rval(IndexAccessProxy(LValueMemberAccess.memberAccess(MemberAccessProxy(ContractStorage(UintCxt), balances_sel)), rval(MemberAccessProxy(ContractStorage(UintCxt), owner_sel)))), amount));
       Assign.assign(LValueMemberAccess.memberAccess(MemberAccessProxy(ContractStorage(UintCxt), totalSupply_sel)), Num.add(rval(MemberAccessProxy(ContractStorage(UintCxt), totalSupply_sel)), amount));
    }
-   function transferFrom (src : address, dst : address, amt : uint) -> Bool {
+   public function transferFrom (src : address, dst : address, amt : uint) -> Bool {
       require1(ge(rval(IndexAccessProxy(LValueMemberAccess.memberAccess(MemberAccessProxy(ContractStorage(UintCxt), balances_sel)), src)), amt));
       withdraw(src, amt);
       deposit(dst, amt);
       return Bool.True;
    }
-   function withdraw (src : address, amt : uint) {
+   public function withdraw (src : address, amt : uint) {
       Assign.assign(LValueMemberAccess.memberAccess(IndexAccessProxy(LValueMemberAccess.memberAccess(MemberAccessProxy(ContractStorage(UintCxt), balances_sel)), src)), Num.sub(rval(IndexAccessProxy(LValueMemberAccess.memberAccess(MemberAccessProxy(ContractStorage(UintCxt), balances_sel)), src)), amt) : uint);
    }
-   function deposit (dst : address, amt : uint) {
+   public function deposit (dst : address, amt : uint) {
       Assign.assign(LValueMemberAccess.memberAccess(IndexAccessProxy(LValueMemberAccess.memberAccess(MemberAccessProxy(ContractStorage(UintCxt), balances_sel)), dst)), Num.add(rval(IndexAccessProxy(LValueMemberAccess.memberAccess(MemberAccessProxy(ContractStorage(UintCxt), balances_sel)), dst)), amt) : uint);
    }
-   function init () {
+   public function init () {
       Assign.assign(LValueMemberAccess.memberAccess(MemberAccessProxy(ContractStorage(UintCxt), owner_sel)), address(81985529216486895));
       Assign.assign(LValueMemberAccess.memberAccess(MemberAccessProxy(ContractStorage(UintCxt), msg_sender_sel)), caller());
       Assign.assign(LValueMemberAccess.memberAccess(MemberAccessProxy(ContractStorage(UintCxt), decimals_sel)), Num.fromWord(18));
    }
-   function main () -> uint {
+   public function main () -> uint {
       init();
       mint(uint(1000));
       mint(uint(1000));

--- a/test/examples/cases/noconstr.solc
+++ b/test/examples/cases/noconstr.solc
@@ -11,7 +11,7 @@ function bla (x : a) -> word {
 }
 
 contract Test {
-  function main() {
+  public function main() {
     return bla(1);
   }
 }

--- a/test/examples/cases/option2.solc
+++ b/test/examples/cases/option2.solc
@@ -1,16 +1,16 @@
 contract Option {
   data Option(a) = None | Some(a);
 
-  function just(x : word) -> Option(word) { return Option.Some(x); }
+  public function just(x : word) -> Option(word) { return Option.Some(x); }
 
-  function maybe(n : word, o : Option(word)) -> word {
+  public function maybe(n : word, o : Option(word)) -> word {
     match o {
       | Option.None => return n;
       | Option.Some(x) => return x;
     }
   }
 
-  function join(mmx : Option(Option(word))) -> Option(word) {
+  public function join(mmx : Option(Option(word))) -> Option(word) {
     match mmx {
       | Option.None => return Option.None;
       | Option.Some(Option.None) => return Option.None;
@@ -18,7 +18,7 @@ contract Option {
     }
   }
 
-  function join2(mmx : Option(Option(word))) -> Option(word) {
+  public function join2(mmx : Option(Option(word))) -> Option(word) {
     match mmx {
       | Option.Some(m) => match m {
           | Option.None => return Option.None;
@@ -28,7 +28,7 @@ contract Option {
     }
   }
 
-  function main() -> word {
+  public function main() -> word {
    //  return maybe(0, join(Option.Some(Option.Some(42))));
    return 42;
   }

--- a/test/examples/cases/pars.solc
+++ b/test/examples/cases/pars.solc
@@ -1,3 +1,3 @@
 contract Pars {
-   function main() -> (){  let f:word; 42:word; (); }
+   public function main() -> (){  let f:word; 42:word; (); }
 }

--- a/test/examples/cases/phantom-type-return-con.solc
+++ b/test/examples/cases/phantom-type-return-con.solc
@@ -10,7 +10,7 @@ data Foo(a) = Foo(word);
   }
 
   contract C {
-    function main() -> word {
+    public function main() -> word {
       return unwrap();
     }
   }

--- a/test/examples/cases/polymatch-error.solc
+++ b/test/examples/cases/polymatch-error.solc
@@ -4,7 +4,7 @@ forall a b . function fst(p: (a, b)) -> a {
     }
 }
 contract TestUnitMatch {
-  function main() -> () {
+  public function main() -> () {
     match ((), ()) {
      | x => return fst(x);
     }

--- a/test/examples/cases/polymorphic-require.solc
+++ b/test/examples/cases/polymorphic-require.solc
@@ -21,12 +21,12 @@ function callvalue() -> uint256 {
 }
 
 contract Deposit {
-function deposit() -> () {
+public function deposit() -> () {
     require(callvalue() != uint256(0));
     return ();
   }
 
-function main() -> () {
+public function main() -> () {
   deposit();
 }
 }

--- a/test/examples/cases/public-constructor.solc
+++ b/test/examples/cases/public-constructor.solc
@@ -1,0 +1,10 @@
+import std.{*};
+import std.dispatch.{*};
+
+contract PublicConstructor {
+    public constructor() {}
+
+    public function answer() -> uint256 {
+        return uint256(42);
+    }
+}

--- a/test/examples/cases/public-fallback.solc
+++ b/test/examples/cases/public-fallback.solc
@@ -1,0 +1,10 @@
+import std.{*};
+import std.dispatch.{*};
+
+contract PublicFallback {
+    constructor() {}
+
+    public fallback() -> () {
+        revert("fallback-was-called");
+    }
+}

--- a/test/examples/cases/public-top-level-function.solc
+++ b/test/examples/cases/public-top-level-function.solc
@@ -1,0 +1,8 @@
+import std.{*};
+import std.dispatch.{*};
+
+// `public` is a contract-function visibility modifier. Applying it to a
+// top-level function (outside any `contract { … }` body) must be rejected.
+public function answer() -> uint256 {
+    return uint256(42);
+}

--- a/test/examples/cases/redundant-match.solc
+++ b/test/examples/cases/redundant-match.solc
@@ -9,5 +9,5 @@ data Bool = False | True;
   }
 
   contract Test {
-    function main() -> Bool { f(Bool.True) }
+    public function main() -> Bool { f(Bool.True) }
   }

--- a/test/examples/cases/reference-encoding-good.solc
+++ b/test/examples/cases/reference-encoding-good.solc
@@ -227,7 +227,7 @@ function g() -> () {
     Assign.assign(LValueMemberAccess.memberAccess(MemberAccessProxy(s, z_sel)), RValueMemberAccess.memberAccess(MemberAccessProxy(s, x_sel)));
 }
 contract C {
-    function main() -> () {
+    public function main() -> () {
         f();
         g();
     }

--- a/test/examples/cases/reference-encoding-good1.solc
+++ b/test/examples/cases/reference-encoding-good1.solc
@@ -228,7 +228,7 @@ function g() -> () {
     Assign.assign(LValueMemberAccess.memberAccess(MemberAccessProxy(s, z_sel)), RValueMemberAccess.memberAccess(MemberAccessProxy(s, x_sel)));
 }
 contract C {
-    function main() -> () {
+    public function main() -> () {
         f();
         g();
     }

--- a/test/examples/cases/reference-encoding.solc
+++ b/test/examples/cases/reference-encoding.solc
@@ -220,7 +220,7 @@ function g() {
     Assign.assign(LValueMemberAccess.memberAccess(MemberAccessProxy(s, z_sel)), RValueMemberAccess.memberAccess(MemberAccessProxy(s, x_sel)));
 }
 contract C {
-    function main() {
+    public function main() {
         f();
         g();
     }

--- a/test/examples/cases/reference-test.solc
+++ b/test/examples/cases/reference-test.solc
@@ -47,7 +47,7 @@ forall abs rep . test(abs):Typedef(rep), rep:Test =>
   }
 
 contract C {
-    function main() {
+    public function main() {
         let x:test(word) = test(memory(42));
         let ptr:word = Test.test(x);
     }

--- a/test/examples/cases/reference.solc
+++ b/test/examples/cases/reference.solc
@@ -18,7 +18,7 @@ forall r : Ref (a,b) . instance XRef(r, PairFst, a) : Ref(a) {}
 forall r : Ref (a,b) . instance XRef(r, PairSnd, b) : Ref(b) {}
 
 contract AssignNested {
-  function main() {
+  public function main() {
     let x : stack( (word, (word, word)) );
     let z : stack( (word, (word, word)) );
 

--- a/test/examples/cases/references-daniel.solc
+++ b/test/examples/cases/references-daniel.solc
@@ -229,7 +229,7 @@ function g() {
 }
 
 contract C {
-    function main() {
+    public function main() {
         f();
         g();
     }

--- a/test/examples/cases/require-annotation-contract-method.solc
+++ b/test/examples/cases/require-annotation-contract-method.solc
@@ -1,10 +1,10 @@
 // Error: contract method missing return type annotation
 contract Doubler {
-  function double(x : word) {
+  public function double(x : word) {
     return x;
   }
 
-  function main() -> word {
+  public function main() -> word {
     return double(21);
   }
 }

--- a/test/examples/cases/simpleDiscount.solc
+++ b/test/examples/cases/simpleDiscount.solc
@@ -20,7 +20,7 @@ function discount(state : AuctionState, phase : Phase) -> word {
 }
 
 contract Discount {
-  function main() -> word {
+  public function main() -> word {
     discount(.Active(420,.address(0)), .Early)
   }
 }

--- a/test/examples/cases/simpleIfExpr.solc
+++ b/test/examples/cases/simpleIfExpr.solc
@@ -1,3 +1,3 @@
 contract SimpleIfStmt {
-  function main() { return (if (true) then 1 else 0); }
+  public function main() { return (if (true) then 1 else 0); }
 }

--- a/test/examples/cases/simpleIfStmt.solc
+++ b/test/examples/cases/simpleIfStmt.solc
@@ -1,3 +1,3 @@
 contract SimpleIfStmt {
-  function main() { if (true) {return 1;} else {return 0;} }
+  public function main() { if (true) {return 1;} else {return 0;} }
 }

--- a/test/examples/cases/skolem-let.solc
+++ b/test/examples/cases/skolem-let.solc
@@ -6,7 +6,7 @@ forall a. function fromWord(x: word) -> a {
   }
 
 contract Unsafe {
-  function main() {
+  public function main() {
     fromWord(7):();
     return 42;
   }

--- a/test/examples/cases/string-const.solc
+++ b/test/examples/cases/string-const.solc
@@ -1,5 +1,5 @@
 contract Answer {
-  function main() {
+  public function main() {
     return "42";
   }
 }

--- a/test/examples/cases/subject-index.solc
+++ b/test/examples/cases/subject-index.solc
@@ -71,7 +71,7 @@ instance StructField(MintCtx, balances_sel):CStructField(mapping(word,word), ())
 
    }
 contract Map {
-   function main () {
+   public function main () {
       mint(1000);
    }
 }

--- a/test/examples/cases/subsumption-constraint.solc
+++ b/test/examples/cases/subsumption-constraint.solc
@@ -10,13 +10,13 @@ forall a . function the_bug(x : a, y : a) -> Bool {
 }
 
 contract Foo {
-    function x() {
+    public function x() {
         let b1 = Bool.True;
         let b2 = Bool.False;
         the_bug(b1, b2);
     }
 
-    function main() {
+    public function main() {
         x();
     }
 }

--- a/test/examples/cases/sum-match-default.solc
+++ b/test/examples/cases/sum-match-default.solc
@@ -1,14 +1,14 @@
 contract SumMatchDefault {
   data Option(a) = None | Some(a);
 
-  function g(s : Option(word)) -> Option(word) {
+  public function g(s : Option(word)) -> Option(word) {
     match s {
       | Option.None => return Option.None;
       | x => return x;
     }
   }
 
-  function main() -> word {
+  public function main() -> word {
     g(Option.None);
     return 42;
   }

--- a/test/examples/cases/synonym-recursive.solc
+++ b/test/examples/cases/synonym-recursive.solc
@@ -2,7 +2,7 @@ type A = B;
 type B = A;
 
 contract RecursiveTest {
-    function main() -> word {
+    public function main() -> word {
         return 0;
     }
 }

--- a/test/examples/cases/td.solc
+++ b/test/examples/cases/td.solc
@@ -15,5 +15,5 @@ function lift1ac(f:(rep) -> res, x:abs) -> res { f(Typedef.rep(x)) }
 
 forall a. function id(x:a) -> a {x}
 contract TD {
-  function main() -> word { lift1ac(id, 42) }
+  public function main() -> word { lift1ac(id, 42) }
 }

--- a/test/examples/cases/tiamat.solc
+++ b/test/examples/cases/tiamat.solc
@@ -127,7 +127,7 @@ instance storage(a):Assign(a) {
 }
 
 contract Tiamat {
-  function main() -> word {
+  public function main() -> word {
     let allowances : storage(dict(address, dict(address, word)));
     let src = address(17);
     setAllowance(allowances, address(1),address(2), 666);

--- a/test/examples/cases/tuple-trick.solc
+++ b/test/examples/cases/tuple-trick.solc
@@ -27,10 +27,10 @@ forall n a b c . n : Nth (b,c) => instance Succ(n) : Nth ((a,b), c) {
 }
 
 contract C {
-  function id (x : word) -> word {
+  public function id (x : word) -> word {
     return x;
   }
-  function main () -> () {
+  public function main () -> () {
     let p : (word, word, word, ());
     let x : word = Nth.nth(Proxy : Proxy(Zero), p);
     let y : word = Nth.nth(Proxy : Proxy(Succ(Zero)), p);

--- a/test/examples/cases/tuva.solc
+++ b/test/examples/cases/tuva.solc
@@ -61,7 +61,7 @@ function idx_lval(x:r) -> a {
 }
 
 contract TestTuva {
-  function main() -> word {
+  public function main() -> word {
     let balances : storage(mapping(address, word));
     let allowances : storage(mapping(address, mapping(address, word) ));
     let ref1 : storage(word) = idx_lval( (balances, address(17)) );

--- a/test/examples/cases/type-synonym-arg.solc
+++ b/test/examples/cases/type-synonym-arg.solc
@@ -4,7 +4,7 @@ function f(x:W) -> W { x }
 
 contract C {
 
-  function main () -> word {
+  public function main () -> word {
     return f(42);
   }
 }

--- a/test/examples/cases/uintdesugared.solc
+++ b/test/examples/cases/uintdesugared.solc
@@ -494,15 +494,15 @@ data balances_sel = balances_sel  ;
 instance StructField(ContractStorage(UintCxt), balances_sel) :CStructField(mapping(address, uint), (word, (address, (uint, (uint, ()))))) {
 }
 contract Uint {
-   function mint (amount : uint) -> () {
+   public function mint (amount : uint) -> () {
       Assign.assign(LValueMemberAccess.memberAccess(IndexAccessProxy(LValueMemberAccess.memberAccess(MemberAccessProxy(ContractStorage(UintCxt), balances_sel)), rval(MemberAccessProxy(ContractStorage(UintCxt), owner_sel)))), Num.add(rval(IndexAccessProxy(LValueMemberAccess.memberAccess(MemberAccessProxy(ContractStorage(UintCxt), balances_sel)), rval(MemberAccessProxy(ContractStorage(UintCxt), owner_sel)))), amount));
       Assign.assign(LValueMemberAccess.memberAccess(MemberAccessProxy(ContractStorage(UintCxt), totalSupply_sel)), Num.add(rval(MemberAccessProxy(ContractStorage(UintCxt), totalSupply_sel)), amount));
    }
-   function init () -> () {
+   public function init () -> () {
       Assign.assign(LValueMemberAccess.memberAccess(MemberAccessProxy(ContractStorage(UintCxt), owner_sel)), address(81985529216486895));
       Assign.assign(LValueMemberAccess.memberAccess(MemberAccessProxy(ContractStorage(UintCxt), decimals_sel)), Num.fromWord(18));
    }
-   function main () -> uint {
+   public function main () -> uint {
       init();
       mint(uint(1000));
       mint(uint(1000));

--- a/test/examples/cases/undefined.solc
+++ b/test/examples/cases/undefined.solc
@@ -7,7 +7,7 @@ forall any.function undefined() -> any {
 function useWord(w:word) -> () {}
 
 contract Magic {
-  function main() -> () {
+  public function main() -> () {
     useWord(undefined());
   }
 }

--- a/test/examples/cases/unit.solc
+++ b/test/examples/cases/unit.solc
@@ -1,23 +1,23 @@
 contract Unit {
-function one (x : ()) -> word {
+public function one (x : ()) -> word {
   return 1;
 }
 
-function unitVal() -> () {
+public function unitVal() -> () {
   return ();
 }
 
-function unitMatch (x : ()) -> word {
+public function unitMatch (x : ()) -> word {
   match x {
   | () => return 1;
   }
 }
 
-function foo (x : word) -> () {
+public function foo (x : word) -> () {
   return ();
 }
 
-function main() -> word {
+public function main() -> word {
   return unitMatch(foo(one(unitVal())));
 }
 }

--- a/test/examples/cases/word-match-default.solc
+++ b/test/examples/cases/word-match-default.solc
@@ -1,5 +1,5 @@
 contract WordMatchDefault {
-  function f(n : word) -> word {
+  public function f(n : word) -> word {
     let result : word;
     match n {
       | 0 => assembly { result := 100 }
@@ -8,7 +8,7 @@ contract WordMatchDefault {
     return result;
   }
 
-  function main() -> word {
+  public function main() -> word {
     return f(42);
   }
 }

--- a/test/examples/cases/xref.solc
+++ b/test/examples/cases/xref.solc
@@ -112,7 +112,7 @@ forall a b r . r:MemoryRef ((a,b)), a:MemoryType, b:MemoryType => instance XRef(
 }
 
 contract Ref219 {
-  function main() {
+  public function main() {
     let mp:M((word, word, word)) = M(96); // no alloc yet
     let p = (1,16,25);
     Ref.store(mp, p);

--- a/test/examples/cases/yul-asm-for-body.solc
+++ b/test/examples/cases/yul-asm-for-body.solc
@@ -10,7 +10,7 @@ function yul_asm_for_body() -> () {
 }
 
 contract Foo {
-    function main() -> () {
+    public function main() -> () {
         yul_asm_for_body()
     }
 }

--- a/test/examples/cases/yul-asm-switch-body.solc
+++ b/test/examples/cases/yul-asm-switch-body.solc
@@ -11,7 +11,7 @@ function yul_asm_switch_body() -> () {
 }
 
 contract Foo {
-    function main() -> () {
+    public function main() -> () {
         yul_asm_switch_body()
     }
 }

--- a/test/examples/cases/yul-deposit-example.solc
+++ b/test/examples/cases/yul-deposit-example.solc
@@ -8,7 +8,7 @@ function deposit(pubkey: memory(string), withdrawal_credentials: memory(string),
 }
 
 contract Foo {
-   function main () -> () {
+   public function main () -> () {
       deposit(memory(0), memory(0), memory(0), uint256(2));
    }
 }

--- a/test/examples/cases/yul-for.solc
+++ b/test/examples/cases/yul-for.solc
@@ -1,5 +1,5 @@
 contract YulFor {
-  function main() -> word {
+  public function main() -> word {
     let loopStart : word = 128;
     let loopEnd : word = 256;
     let res : word;

--- a/test/examples/cases/yul-return.solc
+++ b/test/examples/cases/yul-return.solc
@@ -1,5 +1,5 @@
 contract C {
-  function main() -> () {
+  public function main() -> () {
     assembly {
       return(0,0)
     }

--- a/test/examples/comptime/CondExpr.solc
+++ b/test/examples/comptime/CondExpr.solc
@@ -8,5 +8,5 @@ function notAnswer(n : word) -> word { if(n == 42) then 0 else 42 }
 function answer(n:word) -> word { notAnswer(notAnswer(42)) }
 
 contract Fib {
-  function main() -> word { answer(42) }
+  public function main() -> word { answer(42) }
 }

--- a/test/examples/comptime/CondStmt.solc
+++ b/test/examples/comptime/CondStmt.solc
@@ -11,7 +11,7 @@ function answer(n:word) -> word {
   return notAnswer(notAnswer(42));
 }
 contract Fib {
-function main() -> word {
+public function main() -> word {
    return answer(42);
 }
 }

--- a/test/examples/comptime/OneTwo.solc
+++ b/test/examples/comptime/OneTwo.solc
@@ -23,6 +23,6 @@ function two () -> word {
 }
 
 contract OneTwo {
-  function main() -> word { return two(); }
+  public function main() -> word { return two(); }
 }
 

--- a/test/examples/comptime/Plus.solc
+++ b/test/examples/comptime/Plus.solc
@@ -18,5 +18,5 @@ function two () -> word {
 }
 
 contract Plus {
-  function main() -> word { return two() + two(); }
+  public function main() -> word { return two() + two(); }
 }

--- a/test/examples/comptime/Size.solc
+++ b/test/examples/comptime/Size.solc
@@ -43,7 +43,7 @@ forall a b. a:StorageSize, b:StorageSize => instance (a,b):StorageSize {
 
 
 contract Size {
-  function main() -> word {
+  public function main() -> word {
   return
     StorageSize.size(Proxy:Proxy( (word, (word, ())))); }
 }

--- a/test/examples/comptime/StdSize.solc
+++ b/test/examples/comptime/StdSize.solc
@@ -42,7 +42,7 @@ instance (a, b):StorageSize {
 }
 
 contract Size {
-  function main() -> word {
+  public function main() -> word {
     return StorageSize.size(Proxy:Proxy((word, (word, ()))));
   }
 }

--- a/test/examples/comptime/counter.solc
+++ b/test/examples/comptime/counter.solc
@@ -18,7 +18,7 @@ contract Counter {
     fld0 = 7;
   }
   
-  function main() -> word {
+  public function main() -> word {
     counter = counter + 1;
     return counter;
   }

--- a/test/examples/comptime/fib.solc
+++ b/test/examples/comptime/fib.solc
@@ -8,7 +8,7 @@ function fib(n : word) -> word {
 }
 
 contract Fib {
-function main() -> word {
+public function main() -> word {
   return fib(10);
 }
 }

--- a/test/examples/comptime/string-lit-keccak.solc
+++ b/test/examples/comptime/string-lit-keccak.solc
@@ -4,7 +4,7 @@ pragma no-coverage-condition ;
 pragma no-bounded-variable-condition ;
 
 contract StringLitKeccak {
-  function main() -> word {
+  public function main() -> word {
     // keccakLit folds to a 256-bit word (EVM/Yul semantics)
     return std.keccakLit("abc");
   }

--- a/test/examples/comptime/string-lit-len.solc
+++ b/test/examples/comptime/string-lit-len.solc
@@ -4,7 +4,7 @@ pragma no-coverage-condition ;
 pragma no-bounded-variable-condition ;
 
 contract StringLitLen {
-  function main() -> word {
+  public function main() -> word {
     // strlenLit folds to a word
     return std.strlenLit("hello");
   }

--- a/test/examples/comptime/string-lit-ops.solc
+++ b/test/examples/comptime/string-lit-ops.solc
@@ -7,7 +7,7 @@ pragma no-bounded-variable-condition ;
 // These functions are intended to be folded by MastEval at compile time.
 
 contract StringLitOps {
-  function main() -> () {
+  public function main() -> () {
     // concatLit folds to a string literal, enabling revertLit("...") lowering
     let s : comptime string  = concatLit("ab", "cd");
     std.revertLit(s);

--- a/test/examples/dispatch/Revert.solc
+++ b/test/examples/dispatch/Revert.solc
@@ -12,11 +12,11 @@ function my_revert() -> word {
 contract Foo {
   constructor() {}
 
-  function noAnswer() -> uint256 {
+  public function noAnswer() -> uint256 {
     return uint256(my_revert());
   }
 
-  function answer() -> uint256 {
+  public function answer() -> uint256 {
     return uint256(42);
   }
 }

--- a/test/examples/dispatch/basic.json
+++ b/test/examples/dispatch/basic.json
@@ -189,6 +189,18 @@
           "returndata":"4924aef0",
           "status": "failure"
         }
+      },
+      {
+        "input": {
+          "text-calldata": "non-public hidden() must not be dispatched",
+          "calldata":"aef6d4b1",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata":"4924aef0",
+          "status": "failure"
+        }
       }
     ]
   }

--- a/test/examples/dispatch/basic.solc
+++ b/test/examples/dispatch/basic.solc
@@ -7,33 +7,37 @@ pragma no-bounded-variable-condition ;
 
 contract C {
     constructor() {}
-    function nothing() -> () {}
+    public function nothing() -> () {}
 
-    function something() -> (uint256) {
+    public function something() -> (uint256) {
         return uint256(1);
     }
 
-    function add2(x : uint256, y : uint256) -> uint256 {
+    public function add2(x : uint256, y : uint256) -> uint256 {
         return Add.add(x,y);
     }
 
-    function add3(x : uint256, y : uint256, z : uint256) -> uint256 {
+    public function add3(x : uint256, y : uint256, z : uint256) -> uint256 {
         return Add.add(z, Add.add(x,y));
     }
 
-    function id_bytes(b: memory(bytes)) -> memory(bytes) {
+    public function id_bytes(b: memory(bytes)) -> memory(bytes) {
         return b;
     }
 
-    function id_string(b: memory(string)) -> memory(string) {
+    public function id_string(b: memory(string)) -> memory(string) {
         return b;
     }
 
-    function id_bytes32(b: bytes32) -> bytes32 {
+    public function id_bytes32(b: bytes32) -> bytes32 {
         return b;
     }
 
-    function id_pair() -> (uint256, uint256) {
+    public function id_pair() -> (uint256, uint256) {
         return (uint256(7), uint256(11));
+    }
+
+    function hidden() -> (uint256) {
+        return uint256(42);
     }
 }

--- a/test/examples/dispatch/concat.solc
+++ b/test/examples/dispatch/concat.solc
@@ -8,39 +8,39 @@ pragma no-bounded-variable-condition ;
 contract C {
     constructor() {}
 
-    function concat_b32_b32(a: bytes32, b: bytes32) -> memory(bytes) {
+    public function concat_b32_b32(a: bytes32, b: bytes32) -> memory(bytes) {
         return concat(a, b);
     }
 
-    function concat_b32_bytes(a: bytes32, b: memory(bytes)) -> memory(bytes) {
+    public function concat_b32_bytes(a: bytes32, b: memory(bytes)) -> memory(bytes) {
         return concat(a, b);
     }
 
-    function concat_bytes_bytes(a: memory(bytes), b: memory(bytes)) -> memory(bytes) {
+    public function concat_bytes_bytes(a: memory(bytes), b: memory(bytes)) -> memory(bytes) {
         return concat(a, b);
     }
 
-    function to_bytes_b32(a: bytes32) -> memory(bytes) {
+    public function to_bytes_b32(a: bytes32) -> memory(bytes) {
         return to_bytes(a);
     }
 
-    function to_bytes_bytes(a: memory(bytes)) -> memory(bytes) {
+    public function to_bytes_bytes(a: memory(bytes)) -> memory(bytes) {
         return to_bytes(a);
     }
 
-    function empty_area(n: uint256) -> memory(bytes) {
+    public function empty_area(n: uint256) -> memory(bytes) {
         return to_bytes(empty(Typedef.rep(n)));
     }
 
-    function concat_b32_empty(a: bytes32, n: uint256) -> memory(bytes) {
+    public function concat_b32_empty(a: bytes32, n: uint256) -> memory(bytes) {
         return concat(a, empty(Typedef.rep(n)));
     }
 
-    function concat_nested_b32(a: bytes32, b: bytes32, c: bytes32) -> memory(bytes) {
+    public function concat_nested_b32(a: bytes32, b: bytes32, c: bytes32) -> memory(bytes) {
         return concat(a, concat(b, c));
     }
 
-    function concat_nested_empty(a: bytes32, n: uint256, c: bytes32) -> memory(bytes) {
+    public function concat_nested_empty(a: bytes32, n: uint256, c: bytes32) -> memory(bytes) {
         return concat(a, concat(empty(Typedef.rep(n)), c));
     }
 }

--- a/test/examples/dispatch/counter.solc
+++ b/test/examples/dispatch/counter.solc
@@ -14,7 +14,7 @@ contract Counter {
 //     fld0 = 7;
   }
   
-  function test() -> uint256 {
+  public function test() -> uint256 {
     counter = counter + uint256(1);
     return counter;
   }

--- a/test/examples/dispatch/ecrecover.solc
+++ b/test/examples/dispatch/ecrecover.solc
@@ -2,7 +2,7 @@ import std.{*};
 import std.dispatch.{*};
 
 contract EcrecoverTest {
-    function recover() -> address {
+    public function recover() -> address {
         let h: bytes32 = bytes32(0xaabbccddeeff00112233445566778899aabbccddeeff00112233445566778899);
         let v: uint256 = uint256(27);
         let r: bytes32 = bytes32(0xb3ba6dd3757d18f28736e84b1296af85362b7bdf4548710733c6325abf95311d);

--- a/test/examples/dispatch/fallback.solc
+++ b/test/examples/dispatch/fallback.solc
@@ -4,7 +4,7 @@ import std.dispatch.{*};
 contract WithFallback {
     constructor() {}
 
-    function answer() -> uint256 {
+    public function answer() -> uint256 {
         return uint256(42);
     }
 

--- a/test/examples/dispatch/fib.solc
+++ b/test/examples/dispatch/fib.solc
@@ -6,7 +6,7 @@ function fib(n : word) -> word {
 
 contract Fib {
   constructor() {}
-  function test() -> uint256 {
+  public function test() -> uint256 {
     return uint256(fib(10));
   }
 }

--- a/test/examples/dispatch/hashes.solc
+++ b/test/examples/dispatch/hashes.solc
@@ -12,15 +12,15 @@ function abcBytes() -> memory(bytes) {
 contract C {
     constructor() {}
 
-    function keccak() -> bytes32 {
+    public function keccak() -> bytes32 {
         return keccak256_(abcBytes());
     }
 
-    function sha() -> bytes32 {
+    public function sha() -> bytes32 {
         return sha256(abcBytes());
     }
 
-    function ripemd() -> bytes32 {
+    public function ripemd() -> bytes32 {
         return ripemd160(abcBytes());
     }
 }

--- a/test/examples/dispatch/memory.solc
+++ b/test/examples/dispatch/memory.solc
@@ -2,14 +2,14 @@ import std.{*};
 import std.dispatch.{*};
 
 contract C {
-    function dirty_allocate() -> memory(bytes) {
+    public function dirty_allocate() -> memory(bytes) {
         mstore(get_free_memory() + 32, 0xdeadc0de);
         let ptr = allocate_memory(32 + 32);
         mstore(ptr, 32);
         return memory(ptr);
     }
 
-    function clear_allocate() -> memory(bytes) {
+    public function clear_allocate() -> memory(bytes) {
         mstore(get_free_memory() + 32, 0xdeadc0de);
         let ptr = allocate_zeroed_memory(32 + 32);
         mstore(ptr, 32);

--- a/test/examples/dispatch/miniERC20.solc
+++ b/test/examples/dispatch/miniERC20.solc
@@ -30,41 +30,41 @@ contract MiniERC20 {
     mint(totalSupply_);
   }
 
-  function name() -> memory(string) {
+  public function name() -> memory(string) {
     return name;
   }
 
-  function symbol() -> memory(string) {
+  public function symbol() -> memory(string) {
     return symbol;
   }
 
-  function decimals() -> uint256 {
+  public function decimals() -> uint256 {
     return decimals;
   }
 
-  function allowance(owner_ : address, spender: address) -> uint256 {
+  public function allowance(owner_ : address, spender: address) -> uint256 {
     return allowance[owner_][spender]; // don't use "owner" here
   }
 
-  function balanceOf(account : address) -> uint256 {
+  public function balanceOf(account : address) -> uint256 {
     return balances[account];
   }
 
-  function totalSupply() -> uint256 {
+  public function totalSupply() -> uint256 {
     return totalSupply;
   }
 
   // Note that this is not access guarded — the minting always goes to the owner
-  function mint(amount:uint256) -> () {
+  public function mint(amount:uint256) -> () {
     balances[owner] = Num.add(balances[owner], amount);
     totalSupply = Num.add(totalSupply, amount);
   }
 
-  function transfer(dst : address, amt : uint256) -> bool {
+  public function transfer(dst : address, amt : uint256) -> bool {
       return transferFrom(caller(), dst, amt);
   }
 
-  function transferFrom(src:address, dst:address, amt:uint256) -> bool {
+  public function transferFrom(src:address, dst:address, amt:uint256) -> bool {
      let msg_sender = caller();
      require(balances[src] >= amt, Error(0xf4d678b8)); // InsufficientBalance()
 
@@ -79,7 +79,7 @@ contract MiniERC20 {
      return true;
   }
 
-  function approve(usr: address, amt: uint256) -> bool {
+  public function approve(usr: address, amt: uint256) -> bool {
       let msg_sender = caller();
       allowance[msg_sender][usr] = amt;
       // emit Approval(msg.sender, usr, amt);
@@ -88,11 +88,11 @@ contract MiniERC20 {
 
 
   // testing
-  function getMyBalance() -> uint256 {
+  public function getMyBalance() -> uint256 {
     return balances[caller()];
   }
 
-  function test() -> uint256 {
+  public function test() -> uint256 {
       approve(address(0), uint256(10));
       transferFrom(caller(), address(0), uint256(958));
       return getMyBalance();

--- a/test/examples/dispatch/neg.solc
+++ b/test/examples/dispatch/neg.solc
@@ -68,5 +68,5 @@ instance (a:Neg,b:Neg) => Pair(a,b):Neg {
 
 contract NegPair {
  constructor() {}
- function negPair() -> uint256 { return uint256(fromB(pairfst(Neg.neg(Pair(B.F,B.T))))); }
+ public function negPair() -> uint256 { return uint256(fromB(pairfst(Neg.neg(Pair(B.F,B.T))))); }
 }

--- a/test/examples/dispatch/ownable.solc
+++ b/test/examples/dispatch/ownable.solc
@@ -23,11 +23,11 @@ contract Ownable {
   }
 
   // named getOwner() instead of owner() to avoid collision with the field name
-  function getOwner() -> address {
+  public function getOwner() -> address {
     return owner;
   }
 
-  function changeOwner(newOwner : address) -> () {
+  public function changeOwner(newOwner : address) -> () {
     require(caller() == owner, Error(0x12b0c500)); // OwnableUnauthorizedAccount()
     owner = newOwner;
   }

--- a/test/examples/dispatch/payable.solc
+++ b/test/examples/dispatch/payable.solc
@@ -4,7 +4,7 @@ import std.dispatch.{*};
 contract PayableTest {
     constructor() {}
 
-    payable function deposit() -> uint256 {
+    public payable function deposit() -> uint256 {
         let value;
         assembly {
             value := callvalue()
@@ -12,7 +12,7 @@ contract PayableTest {
         return uint256(value);
     }
 
-    function balance() -> uint256 {
+    public function balance() -> uint256 {
         let value;
         assembly {
             value := selfbalance()

--- a/test/examples/dispatch/slices.solc
+++ b/test/examples/dispatch/slices.solc
@@ -8,58 +8,58 @@ import std.dispatch.{*};
 contract C {
     // --- slice_/truncate on a memory(bytes), materialized with to_bytes ---
 
-    function slice_bytes(a: memory(bytes), start: uint256) -> memory(bytes) {
+    public function slice_bytes(a: memory(bytes), start: uint256) -> memory(bytes) {
         return to_bytes(slice_(a, Typedef.rep(start)));
     }
 
-    function truncate_bytes(a: memory(bytes), end: uint256) -> memory(bytes) {
+    public function truncate_bytes(a: memory(bytes), end: uint256) -> memory(bytes) {
         return to_bytes(truncate(a, Typedef.rep(end)));
     }
 
     // --- slice_/truncate over the result of a concat ---
 
-    function slice_of_concat(a: bytes32, b: bytes32, start: uint256) -> memory(bytes) {
+    public unction slice_of_concat(a: bytes32, b: bytes32, start: uint256) -> memory(bytes) {
         return to_bytes(slice_(concat(a, b), Typedef.rep(start)));
     }
 
-    function truncate_of_concat(a: bytes32, b: bytes32, end: uint256) -> memory(bytes) {
+    public function truncate_of_concat(a: bytes32, b: bytes32, end: uint256) -> memory(bytes) {
         return to_bytes(truncate(concat(a, b), Typedef.rep(end)));
     }
 
     // to_bytes(truncate(slice_(concat(a, b), start), end)) -- the headline nesting:
     // drop `start` bytes, then keep `end` of what remains (re-slicing a memory_slice).
-    function window_of_concat(a: bytes32, b: bytes32, start: uint256, end: uint256) -> memory(bytes) {
+    public function window_of_concat(a: bytes32, b: bytes32, start: uint256, end: uint256) -> memory(bytes) {
         return to_bytes(truncate(slice_(concat(a, b), Typedef.rep(start)), Typedef.rep(end)));
     }
 
     // --- a slice used as a concat operand ---
 
-    function concat_slice_b32(a: memory(bytes), start: uint256, c: bytes32) -> memory(bytes) {
+    public function concat_slice_b32(a: memory(bytes), start: uint256, c: bytes32) -> memory(bytes) {
         return concat(slice_(a, Typedef.rep(start)), c);
     }
 
-    function concat_two_slices(a: memory(bytes), sa: uint256, b: memory(bytes), eb: uint256) -> memory(bytes) {
+    public function concat_two_slices(a: memory(bytes), sa: uint256, b: memory(bytes), eb: uint256) -> memory(bytes) {
         return concat(slice_(a, Typedef.rep(sa)), truncate(b, Typedef.rep(eb)));
     }
 
     // --- re-slicing a memory_slice ---
 
-    function slice_of_slice(a: memory(bytes), s1: uint256, s2: uint256) -> memory(bytes) {
+    public function slice_of_slice(a: memory(bytes), s1: uint256, s2: uint256) -> memory(bytes) {
         return to_bytes(slice_(slice_(a, Typedef.rep(s1)), Typedef.rep(s2)));
     }
 
     // --- hashing a slice directly (no intermediate copy) ---
 
-    function keccak_slice(a: memory(bytes), start: uint256) -> bytes32 {
+    public function keccak_slice(a: memory(bytes), start: uint256) -> bytes32 {
         return keccak256_(slice_(a, Typedef.rep(start)));
     }
 
-    function sha_truncate(a: memory(bytes), end: uint256) -> bytes32 {
+    public function sha_truncate(a: memory(bytes), end: uint256) -> bytes32 {
         return sha256(truncate(a, Typedef.rep(end)));
     }
 
     // keccak256_(truncate(slice_(concat(a, b), start), end)) -- nested chain, hash endpoint.
-    function keccak_window_concat(a: bytes32, b: bytes32, start: uint256, end: uint256) -> bytes32 {
+    public function keccak_window_concat(a: bytes32, b: bytes32, start: uint256, end: uint256) -> bytes32 {
         return keccak256_(truncate(slice_(concat(a, b), Typedef.rep(start)), Typedef.rep(end)));
     }
 }

--- a/test/examples/dispatch/slices.solc
+++ b/test/examples/dispatch/slices.solc
@@ -18,7 +18,7 @@ contract C {
 
     // --- slice_/truncate over the result of a concat ---
 
-    public unction slice_of_concat(a: bytes32, b: bytes32, start: uint256) -> memory(bytes) {
+    public function slice_of_concat(a: bytes32, b: bytes32, start: uint256) -> memory(bytes) {
         return to_bytes(slice_(concat(a, b), Typedef.rep(start)));
     }
 

--- a/test/examples/dispatch/stringid.solc
+++ b/test/examples/dispatch/stringid.solc
@@ -7,7 +7,7 @@ pragma no-bounded-variable-condition ;
 
 contract C {
     constructor() {}
-    function id(x:memory(string)) -> (memory(string)) {
+    public function id(x:memory(string)) -> (memory(string)) {
      let ptr : word = Typedef.rep(x);
      let len : word;
      let n1 : word;
@@ -21,14 +21,14 @@ contract C {
      return x;
     }
 
-    function const_a() -> (memory(string)) {
+    public function const_a() -> (memory(string)) {
       let resPtr = allocate_memory(64);
       let payload : word = 0x7777777777777777777777777777777777777777777777777777777777777777;
       mstore(resPtr, 3);
       mstore(resPtr+32, payload);
       return memory(resPtr);
     }
-    function mylen(x:memory(string)) -> uint256 {
+    public function mylen(x:memory(string)) -> uint256 {
      let ptr : word = Typedef.rep(x);
      let l : word;
      let n1 : word;

--- a/test/examples/invokable/021nid.solc
+++ b/test/examples/invokable/021nid.solc
@@ -1,15 +1,15 @@
 contract Id1 {
-  function id(x) {
+  public function id(x) {
     return x ;
   }
 
-  function nid() {
+  public function nid() {
     return id;
   }
 
-  function const(x, y) { return x; }
+  public function const(x, y) { return x; }
 
-  function main() {
+  public function main() {
     return nid(42);
   }
 }

--- a/test/examples/invokable/022nid-invoke.solc
+++ b/test/examples/invokable/022nid-invoke.solc
@@ -16,7 +16,7 @@ instance IdToken(a) : Invokable(a,a) {
 }
 
 contract InvokeId {
-  function id(x) {
+  public function id(x) {
     return x ;
   }
 
@@ -26,11 +26,11 @@ contract InvokeId {
   }
   */
 
-  function nidimpl() {
+  public function nidimpl() {
     return IdToken;
   }
 
-  function main() {
+  public function main() {
     // Instead of: `return nid(42)`
     return invoke(nidimpl(), 42);
   }

--- a/test/examples/invokable/024lamid.solc
+++ b/test/examples/invokable/024lamid.solc
@@ -1,10 +1,10 @@
 contract Id1 {
-  function id(x) {
+  public function id(x) {
     return x ;
   }
 
 
-  function main() {
+  public function main() {
     let nid = lam(x) {return x;};
     return nid(42);
   }

--- a/test/examples/invokable/025lamid-invoke.solc
+++ b/test/examples/invokable/025lamid-invoke.solc
@@ -23,7 +23,7 @@ instance Lam0Token(a) : Invokable(a,a) {
 
 
 contract InvokeLam {
-function main() {
+public function main() {
   let nid = Lam0Token;
   return invoke(nid, 42);
 }

--- a/test/examples/invokable/026capture.solc
+++ b/test/examples/invokable/026capture.solc
@@ -38,7 +38,7 @@ instance Lam1Closure(a) : Invokable(a,Word) {
 
 
 contract InvokeCapLam {
-function main() {
+public function main() {
   let y = 42;
   let clos = Lam1Closure(y);
 

--- a/test/examples/invokable/027retfun.solc
+++ b/test/examples/invokable/027retfun.solc
@@ -31,13 +31,13 @@ instance Lam1Closure(a) : Invokable(a,Word) {
 
 
 contract InvokeCapLam {
-function foo() {
+public function foo() {
   let y = 42;
   let clos = Lam1Closure(y);
   return clos;
 }
 
-function main() {
+public function main() {
 
   return invoke(foo(), 17);
 }

--- a/test/examples/invokable/028modifier.solc
+++ b/test/examples/invokable/028modifier.solc
@@ -80,7 +80,7 @@ function add1mod(f) {
 contract Modifier {
 
 
-function main() {
+public function main() {
   let barClos = add1mod(FooToken);
   return invoke(barClos, 39);
 }

--- a/test/examples/invokable/031enum.solc
+++ b/test/examples/invokable/031enum.solc
@@ -44,7 +44,7 @@ instance (a:Enum) => FromEnumToken(a) : Invokable(a,Word) {
    }
 }
 contract RGB {
-  function main() {
+  public function main() {
   /*
   let x = fromEnum(Color.B);
   let y = fromEnum(Bool.True);

--- a/test/examples/spec/00answer.solc
+++ b/test/examples/spec/00answer.solc
@@ -1,5 +1,5 @@
 contract Answer {
-  function main() -> word {
+  public function main() -> word {
     return 42;
   }
 }

--- a/test/examples/spec/010answer.solc
+++ b/test/examples/spec/010answer.solc
@@ -1,5 +1,5 @@
 contract Answer {
-  function main() {
+  public function main() {
     return 42;
   }
 }

--- a/test/examples/spec/011id.solc
+++ b/test/examples/spec/011id.solc
@@ -2,13 +2,13 @@ contract Id1 {
 
   data Bool = False | True;
 
-  function id(x) {
+  public function id(x) {
     return x ;
   }
 
-  function const(x, y) { return x; }
+  public function const(x, y) { return x; }
 
-  function main() {
+  public function main() {
     return const(id(42), Bool.False);
   }
 }

--- a/test/examples/spec/012nid.solc
+++ b/test/examples/spec/012nid.solc
@@ -1,15 +1,15 @@
 contract Id1 {
-  function id(x) {
+  public function id(x) {
     return x ;
   }
 
-  function nid() {
+  public function nid() {
     return id;
   }
 
-  function const(x, y) { return x; }
+  public function const(x, y) { return x; }
 
-  function main() {
+  public function main() {
     return const(nid(42), id(1));
   }
 }

--- a/test/examples/spec/013comp.solc
+++ b/test/examples/spec/013comp.solc
@@ -1,15 +1,15 @@
 contract Compose {
-  function compose(f,g) {
+  public function compose(f,g) {
     return lam (x) {
       return f(g(x));
     } ;
   }
 
-  function id(x) { return x; }
+  public function id(x) { return x; }
 
-  function idid() { return compose(id,id); }
+  public function idid() { return compose(id,id); }
 
-  function main() {
+  public function main() {
     let f = compose(id,id);
     return f(42);
   }

--- a/test/examples/spec/01id.solc
+++ b/test/examples/spec/01id.solc
@@ -2,13 +2,13 @@ contract Id1 {
 
   data Bool = False | True;
 
-  function id(x : word) -> word {
+  public function id(x : word) -> word {
     return x ;
   }
 
-  function const(x : word, y : Bool) -> word { return x; }
+  public function const(x : word, y : Bool) -> word { return x; }
 
-  function main() -> word {
+  public function main() -> word {
     return const(id(42), Bool.False);
   }
 }

--- a/test/examples/spec/021not.solc
+++ b/test/examples/spec/021not.solc
@@ -1,18 +1,18 @@
 contract Not {
   data Bool = False | True;
 
-  function main() -> word {
+  public function main() -> word {
     return fromBool(bnot(Bool.False));
   }
 
-  function fromBool(b : Bool) -> word {
+  public function fromBool(b : Bool) -> word {
     match(b) {
       | Bool.False => return 0;
       | Bool.True  => return 1;
     }
   }
 
-  function bnot(b : Bool) -> Bool {
+  public function bnot(b : Bool) -> Bool {
     match b {
       | Bool.False => return Bool.True;
       | Bool.True => return Bool.False;

--- a/test/examples/spec/022add.solc
+++ b/test/examples/spec/022add.solc
@@ -7,7 +7,7 @@ function add(x : word, y : word) -> word {
 }
 
 contract Add1 {
-  function main() -> word {
+  public function main() -> word {
     return add(40, 2);
   }
 }

--- a/test/examples/spec/024arith.solc
+++ b/test/examples/spec/024arith.solc
@@ -58,7 +58,7 @@ function exp(x : word, y: word) -> word {
 
 
 contract Arith {
-  function main() -> word {
+  public function main() -> word {
     return add(mod(sub(div(exp(2,18),4), 1), 16), 27);
   }
 }

--- a/test/examples/spec/027sstore.solc
+++ b/test/examples/spec/027sstore.solc
@@ -1,5 +1,5 @@
 contract Sstore {
-  function main() {
+  public function main() {
     let res : word;
     assembly {
 	sstore(0, 42)

--- a/test/examples/spec/02nid.solc
+++ b/test/examples/spec/02nid.solc
@@ -1,15 +1,15 @@
 contract Id1 {
-  function id(x : word) -> word {
+  public function id(x : word) -> word {
     return x ;
   }
 
-  function nid(x : word) -> word {
+  public function nid(x : word) -> word {
     return id(x);
   }
 
-  function const(x : word, y : word) -> word { return x; }
+  public function const(x : word, y : word) -> word { return x; }
 
-  function main() -> word {
+  public function main() -> word {
     return const(nid(42), id(1));
   }
 }

--- a/test/examples/spec/031maybe.solc
+++ b/test/examples/spec/031maybe.solc
@@ -1,16 +1,16 @@
 contract Option {
   data Option(a) = None | Some(a);
 
-  function just(x : word) -> Option(word) { return Option.Some(x); }
+  public function just(x : word) -> Option(word) { return Option.Some(x); }
 
-  function maybe(n : word, o : Option(word)) -> word {
+  public function maybe(n : word, o : Option(word)) -> word {
     match o {
       | Option.None => return n;
       | Option.Some(x) => return x;
     }
   }
 
-  function main() -> word {
+  public function main() -> word {
     return maybe(0, Option.Some(42));
   }
 }

--- a/test/examples/spec/032simplejoin.solc
+++ b/test/examples/spec/032simplejoin.solc
@@ -1,9 +1,9 @@
 contract Option {
   data Option(a) = None | Some(a);
 
-  function just(x : word) -> Option(word) { return Option.Some(x); }
+  public function just(x : word) -> Option(word) { return Option.Some(x); }
 
-  function maybe(n : word, o : Option(word)) -> word {
+  public function maybe(n : word, o : Option(word)) -> word {
     match o {
       | Option.None => return n;
       | Option.Some(x) => return x;
@@ -11,7 +11,7 @@ contract Option {
   }
 
 
-  function join(mmx : Option(Option(word))) -> Option(word) {
+  public function join(mmx : Option(Option(word))) -> Option(word) {
     match mmx {
       | Option.None => return Option.None;
       | Option.Some(Option.None) => return Option.None;
@@ -19,7 +19,7 @@ contract Option {
     }
   }
 
-  function join2(mmx : Option(Option(word))) -> Option(word) {
+  public function join2(mmx : Option(Option(word))) -> Option(word) {
     match mmx {
       | Option.Some(m) => match m {
           | Option.None => return Option.None;
@@ -29,7 +29,7 @@ contract Option {
     }
   }
 
-  function main() -> word {
+  public function main() -> word {
     return maybe(0, join(Option.Some(Option.Some(42))));
   }
 }

--- a/test/examples/spec/033join.solc
+++ b/test/examples/spec/033join.solc
@@ -1,23 +1,23 @@
 contract Option {
   data Option(a) = None | Some(a);
 
-  function just(x : word) -> Option(word) { return Option.Some(x); }
+  public function just(x : word) -> Option(word) { return Option.Some(x); }
 
-  function maybe(n : word, o : Option(word)) -> word {
+  public function maybe(n : word, o : Option(word)) -> word {
     match o {
       | Option.None => return n;
       | Option.Some(x) => return x;
     }
   }
 
-  function join(mmx : Option(Option(word))) -> Option(word) {
+  public function join(mmx : Option(Option(word))) -> Option(word) {
     match mmx {
       | Option.Some(Option.Some(x)) => return Option.Some(x);
       | _ => return Option.None;
     }
   }
 
-  function main() -> word {
+  public function main() -> word {
     return maybe(0, join(Option.Some(Option.Some(42))));
   }
 }

--- a/test/examples/spec/034cojoin.solc
+++ b/test/examples/spec/034cojoin.solc
@@ -1,16 +1,16 @@
 contract Option {
   data Option(a) = None | Some(a);
 
-  function just(x : word) -> Option(word) { return Option.Some(x); }
+  public function just(x : word) -> Option(word) { return Option.Some(x); }
 
-  function maybe(n : word, o : Option(word)) -> word {
+  public function maybe(n : word, o : Option(word)) -> word {
     match o {
       | Option.None => return n;
       | Option.Some(x) => return x;
     }
   }
 
-  function join(mmx : Option(Option(word))) -> Option(word) {
+  public function join(mmx : Option(Option(word))) -> Option(word) {
     let result = Option.None;
     match mmx {
       | Option.Some(Option.Some(x)) => result = Option.Some(x);
@@ -21,21 +21,21 @@ contract Option {
     return result;
   }
 
- function extract(mx : Option(word)) -> word {
+ public function extract(mx : Option(word)) -> word {
    match mx {
      | Option.Some(x) => return x;
      | Option.None => return 0;
    }
  }
 
-  function cojoin(x : Option(word)) -> Option(Option(word)) { // Test that sum types can grow
+  public function cojoin(x : Option(word)) -> Option(Option(word)) { // Test that sum types can grow
     let result = Option.None;
     result = Option.Some(x);
     return result;
    }
 
 
-  function main() -> word {
+  public function main() -> word {
     return maybe(0, join(cojoin(Option.Some(42))));
   }
 }

--- a/test/examples/spec/035padding.solc
+++ b/test/examples/spec/035padding.solc
@@ -1,14 +1,14 @@
 contract Option {
   data Option(a) = None | Some(a);
 
-  function maybe(n : word, o : Option(word)) -> word {
+  public function maybe(n : word, o : Option(word)) -> word {
     match o {
       | Option.Some(x) => return x;
       | Option.None => return n;
     }
   }
 
-  function main() -> word {
+  public function main() -> word {
     return maybe(7, Option.None);
   }
 }

--- a/test/examples/spec/036wildcard.solc
+++ b/test/examples/spec/036wildcard.solc
@@ -1,14 +1,14 @@
 contract Option {
   data Option(a) = None | Some(a);
 
-  function maybe(n : word, o : Option(word)) -> word {
+  public function maybe(n : word, o : Option(word)) -> word {
     match o {
       | Option.Some(x) => return x;
       | _ => return n;
     }
   }
 
-  function main() -> word {
+  public function main() -> word {
     return maybe(7, Option.None);
   }
 }

--- a/test/examples/spec/037dwarves.solc
+++ b/test/examples/spec/037dwarves.solc
@@ -2,7 +2,7 @@ contract Dwarves {
   data Dwarf = Doc | Grumpy | Sleepy | Bashful | Happy | Sneezy | Dopey;
 
 
-  function fromEnum(c : Dwarf) -> word {
+  public function fromEnum(c : Dwarf) -> word {
     match c {
       | Dwarf.Doc      => return 1;
       | Dwarf.Grumpy   => return 2;
@@ -13,5 +13,5 @@ contract Dwarves {
     }
   }
 
-  function main() -> word { return fromEnum(Dwarf.Happy); }
+  public function main() -> word { return fromEnum(Dwarf.Happy); }
 }

--- a/test/examples/spec/038food0.solc
+++ b/test/examples/spec/038food0.solc
@@ -13,11 +13,11 @@ data CFood = Red(Food) | Green(Food) | Nocolor;
 
 
 contract FoodContract {
-  function id(x : CFood) -> CFood {
+  public function id(x : CFood) -> CFood {
     return(x);
   }
 
-  function main() -> word {
+  public function main() -> word {
   return fromEnum(id(CFood.Green(Food.Beans)));
   }
 }

--- a/test/examples/spec/039food.solc
+++ b/test/examples/spec/039food.solc
@@ -15,7 +15,7 @@ data CFood = Red(Food) | Green(Food) | Nocolor;
 
 
 contract FoodContract {
-  function eat(x : CFood) -> Food {
+  public function eat(x : CFood) -> Food {
     match x {
        | CFood.Red(f) => return f;
        | CFood.Green(f) => return f;
@@ -23,7 +23,7 @@ contract FoodContract {
     }
   }
 
-  function main() -> word {
+  public function main() -> word {
   return fromEnum(eat(CFood.Green(Food.Beans)));
   }
 }

--- a/test/examples/spec/041pair.solc
+++ b/test/examples/spec/041pair.solc
@@ -1,12 +1,12 @@
 contract Pair {
 
-  function fst(p : (word, word)) -> word {
+  public function fst(p : (word, word)) -> word {
     match p {
       | (a,b) => return a;
     }
   }
 
-  function main() -> word {
+  public function main() -> word {
     return fst((1,0));
   }
 }

--- a/test/examples/spec/042triple.solc
+++ b/test/examples/spec/042triple.solc
@@ -1,12 +1,12 @@
 contract Triple {
 
-  function asel(t : (word, word, word)) -> word {
+  public function asel(t : (word, word, word)) -> word {
     match t {
       | (a,b,c) => return c;
     }
   }
 
-  function main() -> word {
+  public function main() -> word {
     return asel((1,21,42));
   }
 }

--- a/test/examples/spec/043fstsnd.solc
+++ b/test/examples/spec/043fstsnd.solc
@@ -29,5 +29,5 @@ function addPair(p : Pair(word, word)) -> word {
 }
 
 contract FstSnd {
- function main() -> word { return  addPair(Pair(41,1)); }
+ public function main() -> word { return  addPair(Pair(41,1)); }
 }

--- a/test/examples/spec/047rgb.solc
+++ b/test/examples/spec/047rgb.solc
@@ -1,6 +1,6 @@
 contract RGB {
   data Color = R | G | B;
-  function main() -> word {
+  public function main() -> word {
     match Color.B {
       | Color.R => return 4;
       | Color.G => return 2;

--- a/test/examples/spec/048rgb2.solc
+++ b/test/examples/spec/048rgb2.solc
@@ -1,7 +1,7 @@
 contract RGB {
   data Color = R | G | B;
 
-  function fromEnum(c : Color) -> word {
+  public function fromEnum(c : Color) -> word {
     match c {
       | Color.R => return 4;
       | Color.G => return 2;
@@ -9,5 +9,5 @@ contract RGB {
     }
   }
 
-  function main() -> word { return fromEnum(Color.B); }
+  public function main() -> word { return fromEnum(Color.B); }
 }

--- a/test/examples/spec/049rgb3.solc
+++ b/test/examples/spec/049rgb3.solc
@@ -2,7 +2,7 @@ data RGB = Red(word) | Green(word) | Blue(word);
 
 contract RGB3 {
 
-  function choose(c:RGB) -> word {
+  public function choose(c:RGB) -> word {
     let res : word;
     match c {
       | .Red(x) => assembly { res := add(x,1) }
@@ -11,7 +11,7 @@ contract RGB3 {
       }
       return res;
   }
-  function main() -> word {
+  public function main() -> word {
     choose(RGB.Green(42))
   }
 }

--- a/test/examples/spec/051expreturn.solc
+++ b/test/examples/spec/051expreturn.solc
@@ -50,7 +50,7 @@ forall a b. function unsafeCast(x:a) -> b {
 
 
 contract ExpReturn {
-  function main() -> Word {
+  public function main() -> Word {
     return elimBool1(Bool.False);
     // return elimBool1(Bool.False);
   }

--- a/test/examples/spec/051negBool.solc
+++ b/test/examples/spec/051negBool.solc
@@ -18,12 +18,12 @@ instance B : Neg {
 
 contract NegBool {
 
-  function fromB(b) {
+  public function fromB(b) {
     match b  {
     | B.F => return 0;
     | B.T => return 1;
     }
   }
 
-  function main() { return  fromB(Neg.neg(B.F)); }
+  public function main() { return  fromB(Neg.neg(B.F)); }
 }

--- a/test/examples/spec/052negPair.solc
+++ b/test/examples/spec/052negPair.solc
@@ -45,19 +45,19 @@ instance (a:Neg,b:Neg) => Pair(a,b):Neg {
 */
 contract NegPair {
 
- function bnot(x) {
+ public function bnot(x) {
    match x {
      | B.T => return B.F;
      | B.F => return B.T;
    }
 }
 
- function fromB(b) {
+ public function fromB(b) {
   match b  {
     | B.F => return 0;
     | B.T => return 1;
   }
 }
 
- function main() { return  fromB(fst(Neg.neg(Pair(B.F,B.T)))); }
+ public function main() { return  fromB(fst(Neg.neg(Pair(B.F,B.T)))); }
 }

--- a/test/examples/spec/052return.solc
+++ b/test/examples/spec/052return.solc
@@ -50,7 +50,7 @@ let res: b; return res;
 
 
 contract ExpReturn {
-  function main() -> word {
+  public function main() -> word {
     return elimBool1(Bool.False);
     // return elimBool1(Bool.True);
   }

--- a/test/examples/spec/053return.solc
+++ b/test/examples/spec/053return.solc
@@ -29,7 +29,7 @@ function elimBool1(b:Bool) -> word {
 
 
 contract ExpReturn {
-  function main() -> word {
+  public function main() -> word {
     return elimBool1(Bool.False);
     // return elimBool1(Bool.True);
   }

--- a/test/examples/spec/06comp.solc
+++ b/test/examples/spec/06comp.solc
@@ -1,9 +1,9 @@
 contract Compose {
-  function id(x : word) -> word { return x; }
+  public function id(x : word) -> word { return x; }
 
-  function idid(x : word) -> word { return id(id(x)); }
+  public function idid(x : word) -> word { return id(id(x)); }
 
-  function main() -> word {
+  public function main() -> word {
     return idid(42);
   }
 }

--- a/test/examples/spec/09not.solc
+++ b/test/examples/spec/09not.solc
@@ -1,18 +1,18 @@
 contract Not {
   data Bool = False | True;
 
-  function main() -> word {
+  public function main() -> word {
     return fromBool(bnot(Bool.False));
   }
 
-  function fromBool(b : Bool) -> word {
+  public function fromBool(b : Bool) -> word {
     match(b) {
       | Bool.False => return 0;
       | Bool.True  => return 1;
     }
   }
 
-  function bnot(b : Bool) -> Bool {
+  public function bnot(b : Bool) -> Bool {
     match b {
       | Bool.False => return Bool.True;
       | Bool.True => return Bool.False;

--- a/test/examples/spec/101struct1Field.solc
+++ b/test/examples/spec/101struct1Field.solc
@@ -247,7 +247,7 @@ function g() -> word {
 }
 
 contract C {
-    function main() {
+    public function main() {
         f();
         return g();
     }

--- a/test/examples/spec/102uintField.solc
+++ b/test/examples/spec/102uintField.solc
@@ -254,7 +254,7 @@ function g() -> word {
 }
 
 contract C {
-    function main() {
+    public function main() {
         f();
         return g();
     }

--- a/test/examples/spec/103struct3Fields.solc
+++ b/test/examples/spec/103struct3Fields.solc
@@ -278,7 +278,7 @@ function g() -> word {
 }
 
 contract C {
-    function main() {
+    public function main() {
         return g();
     }
 }

--- a/test/examples/spec/105nestedStruct.solc
+++ b/test/examples/spec/105nestedStruct.solc
@@ -334,7 +334,7 @@ function readW(w:memory(W)) -> memory(S) {
 }
 
 contract C {
-    function main() {
+    public function main() {
         let s:memory(S) = makeS();
 	let w:memory(W) = makeW(s);
 	let s2:memory(S) = readW(w);

--- a/test/examples/spec/10negBool.solc
+++ b/test/examples/spec/10negBool.solc
@@ -18,12 +18,12 @@ instance B : Neg {
 
 contract NegBool {
 
-  function fromB(b : B) -> word {
+  public function fromB(b : B) -> word {
     match b  {
     | B.F => return 0;
     | B.T => return 1;
     }
   }
 
-  function main() -> word { return  fromB(Neg.neg(B.F)); }
+  public function main() -> word { return  fromB(Neg.neg(B.F)); }
 }

--- a/test/examples/spec/111storageStruct.solc
+++ b/test/examples/spec/111storageStruct.solc
@@ -282,7 +282,7 @@ function g() -> word {
 }
 
 contract C {
-    function main() {
+    public function main() {
         return g();
     }
 }

--- a/test/examples/spec/112ContractStorage.solc
+++ b/test/examples/spec/112ContractStorage.solc
@@ -23,7 +23,7 @@ instance StructField(ContractStorage(CounterCxt), counter_sel):CStructField(word
 contract Counter {
   // struct CounterCxt { counter:word }
 
-  function main() -> word {
+  public function main() -> word {
        let cxt : ContractStorage(CounterCxt) = ContractStorage(CounterCxt);
        let counter_map : MemberAccessProxy(ContractStorage(CounterCxt), counter_sel, ())
        = MemberAccessProxy(cxt, counter_sel);

--- a/test/examples/spec/113counter.solc
+++ b/test/examples/spec/113counter.solc
@@ -15,7 +15,7 @@ data counter_sel = counter_sel;
 instance StructField(ContractStorage(()), counter_sel):CStructField(word, ()) {}
 
 contract Counter {
-   function main () -> word {
+   public function main () -> word {
       let counter_map /*: MemberAccessProxy(ContractStorage(()), counter_sel, ()) */ = MemberAccessProxy(ContractStorage(()), counter_sel);
       Assign.assign(LValueMemberAccess.memberAccess(MemberAccessProxy(ContractStorage(()), counter_sel)), add(rval(counter_map), 1));
       return rval(counter_map);

--- a/test/examples/spec/11negPair.solc
+++ b/test/examples/spec/11negPair.solc
@@ -35,19 +35,19 @@ forall a b . a : Neg, b : Neg => instance (a,b):Neg {
 
 contract NegPair {
 
- function bnot(x : B) -> B {
+ public function bnot(x : B) -> B {
    match x {
      | B.T => return B.F;
      | B.F => return B.T;
    }
 }
 
- function fromB(b : B) -> word {
+ public function fromB(b : B) -> word {
   match b  {
     | B.F => return 0;
     | B.T => return 1;
   }
 }
 
- function main() -> word { return  fromB(fst(Neg.neg((B.F,B.T)))); }
+ public function main() -> word { return  fromB(fst(Neg.neg((B.F,B.T)))); }
 }

--- a/test/examples/spec/120basicCounter.solc
+++ b/test/examples/spec/120basicCounter.solc
@@ -2,7 +2,7 @@ import std.{*};
 contract Counter {
   counter : word;
 
-  function main() -> word {
+  public function main() -> word {
     counter = Num.add(counter, 42);
     return counter;
   }

--- a/test/examples/spec/121counter.solc
+++ b/test/examples/spec/121counter.solc
@@ -7,7 +7,7 @@ pragma no-bounded-variable-condition ;
 contract Counter {
   counter : word;
 
-  function main() -> word {
+  public function main() -> word {
     counter = std.addWord(counter, 1);
     return counter;
   }

--- a/test/examples/spec/122counters.solc
+++ b/test/examples/spec/122counters.solc
@@ -7,7 +7,7 @@ contract Counter {
   counter1 : word;
   counter2 : uint256;
   counter3 : word;
-  function main() -> word {
+  public function main() -> word {
     counter1 += 1;
     counter3 += 2;
     return counter1 + counter3;

--- a/test/examples/spec/123stackAndStorage.solc
+++ b/test/examples/spec/123stackAndStorage.solc
@@ -6,7 +6,7 @@ contract Counter {
   counter2 : uint256;
   counter3 : word;
   
-  function main() -> word {
+  public function main() -> word {
     let x: word;
     x = counter1 + 1;
     counter1 = x;

--- a/test/examples/spec/126nanoerc20.solc
+++ b/test/examples/spec/126nanoerc20.solc
@@ -39,13 +39,13 @@ contract Uint {
   totalSupply : uint256;
   balances : mapping(address,uint256);
 
-  function mint(amount:uint256) -> () {
+  public function mint(amount:uint256) -> () {
     balances[owner] = Num.add(balances[owner], amount);
     totalSupply = Num.add(totalSupply, amount);
   }
 
   //     function transferFrom(address src, address dst, uint256 amt) public returns (bool) 
-  function transferFrom(src:address, dst:address, amt:uint256) -> bool {
+  public function transferFrom(src:address, dst:address, amt:uint256) -> bool {
      require1(ge(balances[src], amt));
 
      /*
@@ -58,21 +58,21 @@ contract Uint {
   }
 
 
-  function withdraw(src:address, amt:uint256) -> () {
+  public function withdraw(src:address, amt:uint256) -> () {
     balances[src] = Num.sub(balances[src], amt):uint256;
   }
   
-  function deposit(dst:address, amt:uint256) -> () {
+  public function deposit(dst:address, amt:uint256) -> () {
     balances[dst] = Num.add(balances[dst], amt):uint256;
   }
 
-  function init() -> () {
+  public function init() -> () {
     owner = address(0x123456789abcdef);
     msg_sender = caller();
     decimals = uint256(18);
   }
   
-  function main() -> uint256 {
+  public function main() -> uint256 {
     init();
     mint(uint256(1000));
     let src : address = owner;

--- a/test/examples/spec/127microerc20.solc
+++ b/test/examples/spec/127microerc20.solc
@@ -39,7 +39,7 @@ contract Mini {
   balances : mapping(address,uint256);
   allowance : mapping(address, mapping(address, uint256));
 
-  function mint(amount:uint256) -> () {
+  public function mint(amount:uint256) -> () {
     balances[owner] = Num.add(balances[owner], amount);
     totalSupply = Num.add(totalSupply, amount);
   }
@@ -60,7 +60,7 @@ contract Mini {
 */
 
 //  function transferFrom(src:address, dst:address, amt:uint256) -> bool {
-  function transferFrom(src : address, dst : address, amt : uint256) -> bool  {
+  public function transferFrom(src : address, dst : address, amt : uint256) -> bool  {
      require1(ge(balances[src], amt));
 
      match (Eq.eq(src, msg_sender)) {
@@ -90,13 +90,13 @@ contract Mini {
 */
 
 
-  function init() -> () {
+  public function init() -> () {
     owner = address(0x123456789abcdef);
     msg_sender = caller();
     decimals = uint256(18);
   }
 
-  function main() -> uint256 {
+  public function main() -> uint256 {
     init();
     mint(uint256(1000));
     allowance[owner][msg_sender] = uint256(10000);

--- a/test/examples/spec/128minierc20.solc
+++ b/test/examples/spec/128minierc20.solc
@@ -28,7 +28,7 @@ contract MiniERC20 {
   balances : mapping(address,uint256);
   allowance : mapping(address, mapping(address, uint256));
 
-  function mint(amount:uint256) -> () {
+  public function mint(amount:uint256) -> () {
     balances[owner] = Num.add(balances[owner], amount);
     totalSupply = Num.add(totalSupply, amount);
   }
@@ -48,7 +48,7 @@ contract MiniERC20 {
     }
 */
 
-  function transferFrom(src:address, dst:address, amt:uint256) -> bool {
+  public function transferFrom(src:address, dst:address, amt:uint256) -> bool {
      let msg_sender = caller();
      myrequire( balances[src] >= amt /* "token/insufficient-balance" */
             , 0x746f6b656e2f696e73756666696369656e742d62616c616e6365
@@ -73,7 +73,7 @@ contract MiniERC20 {
     }
 */
 
-  function approve(usr: address, amt: uint256) -> bool {
+  public function approve(usr: address, amt: uint256) -> bool {
       let msg_sender = caller();
       allowance[msg_sender][usr] = amt;
       // emit Approval(msg.sender, usr, amt);
@@ -81,12 +81,12 @@ contract MiniERC20 {
 
   }
 
-  function init() -> () {
+  public function init() -> () {
     owner = address(0x123456789abcdef);
     decimals = uint256(18); // Num.fromWord(18) fails, which may be a problem
   }
 
-  function main() -> uint256 {
+  public function main() -> uint256 {
     let msg_sender = caller();
     init();
     mint(uint256(1000));

--- a/test/examples/spec/131constructor.solc
+++ b/test/examples/spec/131constructor.solc
@@ -2,13 +2,13 @@
 
 contract Counter {
 
-  function setCounter(v: word) {
+  public function setCounter(v: word) {
     assembly {
       sstore(0x00, v)
     }
   }
 
-  function getCounter() -> word {
+  public function getCounter() -> word {
     let res;
     assembly {
       res := sload(0x00)
@@ -21,7 +21,7 @@ contract Counter {
    setCounter(42);
   }
 
-  function main() -> word {
+  public function main() -> word {
     return getCounter();
   }
 }

--- a/test/examples/spec/135cons3.solc
+++ b/test/examples/spec/135cons3.solc
@@ -15,7 +15,7 @@ function log1(v:t, topic:word) -> () {
 contract Counter {
 
   // setCounter & getCounter are intentionally low-level to avoid clutter
-  function setCounter(v: uint256) -> () {
+  public function setCounter(v: uint256) -> () {
     match v { | uint256(w) =>
       assembly {
 	sstore(0x00, w)
@@ -23,7 +23,7 @@ contract Counter {
     }
   }
 
-  function getCounter() -> uint256 {
+  public function getCounter() -> uint256 {
     let res;
     assembly {
       res := sload(0x00)

--- a/test/examples/spec/903badassign.solc
+++ b/test/examples/spec/903badassign.solc
@@ -1,16 +1,16 @@
 contract Option {
   data Option(a) = None | Some(a);
 
-  function just(x : word) -> Option(word) { return Option.Some(x); }
+  public function just(x : word) -> Option(word) { return Option.Some(x); }
 
-  function maybe(n : word, o : Option(word)) -> word {
+  public function maybe(n : word, o : Option(word)) -> word {
     match o {
       | Option.None => return n;
       | Option.Some(x) => return x;
     }
   }
 
-  function join(mmx : Option(Option(word))) -> Option(word) {
+  public function join(mmx : Option(Option(word))) -> Option(word) {
     let result = Option.None;
     match mmx {
       | Option.Some(Option.Some(x)) => result = Option.Some(x);
@@ -21,7 +21,7 @@ contract Option {
     return result;
   }
 
-  function main() -> word {
+  public function main() -> word {
     return maybe(0, join(Option.Some(Option.Some(42))));
   }
 }

--- a/test/examples/spec/939badfood.solc
+++ b/test/examples/spec/939badfood.solc
@@ -15,7 +15,7 @@ instance Food : Enum {
 }
 
 contract FoodContract {
-  function main() -> word {
+  public function main() -> word {
         return Enum.fromEnum(Food.Beans);
   }
 }

--- a/test/examples/spec/SimpleField.solc
+++ b/test/examples/spec/SimpleField.solc
@@ -6,11 +6,11 @@ pragma no-bounded-variable-condition ;
 contract Simple {
   myval : word ;
 
-  function getVal () -> word {
+  public function getVal () -> word {
     return myval ;
   }
 
-  function main () -> word {
+  public function main () -> word {
     return getVal();
   }
 }

--- a/test/examples/spec/attic/051expreturn.solc
+++ b/test/examples/spec/attic/051expreturn.solc
@@ -53,7 +53,7 @@ contract ExpReturn {
 
 
 
-  function main() -> Word {
+  public function main() -> Word {
     return elimBool1(Bool.False);
     // return elimBool1(Bool.False);
   }

--- a/test/examples/spec/attic/052return.solc
+++ b/test/examples/spec/attic/052return.solc
@@ -50,7 +50,7 @@ let res: b; return res;
 
 
 contract ExpReturn {
-  function main() -> word {
+  public function main() -> word {
     return elimBool1(Bool.False);
     // return elimBool1(Bool.True);
   }

--- a/test/examples/spec/attic/053return.solc
+++ b/test/examples/spec/attic/053return.solc
@@ -29,7 +29,7 @@ function elimBool1(b:Bool) -> word {
 
 
 contract ExpReturn {
-  function main() -> word {
+  public function main() -> word {
     return elimBool1(Bool.False);
     // return elimBool1(Bool.True);
   }

--- a/test/imports/external_lib_main.solc
+++ b/test/imports/external_lib_main.solc
@@ -3,7 +3,7 @@ import @extlib.math.api;
 contract External {
   constructor() {}
 
-  function main() -> word {
+  public function main() -> word {
     return math.api.sum(39);
   }
 }


### PR DESCRIPTION
In a `contract` every function is private, unless marked as `public`. Special cases: `constructor` and `fallback` are always considered public, but the keyword is not needed to be present (if fact it can't be).