### PR TITLE
New options for runsol.sh

### DIFF
--- a/runsol.sh
+++ b/runsol.sh
@@ -10,12 +10,14 @@ if [[ $# -lt 1 ]]; then
     echo "  --runtime-raw-calldata hex        Pass raw calldata directly to geth"
     echo "  --runtime-callvalue value         Pass callvalue to geth (in wei)"
     echo "  --runtime-sender address          Set the sender address for the runtime call"
+    echo "  --runtime-sender-balance wei      Fund the sender account in the genesis state"
     echo "  --debug-runtime                   Explore the evm execution in the interactive debugger"
     echo "  --create true|false               Run the initcode to deploy the contract (default: true)"
     echo "  --create-arguments sig [args...]  Generate calldata using cast calldata"
     echo "  --create-raw-arguments hex        Pass raw calldata directly to geth"
     echo "  --create-callvalue value          Pass callvalue to geth (in wei)"
     echo "  --debug-create                    Explore the evm execution in the interactive debugger"
+    echo "  --verbose                         Print full returndata instead of truncating"
     exit 1
 fi
 
@@ -45,7 +47,9 @@ runtime_calldata_args=()
 runtime_raw_calldata=""
 runtime_callvalue=""
 runtime_sender=""
+runtime_sender_balance=""
 runtime_debug=false
+verbose=false
 
 create=true
 
@@ -96,6 +100,15 @@ while [[ $# -gt 0 ]]; do
                   exit 1
               fi
               runtime_sender=$1
+              shift
+              ;;
+          --runtime-sender-balance)
+              shift
+              if [[ $# -eq 0 ]]; then
+                  echo "Error: --runtime-sender-balance requires a value in wei"
+                  exit 1
+              fi
+              runtime_sender_balance=$1
               shift
               ;;
           --debug-runtime)
@@ -153,6 +166,10 @@ while [[ $# -gt 0 ]]; do
           --debug-create)
               shift
               create_debug=true
+              ;;
+          --verbose)
+              shift
+              verbose=true
               ;;
         *)
             echo "Error: Unknown option: $1"
@@ -278,6 +295,15 @@ if [[ "$create" == "true" ]]; then
     alloc: .accounts
   }')
 
+  if [[ -n "$runtime_sender_balance" ]]; then
+      sender_addr="${runtime_sender:-0x000000000000000000000000000073656e646572}"
+      balance_hex="0x$(printf '%x' "$runtime_sender_balance")"
+      genesis_json=$(echo "$genesis_json" | jq \
+          --arg addr "$sender_addr" \
+          --arg bal  "$balance_hex" \
+          '.alloc[$addr] = {balance: $bal}')
+  fi
+
   echo "$genesis_json" > "$create_poststate"
   echo "$output" | jq -R -c 'fromjson? | select(type == "object")' > "$create_tracefile"
 
@@ -291,10 +317,10 @@ if [[ "$create" == "true" ]]; then
 
   if [[ "$error" == "null" ]]; then
       echo "Creation successful"
-      if [[ ${#result} -gt 16 ]]; then
-          echo "returndata: 0x${result:0:8}...${result: -8}"
-      else
+      if [[ "$verbose" == "true" ]]; then
           echo "returndata: 0x${result}"
+      else
+          echo "returndata: 0x${result:0:8}...${result: -8}"
       fi
   else
       echo "Creation failed: $error"


### PR DESCRIPTION
new opts to runsol.sh: 
 - `--runtime-sender-balance` - caller account balance in wei
 - `--verbose` enables printing full deployment returndata

Usage example:

```
./runsol.sh test/examples/dispatch/payable.solc --runtime-callvalue 42 --runtime-calldata  'deposit(uint)' 42  --runtime-sender-balance 84
```

can be used in conjunction with `--runtime-sender`