### PR TITLE
flake: rebuild testrunner on `nix develop`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -154,6 +154,7 @@
             pkgs.foundry-bin
             pkgs.go-ethereum
             pkgs.jq
+            pkgs.nlohmann_json
             pkgs.solc
             evmone-lib
             (hspkgs.hevm.overrideAttrs (old: { patches = []; }))
@@ -162,6 +163,22 @@
             pkgs.mdbook
           ];
           evmone="${evmone-lib}/lib/${if pkgs.stdenv.isDarwin then "libevmone.dylib" else "libevmone.so"}";
+
+          # Make sure the C++ testrunner is (re)built whenever its sources
+          # change. CMake's incremental build is a no-op when nothing has
+          # changed, so this is cheap on warm shells.
+          shellHook = ''
+            if [ -z "''${SOLCORE_SKIP_TESTRUNNER_BUILD:-}" ]; then
+              testrunner_build_dir="''${PWD}/build"
+              if [ ! -f "$testrunner_build_dir/CMakeCache.txt" ]; then
+                echo "[nix develop] Configuring testrunner build in $testrunner_build_dir"
+                cmake -S "$PWD" -B "$testrunner_build_dir" \
+                  -DIGNORE_VENDORED_DEPENDENCIES=ON >/dev/null
+              fi
+              echo "[nix develop] Building testrunner (incremental)"
+              cmake --build "$testrunner_build_dir" --target testrunner
+            fi
+          '';
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -167,14 +167,21 @@
           # Make sure the C++ testrunner is (re)built whenever its sources
           # change. CMake's incremental build is a no-op when nothing has
           # changed, so this is cheap on warm shells.
+          #
+          # CMakeCache.txt is deleted before each configure so that cmake
+          # re-detects the compiler and make from the current nix store.
+          # The cache becomes stale when the shell enters a different
+          # derivation (different nix store hash for the same tool), causing
+          # "no such file or directory" errors when the old path is gone.
+          # Deleting the cache is safe: compiled object files are preserved
+          # so the subsequent build is still incremental.
           shellHook = ''
             if [ -z "''${SOLCORE_SKIP_TESTRUNNER_BUILD:-}" ]; then
               testrunner_build_dir="''${PWD}/build"
-              if [ ! -f "$testrunner_build_dir/CMakeCache.txt" ]; then
-                echo "[nix develop] Configuring testrunner build in $testrunner_build_dir"
-                cmake -S "$PWD" -B "$testrunner_build_dir" \
-                  -DIGNORE_VENDORED_DEPENDENCIES=ON >/dev/null
-              fi
+              echo "[nix develop] Configuring testrunner build in $testrunner_build_dir"
+              rm -f "$testrunner_build_dir/CMakeCache.txt"
+              cmake -S "$PWD" -B "$testrunner_build_dir" \
+                -DIGNORE_VENDORED_DEPENDENCIES=ON >/dev/null
               echo "[nix develop] Building testrunner (incremental)"
               cmake --build "$testrunner_build_dir" --target testrunner
             fi


### PR DESCRIPTION
Add a shellHook that configures the CMake build directory (if missing) and runs `cmake --build build --target testrunner`. CMake's incremental build is a no-op when nothing changed, so this is cheap on warm shells but ensures the binary stays in sync with `test/testrunner/` sources.

Also add `pkgs.nlohmann_json` to the dev shell so the build can pick it up via `IGNORE_VENDORED_DEPENDENCIES=ON`, matching the path used by the Nix `checks.contests` derivation.

Set SOLCORE_SKIP_TESTRUNNER_BUILD=1 to opt out.