### PR TITLE
Fail loudly when ABI emitter hits a parameterized type

### DIFF
--- a/src/Solcore/Desugarer/ContractDispatch.hs
+++ b/src/Solcore/Desugarer/ContractDispatch.hs
@@ -377,17 +377,22 @@ mkAbiParam pname t =
 -- | Map a Solcore type to its canonical ABI type name and (for tuples) its
 -- component parameters. Memory/calldata are location qualifiers and are
 -- transparent to the ABI. The native @word@ maps to @uint256@; the remaining
--- value-type names (uint256, address, bytes32, bool, bytes, string, ...) already
--- match the Solidity ABI spelling and are passed through unchanged.
+-- value-type names (uint256, address, bytes32, bool, bytes, string, ...) are
+-- nullary type constructors whose names already match the Solidity ABI
+-- spelling, so they are passed through unchanged.
 abiTypeOf :: Ty -> (String, [AbiParam])
 abiTypeOf (TyCon (Name "memory") [t]) = abiTypeOf t
 abiTypeOf (TyCon (Name "calldata") [t]) = abiTypeOf t
 abiTypeOf t@(TyCon (Name "pair") [_, _]) =
   ("tuple", map (mkAbiParam "") (flattenTuple t))
 abiTypeOf (TyCon (Name "word") []) = ("uint256", [])
-abiTypeOf (TyCon n _) = (nameStr n, [])
--- Anything else (e.g. a type variable or a function type) has no ABI spelling;
--- fail loudly rather than emit a malformed `show`-rendered type into the ABI.
+abiTypeOf (TyCon n []) = (nameStr n, [])
+-- Anything else has no ABI spelling: a type variable, a function type, or a
+-- parameterized type constructor (e.g. @mapping(word, word)@ or a custom
+-- generic) that is not one of the location/tuple cases handled above. Dropping
+-- the type arguments here would emit a bare, invalid ABI string like
+-- @"type":"mapping"@, which downstream ABI consumers (etherscan, ethers,
+-- web3py) would misparse — so fail loudly instead.
 abiTypeOf t = error ("contractAbiJson: cannot represent type in ABI: " <> show t)
 
 abiEntryJson :: AbiEntry -> Json

--- a/test/ContractAbiTests.hs
+++ b/test/ContractAbiTests.hs
@@ -1,5 +1,7 @@
 module ContractAbiTests where
 
+import Control.Exception (ErrorCall (..), evaluate, try)
+import Data.List (isInfixOf)
 import Solcore.Desugarer.ContractDispatch (contractAbiJson)
 import Solcore.Frontend.Syntax
 import Solcore.Primitives.Primitives (word)
@@ -13,7 +15,20 @@ contractAbiTests =
     [ testCase "only public functions are exposed" $
         contractAbiJson onlyPublicContract @?= onlyPublicExpected,
       testCase "constructor, payable, word and tuple returns" $
-        contractAbiJson richContract @?= richExpected
+        contractAbiJson richContract @?= richExpected,
+      testCase "parameterized parameter type fails loudly" $ do
+        -- A public function whose parameter is a parameterized type
+        -- (e.g. `mapping(word, word)`) has no ABI spelling. Dropping the type
+        -- arguments would emit a bare, invalid `"type":"mapping"` string, so the
+        -- emitter must fail loudly instead.
+        result <- try (evaluate (length (contractAbiJson mappingParamContract)))
+        case result of
+          Left (ErrorCall msg) ->
+            assertBool
+              ("unexpected error message: " <> msg)
+              ("cannot represent type in ABI" `isInfixOf` msg)
+          Right _ ->
+            assertFailure "expected ABI emission to fail for a parameterized parameter type"
     ]
 
 -- Helpers for building sample contracts
@@ -83,6 +98,24 @@ richContract =
             [Typed False (Name "to") (tyCon "address")]
             (Just (TyCon (Name "pair") [word, tyCon "bool"]))
             True
+        )
+    ]
+
+-- A contract with a public function taking a parameterized type that the ABI
+-- emitter cannot represent (here `mapping(word, word)`).
+
+mappingParamContract :: Contract Name
+mappingParamContract =
+  Contract
+    (Name "Store")
+    []
+    [ fun
+        True
+        ( sig
+            "put"
+            [Typed False (Name "m") (TyCon (Name "mapping") [word, word])]
+            (Just (tyCon "uint256"))
+            False
         )
     ]
 


### PR DESCRIPTION
The catch-all `abiTypeOf (TyCon n _)` matched any type constructor regardless of arity, discarding its type arguments. A public function with a parameterized parameter type (e.g. `mapping(word, word)` or a custom generic) emitted a bare, invalid ABI string like `"type":"mapping"`, which ABI consumers (etherscan, ethers, web3py) misparse. This also shadowed the loud-error fallthrough below it.

Restrict the passthrough to nullary type constructors (which is what all legitimate ABI value types — address, bool, bytes32, uint256, bytes, string, word — are), so parameterized types fall through to the existing "cannot represent type in ABI" error instead of silently producing malformed output. Selectors are unaffected.

Add a ContractAbiTests case asserting a mapping-typed parameter fails loudly.