### PR TITLE
Add memory initialisation if contract is not deployed

### DIFF
--- a/yule/Main.hs
+++ b/yule/Main.hs
@@ -60,7 +60,10 @@ main = do
 wrapInObject :: Bool -> YulObject -> Doc
 wrapInObject deploy yulo@(YulObject name code inners)
   | deploy = ppr (createDeployment yulo)
-  | otherwise = ppr (YulObject name (addRetCode code) inners)
+  | otherwise = ppr (YulObject name (addMemInit (addRetCode code)) inners)
+
+addMemInit :: YulCode -> YulCode
+addMemInit c = YulCode [[yulStmt| mstore(64, memoryguard(128)) |]] <> c
 
 addRetCode :: YulCode -> YulCode
 addRetCode c = c <> retCode


### PR DESCRIPTION
This is an attempt to fix #442: in a regular contract, memory initialisation is performed by dispatch code, so it does not happen for contracts with explicit `main`. This PR adds memory initialisation code for contracts that are not deployed (this means mostly some tests)