### PR TITLE
Add storage support for `bytes` fields

### DIFF
--- a/run_contests.sh
+++ b/run_contests.sh
@@ -19,6 +19,7 @@ bash ./contest.sh test/examples/dispatch/slices.json
 bash ./contest.sh test/examples/dispatch/fallback.json
 bash ./contest.sh test/examples/dispatch/ecrecover.json
 bash ./contest.sh test/examples/dispatch/memory.json
+bash ./contest.sh test/examples/dispatch/storage.json
 bash ./contest.sh test/examples/dispatch/generic_sum.json
 bash ./contest.sh test/examples/dispatch/generic_product.json
 bash ./contest.sh test/examples/dispatch/forloops.json

--- a/std/std.solc
+++ b/std/std.solc
@@ -1518,6 +1518,18 @@ instance memory(string):StorageSize {
     }
 }
 
+instance bytes:StorageSize {
+    function size(x:Proxy(bytes)) -> word {
+        return 1;
+    }
+}
+
+instance memory(bytes):StorageSize {
+    function size(x:Proxy(memory(bytes))) -> word {
+        return 1;
+    }
+}
+
 forall a b. a:StorageSize, b:StorageSize => instance (a,b):StorageSize {
     function size(x:Proxy((a,b))) -> word {
         let a_sz:word = StorageSize.size(Proxy:Proxy(a));
@@ -1759,6 +1771,24 @@ instance storage(string):CanStore(memory(string)) {
   }
 
   function load(src:storage(string)) -> memory(string) {
+    let srcPtr : word = Typedef.rep(src);
+    let dstPtr : word = get_free_memory();
+    let endPtr = loadBytesFromStorage(srcPtr, dstPtr);
+    set_free_memory(endPtr);
+    return memory(dstPtr);
+  }
+}
+
+// bytes share the same storage layout as string, so the same
+// storeBytesFromMemory / loadBytesFromStorage helpers apply.
+instance storage(bytes):CanStore(memory(bytes)) {
+  function store(dst:storage(bytes), src:memory(bytes)) -> () {
+    let srcPtr : word = Typedef.rep(src);
+    let slot = Typedef.rep(dst);
+    storeBytesFromMemory(slot, srcPtr);
+  }
+
+  function load(src:storage(bytes)) -> memory(bytes) {
     let srcPtr : word = Typedef.rep(src);
     let dstPtr : word = get_free_memory();
     let endPtr = loadBytesFromStorage(srcPtr, dstPtr);

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -113,6 +113,7 @@ dispatches =
     "Files for dispatch cases"
     [ runDispatchTest "basic.solc",
       runDispatchTest "stringid.solc",
+      runDispatchTest "storage.solc",
       runDispatchTest "miniERC20.solc",
       runDispatchTest "Revert.solc",
       runDispatchTest "hashes.solc",

--- a/test/examples/dispatch/storage.json
+++ b/test/examples/dispatch/storage.json
@@ -1,0 +1,64 @@
+{
+  "storagebytes": {
+    "bytecode": "_CODE",
+    "contract": "C",
+    "tests": [
+      {
+        "input": {
+          "comment": "constructor()",
+          "calldata": "",
+          "value": "0"
+        },
+        "kind": "constructor"
+      },
+      {
+        "input": {
+          "comment": "set(bytes) 0xdeadbeef -- short, stored in-place",
+          "calldata": "0399321e00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000004deadbeef00000000000000000000000000000000000000000000000000000000",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "get() -> (bytes) returns the short value just stored",
+          "calldata": "6d4ce63c",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000004deadbeef00000000000000000000000000000000000000000000000000000000",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "set(bytes) 40-byte value -- long, stored out-of-place",
+          "calldata": "0399321e0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002800112233445566778899aabbccddeeff00112233445566778899aabbccddeeff0011223344556677000000000000000000000000000000000000000000000000",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "get() -> (bytes) returns the long value just stored",
+          "calldata": "6d4ce63c",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002800112233445566778899aabbccddeeff00112233445566778899aabbccddeeff0011223344556677000000000000000000000000000000000000000000000000",
+          "status": "success"
+        }
+      }
+    ]
+  }
+}

--- a/test/examples/dispatch/storage.solc
+++ b/test/examples/dispatch/storage.solc
@@ -1,0 +1,17 @@
+import std.{*};
+import std.dispatch.{*};
+
+// Storage support for a `memory(bytes)` contract field: assigning to the
+// field copies the byte array into storage, reading it back loads it into
+// fresh memory. Exercises StorageSize / CanStore for memory(bytes).
+contract C {
+  content: bytes;
+
+  public function set(value: memory(bytes)) -> () {
+    content = value;
+  }
+
+  public function get() -> memory(bytes) {
+    return content;
+  }
+}


### PR DESCRIPTION
Mirror the existing string/memory(string) storage support for bytes:
- StorageSize instance for memory(bytes)
- CanStore instance for storage(memory(bytes)) that copies to/from storage using the existing storeBytesFromMemory / loadBytesFromStorage helpers (bytes and string share an identical storage layout)

This lets a contract declare a `memory(bytes)` field and assign/read it, e.g.

  contract C {
    content: bytes;
    public function set(value: memory(bytes)) -> () { content = value; }
    public function get() -> memory(bytes) { return content; }
  }

Adds a storage dispatch test (compile + EVM round-trip for both short in-place and long out-of-place byte arrays).