### PR TITLE
Fix tcYulStmt dropping uninitialized `let` and crashing on bool literals

### DIFF
--- a/run_contests.sh
+++ b/run_contests.sh
@@ -6,6 +6,7 @@ root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$root_dir"
 
 bash ./contest.sh test/examples/dispatch/basic.json
+bash ./contest.sh test/examples/dispatch/assembly.json
 bash ./contest.sh test/examples/dispatch/neg.json
 bash ./contest.sh test/examples/dispatch/miniERC20.json
 bash ./contest.sh test/examples/dispatch/Revert.json

--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -1690,10 +1690,14 @@ tcYulStmt (YBlock yblk) =
     _ <- tcYulBlock yblk
     -- names defined in should not return
     pure ([], unit)
-tcYulStmt s@(YLet ns (Just e)) =
+tcYulStmt s@(YLet ns me) =
   do
-    t <- tcYulExp e
-    checkYulAssignArity s ns e t
+    -- 'let x, y := e' type-checks the RHS and arity; 'let x' (no initializer)
+    -- just introduces the bindings. Either way the names must enter the env as
+    -- 'word', otherwise later 'YAssign'/'YIdent' uses go unchecked.
+    forM_ me $ \e -> do
+      t <- tcYulExp e
+      checkYulAssignArity s ns e t
     mapM_ (flip extEnv mword) ns
     pure (ns, unit)
 tcYulStmt (YExp e) =
@@ -1721,7 +1725,23 @@ tcYulStmt (YFor initBlk e bdy upd) =
       _ <- tcYulBlock upd
       pure ()
     pure ([], unit)
-tcYulStmt _ = pure ([], unit)
+tcYulStmt (YFun fnName args rets body) =
+  do
+    -- Yul functions are word-typed; register the name (so calls resolve and
+    -- recursion type-checks) and check the body with the parameters and named
+    -- returns bound. A zero-return function has type '... -> unit'.
+    let fnRetTy = maybe unit (\rs -> if null rs then unit else word) rets
+        fnTy = funtype (map (const word) args) fnRetTy
+    extEnv fnName (monotype fnTy)
+    _ <- withLocalEnv do
+      mapM_ (flip extEnv mword) args
+      mapM_ (flip extEnv mword) (concat rets)
+      tcYulBlock body
+    pure ([], unit)
+tcYulStmt YBreak = pure ([], unit)
+tcYulStmt YContinue = pure ([], unit)
+tcYulStmt YLeave = pure ([], unit)
+tcYulStmt (YComment _) = pure ([], unit)
 
 -- Yul builtins/opcodes return either 0 values (type 'unit') or 1 value
 -- (any other type). Compare the number of names on the left-hand side of
@@ -1773,7 +1793,9 @@ tcYulExp (YMeta _) = pure word
 tcYLit :: YLiteral -> TcM Ty
 tcYLit (YulString _) = return string
 tcYLit (YulNumber _) = return word
