### PR TITLE
Enforce payable vs non-payable constructors

### DIFF
--- a/run_contests.sh
+++ b/run_contests.sh
@@ -12,6 +12,8 @@ bash ./contest.sh test/examples/dispatch/Revert.json
 bash ./contest.sh test/examples/dispatch/ownable.json
 bash ./contest.sh test/examples/dispatch/hashes.json
 bash ./contest.sh test/examples/dispatch/payable.json
+bash ./contest.sh test/examples/dispatch/payable_ctor.json
+bash ./contest.sh test/examples/dispatch/nonpayable_ctor.json
 bash ./contest.sh test/examples/dispatch/concat.json
 bash ./contest.sh test/examples/dispatch/slices.json
 bash ./contest.sh test/examples/dispatch/fallback.json

--- a/src/Solcore/Desugarer/ContractDispatch.hs
+++ b/src/Solcore/Desugarer/ContractDispatch.hs
@@ -78,7 +78,7 @@ genMainFn addMain c@(Contract cname tys cdecls)
   where
     cdecls'' = if hasConstructor cdecls then cdecls else cdecls ++ [defaultConstructor]
     cdecls' = Set.unions (map (transformCDecl cname) cdecls'')
-    defaultConstructor = CConstrDecl (Constructor {constrParams = [], constrBody = []})
+    defaultConstructor = CConstrDecl (Constructor {constrParams = [], constrBody = [], constrPayable = False})
     mainfn = FunDef False (Signature [] [] "main" [] False (Just unit) False) body
     body = [StmtExp (Call Nothing (QualName "RunContract" "exec") [cdata])]
     cdata = Con "Contract" [methods, fallback]
@@ -135,6 +135,7 @@ transformConstructor contractName cons
   | otherwise = error $ "Internal Error: contract constructor must be fully typed"
   where
     params = constrParams cons
+    payable = constrPayable cons
     argsTuple = (tupleTyFromList (mapMaybe getTy params))
     initFun = CFunDecl (FunDef False initSig (constrBody cons))
     initSig =
@@ -200,19 +201,34 @@ transformConstructor contractName cons
           sigReturn = Just unit,
           sigPayable = False
         }
+    -- A non-payable constructor must reject any incoming value transfer
+    -- during deployment. A payable constructor skips this check. This mirrors
+    -- the method-level callvalue check used by the runtime dispatch and
+    -- reverts with the same NonPayableReceivedValue error (0xb5988ea3).
+    callvalueCheck
+      | payable = []
+      | otherwise =
+          [ StmtExp $
+              Call
+                Nothing
+                (QualName "MethodLevelCallvalueCheck" "checkCallvalue")
+                [proxyExp (TyCon "NonPayable" [])]
+          ]
     startBody =
