### PR TITLE
Remove obsolete mload/sload helpers

### DIFF
--- a/std/std.solc
+++ b/std/std.solc
@@ -105,10 +105,6 @@ export {
   sha256,
   slice(*),
   slice_,
-  sloadViaWord,
-  sload_,
-  sstore_,
-  sstoreViaWord,
   storage(*),
   storeBytesFromMemory,
   string,
@@ -1529,20 +1525,6 @@ pragma no-coverage-condition MemberAccessProxy, LVA, RVA, CStructField, Assign;
 pragma no-bounded-variable-condition LVA, RVA;
 // -- storage
 
-function sload_(x:word) -> word {
-    let res: word;
-    assembly {
-       res := sload(x)
-    }
-    return res;
-  }
-
-function sstore_(a:word, v:word) -> () {
-    assembly { sstore(a,v) }
-}
-
-
-
 forall self.
 class self:StorageSize {
     function size(x:Proxy(self)) -> word;
@@ -1612,7 +1594,6 @@ forall a b. a:StorageSize, b:StorageSize => instance (a,b):StorageSize {
     }
 }
 
-
 forall self.
 class self:StorageType {
     function load(ptr:word) -> self;
@@ -1621,33 +1602,10 @@ class self:StorageType {
 
 instance word:StorageType {
     function load(ptr:word) -> word {
-        let r:word;
-        assembly {
-            r := sload(ptr)
-        }
-        return r;
+        return sload(ptr);
     }
     function store(ptr:word, value:word) -> () {
-        assembly {
-            sstore(ptr, value)
-        }
-    }
-}
-
-forall a. a:Typedef(word) =>
-function sloadViaWord(ptr:word) -> a {
-    let r:word;
-    assembly {
-	r := sload(ptr)
-    }
-    return Typedef.abs(r);
-}
-
-forall a. a:Typedef(word) =>
-function sstoreViaWord(ptr:word, value:a) -> () {
-    let w: word = Typedef.rep(value);
-    assembly {
-	sstore(ptr, w)
+        sstore(ptr, value);
     }
 }
 

--- a/std/std.solc
+++ b/std/std.solc
@@ -1,3 +1,5 @@
+import std.opcodes.{mstore, mload, sstore, sload};
+
 pragma no-patterson-condition ABIEncode, Num;
 pragma no-coverage-condition ABIDecode, MemoryType;
 
@@ -85,8 +87,6 @@ export {
   memberAccessBase,
   memory(*),
   memory_ref,
-  mload,
-  mstore,
   ne,
   not,
   or,
@@ -805,20 +805,9 @@ data mapping(member, index) = mapping(word) ;
 
 // --- Low-level memory ops
 
-function mload(a:word) -> word {
-  let res: word;
-  assembly { res := mload(a) }
-  return res;
-}
-
-function mstore(a:word, v:word) -> () {
-  assembly { mstore(a,v) }
-}
-
 function strlen(s:memory(string)) -> word {
   match s { | memory(a) => return mload(a); }
 }
-
 
 // --- Memory Utilities ---
 

--- a/test/examples/dispatch/hashes.solc
+++ b/test/examples/dispatch/hashes.solc
@@ -1,5 +1,6 @@
 import std.{*};
 import std.dispatch.{*};
+import std.opcodes.{mstore};
 
 // Build a memory(bytes) holding the three-byte string "abc".
 function abcBytes() -> memory(bytes) {

--- a/test/examples/dispatch/memory.solc
+++ b/test/examples/dispatch/memory.solc
@@ -1,5 +1,6 @@
 import std.{*};
 import std.dispatch.{*};
+import std.opcodes.{mstore};
 
 contract C {
     public function dirty_allocate() -> memory(bytes) {

--- a/test/examples/dispatch/stringid.solc
+++ b/test/examples/dispatch/stringid.solc
@@ -1,6 +1,8 @@
 import std.{*};
-import std.{memory, string, Typedef, log1, allocate_memory, mstore, uint256};
+import std.{memory, string, Typedef, log1, allocate_memory, uint256};
 import std.dispatch.{*};
+import std.opcodes.{mstore, mload};
+
 pragma no-patterson-condition ;
 pragma no-coverage-condition ;
 pragma no-bounded-variable-condition ;


### PR DESCRIPTION
The `std.opcodes` helpers can be used where, otherwise for storage the `StorageType` class is used everywhere.