### PR TITLE
Make parser recognise identifiers that start with a keyword

### DIFF
--- a/src/Solcore/Frontend/Lexer/SolcoreLexer.hs
+++ b/src/Solcore/Frontend/Lexer/SolcoreLexer.hs
@@ -32,8 +32,11 @@ lexeme = L.lexeme sc
 symbol :: String -> Parser String
 symbol = L.symbol sc
 
+identChar :: Parser Char
+identChar = alphaNumChar <|> char '_'
+
 keyword :: String -> Parser ()
-keyword kw = lexeme (string kw *> notFollowedBy (alphaNumChar <|> char '_'))
+keyword kw = lexeme (try (string kw *> notFollowedBy identChar))
 
 reservedWords :: [String]
 reservedWords =
@@ -74,7 +77,7 @@ identifier = lexeme go <?> "identifier"
   where
     go = do
       h <- letterChar
-      t <- many (alphaNumChar <|> char '_')
+      t <- many identChar
       let w = h : t
       if w `elem` reservedWords
         then fail ("reserved word used as identifier: " ++ w)

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -39,7 +39,8 @@ parserTests =
       patternTests,
       exprTests,
       stmtTests,
-      declTests
+      declTests,
+      keywordPrefixTests
     ]
 
 word :: Ty
@@ -253,6 +254,25 @@ exprTests =
           expP
           "lam(x:word) { return x; }"
           (Lam [Typed False "x" word] [Return (var "x")] Nothing)
+    ]
+
+-- | Identifiers that start with a keyword (e.g. `datavalue`, which begins with
+-- `data`) must not be mistaken for the keyword. The lexer's `keyword` parser is
+-- atomic, so a keyword tried as an alternative backtracks instead of consuming
+-- the prefix.
+keywordPrefixTests :: TestTree
+keywordPrefixTests =
+  testGroup
+    "Keyword prefixes"
+    [ testCase "statement-initial assignment to keyword-prefixed name" $
+        parsesAs stmtP "datavalue = 2;" (Assign (var "datavalue") (lit 2)),
+      testCase "statement-initial expression with keyword-prefixed name" $
+        parsesAs stmtP "datavalue;" (StmtExp (var "datavalue")),
+      testCase "contract field with keyword-prefixed name" $
+        parsesAs
+          topDeclP
+          "contract C { datavalue : word; }"
+          (TContr (Contract "C" [] [CFieldDecl (Field "datavalue" word Nothing)]))
     ]
 
 stmtTests :: TestTree


### PR DESCRIPTION
Fixes #497