### PR TITLE
test/dispatch: add WETH9 contract and integration test

### DIFF
--- a/run_contests.sh
+++ b/run_contests.sh
@@ -22,3 +22,4 @@ bash ./contest.sh test/examples/dispatch/memory.json
 bash ./contest.sh test/examples/dispatch/generic_sum.json
 bash ./contest.sh test/examples/dispatch/generic_product.json
 bash ./contest.sh test/examples/dispatch/forloops.json
+bash ./contest.sh test/examples/dispatch/weth9.json

--- a/test/examples/dispatch/weth9.json
+++ b/test/examples/dispatch/weth9.json
@@ -1,0 +1,199 @@
+{
+  "weth9": {
+    "bytecode": "_CODE",
+    "contract": "WETH9",
+    "tests": [
+      {
+        "input": {
+          "comment": "constructor()",
+          "calldata": "",
+          "value": "0"
+        },
+        "kind": "constructor",
+        "output": {
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "deposit()  value=100",
+          "calldata": "d0e30db0",
+          "value": "100"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "balanceOf(caller) -> 100",
+          "calldata": "70a082310000000000000000000000001212121212121212121212121212120000000012",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000064",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "totalSupply() -> 100 (contract ETH balance)",
+          "calldata": "18160ddd",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000064",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "transfer($ANVIL1, 30) -> true",
+          "calldata": "a9059cbb00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c8000000000000000000000000000000000000000000000000000000000000001e",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000001",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "balanceOf($ANVIL1) -> 30",
+          "calldata": "70a0823100000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c8",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "000000000000000000000000000000000000000000000000000000000000001e",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "balanceOf(caller) -> 70",
+          "calldata": "70a082310000000000000000000000001212121212121212121212121212120000000012",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000046",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "withdraw(20) — burns WETH and refunds ETH to caller",
+          "calldata": "2e1a7d4d0000000000000000000000000000000000000000000000000000000000000014",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "balanceOf(caller) -> 50",
+          "calldata": "70a082310000000000000000000000001212121212121212121212121212120000000012",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000032",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "totalSupply() -> 80 (after 20 wei withdrawn)",
+          "calldata": "18160ddd",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000050",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "approve($ANVIL1, 25) -> true",
+          "calldata": "095ea7b300000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c80000000000000000000000000000000000000000000000000000000000000019",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000001",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "allowance(caller, $ANVIL1) -> 25",
+          "calldata": "dd62ed3e000000000000000000000000121212121212121212121212121212000000001200000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c8",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000019",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "withdraw(1000) — InsufficientBalance() revert",
+          "calldata": "2e1a7d4d00000000000000000000000000000000000000000000000000000000000003e8",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "f4d678b8",
+          "status": "failure"
+        }
+      },
+      {
+        "input": {
+          "comment": "fallback with unknown selector + value=7 auto-wraps ETH",
+          "calldata": "deadbeef",
+          "value": "7"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "balanceOf(caller) -> 57 (50 + 7 via fallback)",
+          "calldata": "70a082310000000000000000000000001212121212121212121212121212120000000012",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000039",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "totalSupply() -> 87 (80 + 7)",
+          "calldata": "18160ddd",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000057",
+          "status": "success"
+        }
+      }
+    ]
+  }
+}

--- a/test/examples/dispatch/weth9.solc
+++ b/test/examples/dispatch/weth9.solc
@@ -1,0 +1,84 @@
+import std.{*};
+import std.opcodes.{caller as caller_, callvalue as callvalue_, selfbalance, gas, call};
+import std.dispatch.{*};
+
+// Forward `wad` wei to `dst` via a zero-data CALL and revert on failure.
+function sendValue(dst: address, wad: uint256) -> () {
+    let ret = call(gas(), Typedef.rep(dst), Typedef.rep(wad), 0, 0, 0, 0);
+    require(ret != 0, Error(0x90b8ec18)); // TransferFailed()
+}
+
+function caller() -> address {
+    return address(caller_());
+}
+
+function callvalue() -> uint256 {
+    return uint256(callvalue_());
+}
+
+// Based on https://github.com/gnosis/canonical-weth/blob/master/contracts/WETH9.sol
+// That code is written WITHOUT checked arithmetic.
+contract WETH9 {
+    balances : mapping(address, uint256);
+    allowance : mapping(address, mapping(address, uint256));
+
+    constructor() {}
+
+    // --- ETH <-> WETH ---
+
+    public payable function deposit() -> () {
+        let sender = caller();
+        balances[sender] = balances[sender] + callvalue();
+    }
+
+    public function withdraw(wad: uint256) -> () {
+        let sender = caller();
+        require(balances[sender] >= wad, Error(0xf4d678b8)); // InsufficientBalance()
+        balances[sender] = balances[sender] - wad;
+        sendValue(sender, wad);
+    }
+
+    // totalSupply == ETH held by this contract (matches canonical WETH9).
+    public function totalSupply() -> uint256 {
+        return uint256(selfbalance());
+    }
+
+    // --- ERC20 surface ---
+
+    public function balanceOf(account: address) -> uint256 {
+        return balances[account];
+    }
+
+    public function allowance(owner_: address, spender: address) -> uint256 {
+        return allowance[owner_][spender];
+    }
+
+    public function approve(usr: address, wad: uint256) -> bool {
+        let sender = caller();
+        allowance[sender][usr] = wad;
+        return true;
+    }
+
+    public function transfer(dst: address, wad: uint256) -> bool {
+        return transferFrom(caller(), dst, wad);
+    }
+
+    public function transferFrom(src: address, dst: address, wad: uint256) -> bool {
+        let sender = caller();
+        require(balances[src] >= wad, Error(0xf4d678b8)); // InsufficientBalance()
+
+        if (src != sender && allowance[src][sender] != (maxVal():uint256)) {
+            require(allowance[src][sender] >= wad, Error(0x13be252b)); // InsufficientAllowance()
+            allowance[src][sender] -= wad;
+        }
+        balances[src] = balances[src] - wad;
+        balances[dst] = balances[dst] + wad;
+        return true;
+    }
+
+    // Plain ETH transfers (no calldata, just value) auto-wrap into WETH.
+    payable fallback() -> () {
+        let sender = caller();
+        balances[sender] = balances[sender] + callvalue();
+    }
+}


### PR DESCRIPTION
Mirrors the canonical WETH9 surface (deposit/withdraw + ERC20) on top of the existing miniERC20 patterns: payable deposit() and fallback wrap incoming ETH into balances[msg.sender], withdraw() burns and refunds via a low-level CALL with the gas/value/address packed via Typedef.rep, and totalSupply() reports selfbalance() to match the reference contract.

The JSON exercises constructor, deposit-with-value, ERC20 transfer/ approve/allowance, withdraw, an insufficient-balance revert (selector 0xf4d678b8), and an unknown-selector fallback auto-wrap — verifying the contract's running balance against both balanceOf and selfbalance after each step.

This is fully Claude generated, and it got it working one-shot just by prompting "write weth9.solc in test/examples/dispatch/ and add a test file too". I did some cleanup after (using std.opcodes, using `+`/`-` and not `Num.add` which it prefers, adding some comments).

This is another critical contract in Ethereum: https://etherscan.io/address/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2