-tcYLit lit = notImplemented "tcYLit" lit
+-- Yul has no boolean type: 'true'/'false' are word literals (1/0).
+tcYLit YulTrue = return word
+tcYLit YulFalse = return word
 
 tcYulCases :: YulCases -> TcM ()
 tcYulCases = mapM_ tcYulCase

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -112,6 +112,7 @@ dispatches =
   testGroup
     "Files for dispatch cases"
     [ runDispatchTest "basic.solc",
+      runDispatchTest "assembly.solc",
       runDispatchTest "stringid.solc",
       runDispatchTest "miniERC20.solc",
       runDispatchTest "Revert.solc",

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -269,6 +269,8 @@ cases =
       runTestExpectingFailure "asm-assign-no-return.solc" caseFolder,
       runTestExpectingFailure "asm-assign-non-word.solc" caseFolder,
       runTestExpectingFailure "asm-let-no-return.solc" caseFolder,
+      runTestForFile "asm-let-uninit.solc" caseFolder,
+      runTestForFile "asm-let-bool-lit.solc" caseFolder,
       runTestForFile "asm-match-tuple-read.solc" caseFolder,
       runTestForFile "asm-match-tuple-write-read.solc" caseFolder,
       runTestForFile "bal.solc" caseFolder,

--- a/test/examples/cases/asm-let-bool-lit.solc
+++ b/test/examples/cases/asm-let-bool-lit.solc
@@ -1,0 +1,13 @@
+// Yul has no boolean type: `true`/`false` are word literals (1/0). A literal
+// `true` in an assembly block must type-check as `word`. Before the fix
+// `tcYLit YulTrue/YulFalse` called `notImplemented`, crashing the compiler.
+contract Test {
+  public function main() -> word {
+    let r : word = 0;
+    assembly {
+      let x := true
+      r := x
+    }
+    return r;
+  }
+}

--- a/test/examples/cases/asm-let-uninit.solc
+++ b/test/examples/cases/asm-let-uninit.solc
@@ -1,0 +1,15 @@
+// An uninitialized Yul `let x` must introduce the binding so that later
+// assignments and reads of `x` resolve and are type-checked as `word`.
+// Before the fix `tcYulStmt` dropped `YLet ns Nothing`, so `x` never entered
+// the env and the read `r := x` failed to resolve.
+contract Test {
+  public function main() -> word {
+    let r : word = 0;
+    assembly {
+      let x
+      x := add(1, 1)
+      r := x
+    }
+    return r;
+  }
+}

--- a/test/examples/dispatch/assembly.json
+++ b/test/examples/dispatch/assembly.json
@@ -1,0 +1,28 @@
+{
+  "assembly": {
+    "bytecode": "_CODE",
+    "contract": "C",
+    "tests": [
+      {
+        "input": {
+          "comment": "constructor()",
+          "calldata": "",
+          "value": "0"
+        },
+        "kind": "constructor"
+      },
+      {
+        "input": {
+          "comment": "asmBool()(uint256) -> 1 (Yul `true` is word 1)",
+          "calldata": "7d4bb2ec",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000001",
+          "status": "success"
+        }
+      }
+    ]
+  }
+}

--- a/test/examples/dispatch/assembly.solc
+++ b/test/examples/dispatch/assembly.solc
@@ -1,0 +1,19 @@
+import std.{*};
+import std.dispatch.{*};
+
+contract C {
+    constructor() {}
+
+    // Exercises a Yul block that declares an uninitialized `let y`, assigns the
+    // boolean literal `true` to it, and writes it back to the surrounding
+    // `word` local `x`. `true` is the word `1`, so this returns uint256(1).
+    public function asmBool() -> uint256 {
+        let x : word;
+        assembly {
+          let y
+          y := true
+          x := y
+        }
+        return uint256(x);
+    }
+}


### PR DESCRIPTION
Fixes #491
Fixes #492

`tcYulStmt` only matched `YLet ns (Just e)`; uninitialized `let x` (`YLet ns Nothing`) fell into the `tcYulStmt _ = pure ([], unit)` catch-all, so `x` never entered the env and later assignments/reads of it bypassed the LHS arity/type check. The same catch-all also silently swallowed `YFun` (Yul function bodies never typed), `YBreak`, `YContinue`, `YLeave`, and `YComment`. Additionally a literal `true` / `false` in a Yul block hit `tcYLit ... = notImplemented`, crashing the compiler.

- Handle `YLet` with and without an initializer; both introduce `word` bindings into the env.
- Type-check `YFun` bodies with parameters and named returns bound, and register the function name so calls (and recursion) resolve.
- Make `YBreak`/`YContinue`/`YLeave`/`YComment` explicit no-ops and drop the catch-all so the match is exhaustive.
- Treat Yul `true`/`false` as `word` literals (no Yul boolean type).
- Add regression tests asm-let-uninit.solc and asm-let-bool-lit.solc.