### PR TITLE
Support contracts with no functions

### DIFF
--- a/std/dispatch.solc
+++ b/std/dispatch.solc
@@ -211,6 +211,11 @@ forall name payability args rets fn
   }
 }
 
+// Base case: a contract with no methods has nothing to dispatch to
+instance ():RunDispatch {
+  function go(methods : ()) -> () { }
+}
+
 // Recursive instance
 forall n m . n:ExecMethod, n:Selector, m:RunDispatch => instance (n,m):RunDispatch {
   function go(methods : (n,m)) -> () {

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -86,7 +86,9 @@ dispatches =
       runDispatchTest "stringid.solc",
       runDispatchTest "miniERC20.solc",
       runDispatchTest "Revert.solc",
-      runDispatchTest "hashes.solc"
+      runDispatchTest "hashes.solc",
+      runDispatchTest "empty.solc",
+      runDispatchTest "empty_no_constructor.solc"
     ]
   where
     runDispatchTest file = runTestForFileWith (emptyOption mempty) file "./test/examples/dispatch"

--- a/test/examples/dispatch/empty.solc
+++ b/test/examples/dispatch/empty.solc
@@ -1,0 +1,6 @@
+import std.{*};
+import std.dispatch.{*};
+
+contract C {
+    constructor() {}
+}

--- a/test/examples/dispatch/empty_no_constructor.solc
+++ b/test/examples/dispatch/empty_no_constructor.solc
@@ -1,0 +1,5 @@
+import std.{*};
+import std.dispatch.{*};
+
+contract C {
+}


### PR DESCRIPTION
Fixes #439.

Add a no-op `() : RunDispatch` instance so that contracts with no methods type-check. Previously `tupleExpFromList []` in the dispatch desugarer produced a `()` for the methods tuple, and the type checker could not entail `() : RunDispatch`, breaking compilation of contracts like `contract C { constructor() {} }` or `contract C {}`.