### PR TITLE
Fix returnCount arity for sum-returning HULL functions

### DIFF
--- a/src/Language/Hull/TcEnv.hs
+++ b/src/Language/Hull/TcEnv.hs
@@ -27,12 +27,19 @@ emptyHullTcEnv :: HullTcEnv
 emptyHullTcEnv = HullTcEnv Map.empty hullBuiltins Nothing
 
 -- Number of word-sized slots a return type occupies.
+-- This MUST mirror yule's @sizeOf@ (yule/Translate.hs): sum types lower to a
+-- tag word plus the widest variant payload, so they occupy more than one slot.
+-- Collapsing them to 1 here lets a sum-returning function be assigned into a
+-- single-word asm LHS that yule then lowers to a multi-word Yul return.
 returnCount :: Type -> Int
 returnCount TUnit = 0
 returnCount TWord = 1
+returnCount TBool = 1
 returnCount (TPair a b) = returnCount a + returnCount b
+returnCount (TSum a b) = 1 + max (returnCount a) (returnCount b)
+returnCount (TSumN ts) = 1 + maximum (map returnCount ts)
 returnCount (TNamed _ t) = returnCount t
-returnCount _ = 1
+returnCount (TFun _ _) = error "returnCount: function type has no runtime representation"
 
 -- Return type for exactly n word-sized return slots.
 nReturns :: Int -> Type

--- a/test/HullCases.hs
+++ b/test/HullCases.hs
@@ -29,7 +29,8 @@ hullTests =
           runHullTestExpectingFailure "07-err-undef-var.hull",
           runHullTestExpectingFailure "08-err-arity.hull",
           runHullTestExpectingFailure "09-err-sum-payload.hull",
-          runHullTestExpectingFailure "10-err-fst-non-pair.hull"
+          runHullTestExpectingFailure "10-err-fst-non-pair.hull",
+          runHullTestExpectingFailure "11-err-asm-sum-return.hull"
         ]
     ]
 

--- a/test/examples/hull/11-err-asm-sum-return.hull
+++ b/test/examples/hull/11-err-asm-sum-return.hull
@@ -1,0 +1,18 @@
+// Error: lookup() returns a sum (word + word), which occupies 2 word-sized
+//        slots (tag + payload), but the assignment binds it into the single
+//        word `r`. returnCount must agree with yule's sizeOf here, otherwise
+//        yule lowers a 2-slot Yul return into a 1-slot LHS, which solc rejects.
+object AsmSumReturn {
+  code {
+    function lookup() -> word + word {
+      return inl<word + word> 7
+    }
+    function caller() -> word {
+      let r : word
+      assembly {
+        r := usr$lookup()
+      }
+      return r
+    }
+  }
+}


### PR DESCRIPTION
returnCount in Language/Hull/TcEnv.hs collapsed every non-TFun/TPair type to a single word slot, so a sum-returning function called from a user asm block passed HULL's YAssign/YLet arity check (1 == 1). yule's sizeOf, however, lowers a TSum return as `1 + max (sizeOf t1) (sizeOf t2)` words, emitting a multi-word Yul return into a single-slot LHS that solc later rejects.

Make returnCount mirror yule's sizeOf exactly by adding explicit TSum, TSumN and TBool cases (and an explicit TFun error), so the asm arity check agrees with the eventual Yul lowering.

Add a Hull type-checker test (11-err-asm-sum-return.hull) that assigns a `word + word` returning function into a single word in an assembly block; it now correctly fails the return-count check.