-      [ Asm [yulBlock|{ mstore(64, memoryguard(128)) }|],
-        Let False "conargs" (Just argsTuple) (Just (Call Nothing "copy_arguments_for_constructor" [])),
-        -- , Match [Var "conargs"] ...
-        Let False "fun" Nothing (Just (Var initFunName)),
-        StmtExp $ Call Nothing "fun" [Var "conargs"],
-        Asm
-          [yulBlock|{
+      [ Asm [yulBlock|{ mstore(64, memoryguard(128)) }|]
+      ]
+        <> callvalueCheck
+        <> [ Let False "conargs" (Just argsTuple) (Just (Call Nothing "copy_arguments_for_constructor" [])),
+             -- , Match [Var "conargs"] ...
+             Let False "fun" Nothing (Just (Var initFunName)),
+             StmtExp $ Call Nothing "fun" [Var "conargs"],
+             Asm
+               [yulBlock|{
             let size := datasize(`yulContractName`)
             codecopy(0, dataoffset(`yulContractName`), datasize(`yulContractName`))
             return(0, size)
           }|]
-      ]
+           ]
     startFun = CFunDecl (FunDef False startSig startBody)
 
     isTyped (Typed {}) = True

--- a/src/Solcore/Desugarer/DecisionTreeCompiler.hs
+++ b/src/Solcore/Desugarer/DecisionTreeCompiler.hs
@@ -78,8 +78,8 @@ instance Compile (ContractDecl Id) where
   compile d = pure d
 
 instance Compile (Constructor Id) where
-  compile (Constructor ps bd) =
-    Constructor ps <$> compile bd
+  compile (Constructor ps bd payable) =
+    (\bd' -> Constructor ps bd' payable) <$> compile bd
 
 instance Compile (FunDef Id) where
   compile (FunDef p sig bd) =

--- a/src/Solcore/Desugarer/IndirectCall.hs
+++ b/src/Solcore/Desugarer/IndirectCall.hs
@@ -77,8 +77,8 @@ instance Desugar (Field Name) where
     Field n t <$> desugar me
 
 instance Desugar (Constructor Name) where
-  desugar (Constructor ps bd) =
-    Constructor ps <$> desugar bd
+  desugar (Constructor ps bd payable) =
+    (\bd' -> Constructor ps bd' payable) <$> desugar bd
 
 instance Desugar (Stmt Name) where
   desugar (lhs := rhs) =

--- a/src/Solcore/Frontend/Module/Loader.hs
+++ b/src/Solcore/Frontend/Module/Loader.hs
@@ -490,8 +490,8 @@ stubContractDeclBody (CFieldDecl (Field n ty _initExp)) =
   CFieldDecl (Field n ty Nothing)
 stubContractDeclBody (CFunDecl fd) =
   CFunDecl (stubFunDefBody fd)
-stubContractDeclBody (CConstrDecl (Constructor params _body)) =
-  CConstrDecl (Constructor params [])
+stubContractDeclBody (CConstrDecl (Constructor params _body payable)) =
+  CConstrDecl (Constructor params [] payable)
 stubContractDeclBody decl =
   decl
 
@@ -1449,11 +1449,12 @@ renameContractDeclTypeRefs renameMap (CFieldDecl (Field n ty me)) =
     (Field n (renameTyTypeRefs renameMap ty) (renameExpTypeRefs renameMap <$> me))
 renameContractDeclTypeRefs renameMap (CFunDecl fd) =
   CFunDecl (renameFunDefTypeRefs renameMap fd)
-renameContractDeclTypeRefs renameMap (CConstrDecl (Constructor ps body)) =
+renameContractDeclTypeRefs renameMap (CConstrDecl (Constructor ps body payable)) =
   CConstrDecl
     ( Constructor
         (map (renameParamTypeRefs renameMap) ps)
         (renameBodyTypeRefs renameMap body)
+        payable
     )
 
 renameClassTypeRefs :: Map Name Name -> Class -> Class

--- a/src/Solcore/Frontend/Parser/Decl.hs
+++ b/src/Solcore/Frontend/Parser/Decl.hs
@@ -332,7 +332,7 @@ contractDeclP =
   CDataDecl
     <$> dataP
       <|> CConstrDecl
-    <$> constructorDeclP
+    <$> try constructorDeclP
       <|> rejectPublicOnImplicitlyPublicP
       <|> withSigPrefix
         ( \vars ctx ->
@@ -364,10 +364,11 @@ fieldDeclP = do
 
 constructorDeclP :: Parser Constructor
 constructorDeclP = do
+  payable <- option False (True <$ keyword "payable")
   keyword "constructor"
   ps <- parens (paramP `sepBy` comma)
   body <- braces bodyP
-  return (Constructor ps body)
+  return (Constructor ps body payable)
 
 topDeclP :: Parser TopDecl
 topDeclP =

--- a/src/Solcore/Frontend/Pretty/SolcorePretty.hs
+++ b/src/Solcore/Frontend/Pretty/SolcorePretty.hs
@@ -161,8 +161,7 @@ instance (Pretty a) => Pretty (ContractDecl a) where
 
 instance (Pretty a) => Pretty (Constructor a) where
   ppr (Constructor ps bd payable) =
-    (if payable then text "payable" else empty)
-      <+> text "constructor"
+    (if payable then text "payable" <+> text "constructor" else text "constructor")
       <+> pprParams ps
       <+> lbrace
       $$ nest 3 (vcat (map ppr bd))

--- a/src/Solcore/Frontend/Pretty/SolcorePretty.hs
+++ b/src/Solcore/Frontend/Pretty/SolcorePretty.hs
@@ -160,8 +160,9 @@ instance (Pretty a) => Pretty (ContractDecl a) where
     ppr c
 
 instance (Pretty a) => Pretty (Constructor a) where
-  ppr (Constructor ps bd) =
-    text "constructor"
+  ppr (Constructor ps bd payable) =
+    (if payable then text "payable" else empty)
+      <+> text "constructor"
       <+> pprParams ps
       <+> lbrace
       $$ nest 3 (vcat (map ppr bd))

--- a/src/Solcore/Frontend/Pretty/TreePretty.hs
+++ b/src/Solcore/Frontend/Pretty/TreePretty.hs
@@ -136,8 +136,9 @@ instance Pretty ContractDecl where
     ppr c
 
 instance Pretty Constructor where
-  ppr (Constructor ps bd) =
-    text "constructor"
+  ppr (Constructor ps bd payable) =
+    (if payable then text "payable" else empty)
+      <+> text "constructor"
       <+> pprParams ps
       <+> lbrace
       $$ nest 3 (vcat (map ppr bd))

--- a/src/Solcore/Frontend/Pretty/TreePretty.hs
+++ b/src/Solcore/Frontend/Pretty/TreePretty.hs
@@ -137,8 +137,7 @@ instance Pretty ContractDecl where
 
 instance Pretty Constructor where
   ppr (Constructor ps bd payable) =
-    (if payable then text "payable" else empty)
-      <+> text "constructor"
+    (if payable then text "payable" <+> text "constructor" else text "constructor")
       <+> pprParams ps
       <+> lbrace
       $$ nest 3 (vcat (map ppr bd))

--- a/src/Solcore/Frontend/Syntax/Contract.hs
+++ b/src/Solcore/Frontend/Syntax/Contract.hs
@@ -141,7 +141,8 @@ data TySym
 data Constructor a
   = Constructor
   { constrParams :: [Param a],
-    constrBody :: (Body a)
+    constrBody :: (Body a),
+    constrPayable :: Bool
   }
   deriving (Eq, Ord, Show, Data, Typeable)
 

--- a/src/Solcore/Frontend/Syntax/NameResolution.hs
+++ b/src/Solcore/Frontend/Syntax/NameResolution.hs
@@ -238,13 +238,13 @@ instance Resolve S.ContractDecl where
 instance Resolve S.Constructor where
   type Result S.Constructor = Constructor Name
 
-  resolve c@(S.Constructor ps bdy) =
+  resolve c@(S.Constructor ps bdy payable) =
     withLocalCtx $ do
       ps' <- resolve ps `wrapError` c
       let args = map paramName ps'
       mapM_ addParameter args
       bdy' <- resolve bdy `wrapError` c
-      pure (Constructor ps' bdy')
+      pure (Constructor ps' bdy' payable)
 
 instance Resolve S.Field where
   type Result S.Field = Field Name

--- a/src/Solcore/Frontend/Syntax/SyntaxTree.hs
+++ b/src/Solcore/Frontend/Syntax/SyntaxTree.hs
@@ -164,7 +164,8 @@ data TySym
 data Constructor
   = Constructor
   { constrParams :: [Param],
-    constrBody :: Body
+    constrBody :: Body,
+    constrPayable :: Bool
   }
   deriving (Eq, Ord, Show, Data, Typeable)
 

--- a/src/Solcore/Frontend/TypeInference/SccAnalysis.hs
+++ b/src/Solcore/Frontend/TypeInference/SccAnalysis.hs
@@ -221,7 +221,7 @@ instance Names (FunDef Name) where
     names sig `union` names bdy
 
 instance Names (Constructor Name) where
-  names (Constructor ps bdy) =
+  names (Constructor ps bdy _) =
     names ps `union` names bdy
 
 instance Names (Class Name) where

--- a/src/Solcore/Frontend/TypeInference/TcContract.hs
+++ b/src/Solcore/Frontend/TypeInference/TcContract.hs
@@ -431,7 +431,7 @@ generateTopDeclsFor ps =
 -- type checking contract constructors
 
 tcConstructor :: Constructor Name -> TcM (Constructor Id)
-tcConstructor (Constructor ps bd) =
+tcConstructor (Constructor ps bd payable) =
   do
     -- building parameters for constructors
     ps' <- mapM tcParam ps
@@ -439,7 +439,7 @@ tcConstructor (Constructor ps bd) =
         f (Untyped _ (Id n _)) = ((n,) . monotype) <$> freshTyVar
     lctx <- mapM f ps'
     (bd', _, _) <- withLocalCtx lctx (tcBody bd)
-    pure (Constructor ps' bd')
+    pure (Constructor ps' bd' payable)
 
 -- checking class definitions and adding them to environment
 

--- a/src/Solcore/Frontend/TypeInference/TcSubst.hs
+++ b/src/Solcore/Frontend/TypeInference/TcSubst.hs
@@ -405,11 +405,11 @@ instance (HasType a) => HasType (Field a) where
   bv (Field _ t me) = bv t `union` bv me
 
 instance (HasType a) => HasType (Constructor a) where
-  apply s (Constructor ps bd) =
-    Constructor (apply s ps) (apply s bd)
-  fv (Constructor ps bd) =
+  apply s (Constructor ps bd payable) =
+    Constructor (apply s ps) (apply s bd) payable
+  fv (Constructor ps bd _) =
     fv ps `union` fv bd
-  mv (Constructor ps bd) =
+  mv (Constructor ps bd _) =
     mv ps `union` mv bd
-  bv (Constructor ps bd) =
+  bv (Constructor ps bd _) =
     bv ps `union` bv bd

--- a/test/examples/dispatch/nonpayable_ctor.json
+++ b/test/examples/dispatch/nonpayable_ctor.json
@@ -1,0 +1,20 @@
+{
+  "NonPayableCtor": {
+    "bytecode": "",
+    "contract": "NonPayableCtor",
+    "tests": [
+      {
+        "input": {
+          "text-calldata": "non-payable constructor rejects incoming value",
+          "calldata": "",
+          "value": "42"
+        },
+        "kind": "constructor",
+        "output": {
+          "returndata": "b5988ea3",
+          "status": "failure"
+        }
+      }
+    ]
+  }
+}

--- a/test/examples/dispatch/nonpayable_ctor.solc
+++ b/test/examples/dispatch/nonpayable_ctor.solc
@@ -1,0 +1,17 @@
+import std.{*};
+import std.dispatch.{*};
+
+// A contract whose constructor is NOT marked `payable`. Deploying it with an
+// incoming value transfer must revert with the NonPayableReceivedValue error
+// (selector 0xb5988ea3), exactly like calling a non-payable method with value.
+contract NonPayableCtor {
+    constructor() {}
+
+    public function balance() -> uint256 {
+        let value;
+        assembly {
+            value := selfbalance()
+        }
+        return uint256(value);
+    }
+}

--- a/test/examples/dispatch/payable.json
+++ b/test/examples/dispatch/payable.json
@@ -5,10 +5,14 @@
     "tests": [
       {
         "input": {
+          "text-calldata": "non-payable constructor accepts zero value",
           "calldata": "",
           "value": "0"
         },
-        "kind": "constructor"
+        "kind": "constructor",
+        "output": {
+          "status": "success"
+        }
       },
       {
         "input": {

--- a/test/examples/dispatch/payable_ctor.json
+++ b/test/examples/dispatch/payable_ctor.json
@@ -1,0 +1,31 @@
+{
+  "PayableCtor": {
+    "bytecode": "",
+    "contract": "PayableCtor",
+    "tests": [
+      {
+        "input": {
+          "text-calldata": "payable constructor accepts value",
+          "calldata": "",
+          "value": "42"
+        },
+        "kind": "constructor",
+        "output": {
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "text-calldata": "balance()(uint256) -- value sent at deploy was retained",
+          "calldata": "b69ef8a8",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "000000000000000000000000000000000000000000000000000000000000002a",
+          "status": "success"
+        }
+      }
+    ]
+  }
+}

--- a/test/examples/dispatch/payable_ctor.solc
+++ b/test/examples/dispatch/payable_ctor.solc
@@ -1,0 +1,17 @@
+import std.{*};
+import std.dispatch.{*};
+
+// A contract whose constructor is explicitly marked `payable`.
+// Deploying it with an incoming value transfer must succeed and the
+// transferred value is retained by the newly created contract.
+contract PayableCtor {
+    payable constructor() {}
+
+    public function balance() -> uint256 {
+        let value;
+        assembly {
+            value := selfbalance()
+        }
+        return uint256(value);
+    }
+}

--- a/test/testrunner/testrunner.cpp
+++ b/test/testrunner/testrunner.cpp
@@ -169,6 +169,13 @@ int main(int argc, char** argv)
 							continue;
 						}
 					}
+					else
+					{
+						std::cerr << "Unsupported expectedStatus: " << expectedStatus << std::endl;
+						resultRecorder.record(filename, "Unsupported constructor status expectation.", "failure", expectedStatus, gasUsed, gasUsedForDeposit);
+						hasTestFailure = true;
+						continue;
+					}
 					if (test["output"].contains("returndata"))
 					{
 						auto expectedOutput = test["output"]["returndata"].get<std::string>();
@@ -216,6 +223,13 @@ int main(int argc, char** argv)
 						hasTestFailure = true;
 						continue;
 					}
+				}
+				else
+				{
+					std::cerr << "Unsupported expectedStatus: " << expectedStatus << std::endl;
+					resultRecorder.record(filename, "Unsupported status expectation.", "failure", expectedStatus, gasUsed, gasUsedForDeposit);
+					hasTestFailure = true;
+					continue;
 				}
 				auto expectedOutput = test["output"]["returndata"].get<std::string>();
 				if (output != fromHex(expectedOutput))

--- a/test/testrunner/testrunner.cpp
+++ b/test/testrunner/testrunner.cpp
@@ -141,14 +141,58 @@ int main(int argc, char** argv)
 
 			if (kind == "constructor")
 			{
-				if (!status)
+				// A constructor test may optionally declare an expected outcome via
+				// an "output" object (status + optional returndata), mirroring "call"
+				// tests. This lets us assert that a non-payable constructor rejects an
+				// incoming value transfer. When "output" is absent, creation is expected
+				// to succeed (backwards compatible with existing test suites).
+				if (test.contains("output"))
 				{
-					std::cerr << "Creation failed." << std::endl;
-					resultRecorder.record(filename, "Creation failed for constructor test.", "", "", gasUsed, gasUsedForDeposit);
-					hasTestFailure = true;
-					continue;
+					auto expectedStatus = test["output"]["status"].get<std::string>();
+					if (expectedStatus == "failure")
+					{
+						if (status)
+						{
+							std::cerr << "Expected creation failure but got success" << std::endl;
+							resultRecorder.record(filename, "Expected constructor status failure but got success.", "success", expectedStatus, gasUsed, gasUsedForDeposit);
+							hasTestFailure = true;
+							continue;
+						}
+					}
+					else if (expectedStatus == "success")
+					{
+						if (!status)
+						{
+							std::cerr << "Expected creation success but got failure" << std::endl;
+							resultRecorder.record(filename, "Expected constructor status success but got failure.", "failure", expectedStatus, gasUsed, gasUsedForDeposit);
+							hasTestFailure = true;
+							continue;
+						}
+					}
+					if (test["output"].contains("returndata"))
+					{
+						auto expectedOutput = test["output"]["returndata"].get<std::string>();
+						if (output != fromHex(expectedOutput))
+						{
+							std::cerr << "Expected " << expectedOutput << " but got " << toHex(output) << std::endl;
+							resultRecorder.record(filename, "Expected different constructor output.", toHex(output), expectedOutput, gasUsed, gasUsedForDeposit);
+							hasTestFailure = true;
+							continue;
+						}
+					}
+					resultRecorder.record(filename, "Passed.", toHex(output), test["output"].value("returndata", std::string("")), gasUsed, gasUsedForDeposit);
 				}
-				resultRecorder.record(filename, "Creation succeeded.", "", "", gasUsed, gasUsedForDeposit);
+				else
+				{
+					if (!status)
+					{
+						std::cerr << "Creation failed." << std::endl;
+						resultRecorder.record(filename, "Creation failed for constructor test.", "", "", gasUsed, gasUsedForDeposit);
+						hasTestFailure = true;
+						continue;
+					}
+					resultRecorder.record(filename, "Creation succeeded.", "", "", gasUsed, gasUsedForDeposit);
+				}
 			}
 			else
 			{


### PR DESCRIPTION
Constructors can now be marked `payable`. A non-payable constructor (the default) rejects any incoming value transfer at deploy time, reverting with the same NonPayableReceivedValue error (0xb5988ea3) used by the runtime method-level callvalue check. A payable constructor accepts value.

- Add `constrPayable` to the surface and resolved Constructor AST
- Parse `payable constructor(...)` (backtrack so `payable function/fallback` still parse)
- Emit a NonPayable callvalue check in the generated deployer for non-payable constructors
- Pretty-print the `payable` modifier
- Let constructor tests assert an expected outcome (status/returndata); absent "output" still means "expect success"
- Add payable_ctor / nonpayable_ctor dispatch tests and assert the existing PayableTest constructor accepts zero value