### PR TITLE
Implement `continue` statements in for-loops

### DIFF
--- a/src/Language/Hull.hs
+++ b/src/Language/Hull.hs
@@ -61,6 +61,7 @@ data Stmt
   | SBlock Body
   | SFor Stmt Expr Stmt Stmt
   | SBreak
+  | SContinue
   | SMatch Type Expr [Alt]
   | SFunction Name [Arg] Type [Stmt]
   | SRevert String
@@ -141,6 +142,7 @@ instance Pretty Stmt where
       <+> parens (ppr initStmt >< semi <+> ppr cond >< semi <+> ppr post)
       <+> ppr body
   ppr SBreak = text "break"
+  ppr SContinue = text "continue"
   ppr (SMatch t e alts) =
     text "match"
       >< angles (ppr t)

--- a/src/Language/Hull/Parser.hs
+++ b/src/Language/Hull/Parser.hs
@@ -16,6 +16,7 @@ import Language.Hull
         SAssign,
         SBlock,
         SBreak,
+        SContinue,
         SExpr,
         SFor,
         SFunction,
@@ -152,6 +153,7 @@ hullStmt =
       SMatch <$> (pKeyword "match" *> angles hullType) <*> (hullExpr <* pKeyword "with") <*> braces (many hullAlt),
       hullFor,
       SBreak <$ pKeyword "break",
+      SContinue <$ pKeyword "continue",
       SFunction
         <$> (pKeyword "function" *> identifier)
         <*> parens (commaSep hullArg)

--- a/src/Language/Hull/TypeCheck.hs
+++ b/src/Language/Hull/TypeCheck.hs
@@ -93,6 +93,7 @@ checkStmt (SFor initStmt cond post body) =
       TSum TUnit TUnit -> pure ()
       _ -> hullError ("for condition must be bool or sum () (), got " ++ show t)
 checkStmt SBreak = pure ()
+checkStmt SContinue = pure ()
 checkStmt (SRevert _) = pure ()
 checkStmt (SComment _) = pure ()
 

--- a/src/Solcore/Backend/ComptimeCheck.hs
+++ b/src/Solcore/Backend/ComptimeCheck.hs
@@ -103,6 +103,8 @@ checkStmt ft pure_ retCt fname env stmt = case stmt of
     return env
   MastBreak ->
     return env
+  MastContinue ->
+    return env
   MastSeq stmts -> do
     checkStmts ft pure_ retCt fname env stmts
     return env

--- a/src/Solcore/Backend/EmitHull.hs
+++ b/src/Solcore/Backend/EmitHull.hs
@@ -356,6 +356,7 @@ emitStmt (MastAsm as) = do
     notEVar (Hull.EVar _) = False
     notEVar _ = True
 emitStmt MastBreak = pure [Hull.SBreak]
+emitStmt MastContinue = pure [Hull.SContinue]
 emitStmt (MastSeq stmts) = concat <$> mapM emitStmt stmts
 
 emitStmts :: [MastStmt] -> EM [Hull.Stmt]

--- a/src/Solcore/Backend/Mast.hs
+++ b/src/Solcore/Backend/Mast.hs
@@ -106,6 +106,7 @@ data MastStmt
   | MastMatch MastExp [MastAlt]
   | MastFor MastStmt MastExp MastStmt [MastStmt]
   | MastBreak
+  | MastContinue
   | MastAsm YulBlock
   | MastSeq [MastStmt]
   deriving (Eq, Ord, Show)
@@ -248,6 +249,7 @@ instance Pretty MastStmt where
       $$ nest 3 (vcat (map ppr yblk))
       $$ rbrace
   ppr MastBreak = text "break" >< semi
+  ppr MastContinue = text "continue" >< semi
   ppr (MastSeq stmts) = hsep (punctuate comma (map ppr stmts))
 
 pprMastAlt :: MastAlt -> Doc

--- a/src/Solcore/Backend/MastEval.hs
+++ b/src/Solcore/Backend/MastEval.hs
@@ -289,6 +289,7 @@ evalStmt tyReg env stmt = case stmt of
         pure (Map.empty, [MastAsm yul'])
   MastSeq stmts -> evalStmts tyReg env stmts
   MastBreak -> pure (env, [MastBreak])
+  MastContinue -> pure (env, [MastContinue])
   MastFor initStmt cond post body -> do
     -- Evaluate loop parts for local simplification, but do not propagate
     -- value bindings across the loop boundary.
@@ -345,6 +346,7 @@ evalLoopStmt env st = case st of
     pure (Map.empty, MastFor initStmt' cond' post' bodies')
   MastAsm yul -> pure (Map.empty, MastAsm yul)
   MastBreak -> pure (env, MastBreak)
+  MastContinue -> pure (env, MastContinue)
   MastSeq stmts -> do
     (env', stmts') <- mapAccumM evalLoopStmt env stmts
     pure (env', MastSeq stmts')
@@ -727,6 +729,7 @@ evalFunBody tyReg env (stmt : rest) = case stmt of
       Nothing -> pure Nothing -- Scrutinee not known, can't select branch
   MastFor {} -> pure Nothing -- Loop execution cannot be folded safely here
   MastBreak -> pure Nothing -- Control transfer cannot be folded
+  MastContinue -> pure Nothing -- Control transfer cannot be folded
   MastAsm yul -> do
     -- Try to interpret the asm block statically.
     -- If successful, update env and continue inlining; otherwise give up.
@@ -883,6 +886,7 @@ stmtIsPure pureFuns (MastFor initStmt cond post body) =
     && stmtIsPure pureFuns post
     && bodyIsPure pureFuns body
 stmtIsPure _ MastBreak = True
+stmtIsPure _ MastContinue = True
 stmtIsPure pureFuns (MastSeq stmts) = bodyIsPure pureFuns stmts
 
 expIsPure :: Set.Set Name -> MastExp -> Bool
@@ -1020,6 +1024,7 @@ callsInStmt (MastFor initStmt cond post body) =
 callsInStmt (MastSeq stmts) = Set.unions (map callsInStmt stmts)
 callsInStmt (MastAsm _) = Set.empty
 callsInStmt MastBreak = Set.empty
+callsInStmt MastContinue = Set.empty
 
 callsInExp :: MastExp -> Set.Set Name
 callsInExp (MastLit _) = Set.empty

--- a/src/Solcore/Backend/Specialise.hs
+++ b/src/Solcore/Backend/Specialise.hs
@@ -738,6 +738,7 @@ specStmt (For initStmt cond post body) = do
   return $ For initStmt' cond' post' body'
 specStmt (Asm ys) = pure (Asm ys)
 specStmt Break = pure Break
+specStmt Continue = pure Continue
 specStmt EmptyStmt = pure EmptyStmt
 specStmt stmt = errors ["specStmt not implemented for: ", show stmt]
 
@@ -1125,6 +1126,7 @@ toMastStmt (For initStmt cond postStmt body) =
   MastFor (toMastStmt initStmt) (toMastExp cond) (toMastStmt postStmt) (toMastBody body)
 toMastStmt (Block body) = MastSeq (toMastBody body)
 toMastStmt Break = MastBreak
+toMastStmt Continue = MastContinue
 toMastStmt EmptyStmt = MastSeq []
 toMastStmt s = error $ "toMastStmt: unexpected " ++ show s
 

--- a/src/Solcore/Desugarer/DecisionTreeCompiler.hs
+++ b/src/Solcore/Desugarer/DecisionTreeCompiler.hs
@@ -104,6 +104,8 @@ instance Compile (Stmt Id) where
     pure s
   compile Break =
     pure Break
+  compile Continue =
+    pure Continue
   compile EmptyStmt =
     pure EmptyStmt
   compile (Match es eqns) = do

--- a/src/Solcore/Desugarer/FieldAccess.hs
+++ b/src/Solcore/Desugarer/FieldAccess.hs
@@ -158,6 +158,7 @@ transStmt cenv stmt = (cenv, go stmt cenv)
     go Let {} = error "Impossible"
     go s@Asm {} = pure s
     go Break = pure Break
+    go Continue = pure Continue
     go EmptyStmt = pure EmptyStmt
 
 -- go s = pure s

--- a/src/Solcore/Desugarer/IndirectCall.hs
+++ b/src/Solcore/Desugarer/IndirectCall.hs
@@ -99,6 +99,7 @@ instance Desugar (Stmt Name) where
   desugar (For initStmt cond postStmt body) =
     For <$> desugar initStmt <*> desugar cond <*> desugar postStmt <*> desugar body
   desugar Break = pure Break
+  desugar Continue = pure Continue
   desugar EmptyStmt = pure EmptyStmt
 
 instance Desugar (Exp Name) where

--- a/src/Solcore/Frontend/ComptimeCheck.hs
+++ b/src/Solcore/Frontend/ComptimeCheck.hs
@@ -160,6 +160,7 @@ checkStmt st retCt ctx env stmt = case stmt of
   Asm _ -> return env
   Block body -> checkBody st retCt ctx env body >> return env
   Break -> return env
+  Continue -> return env
   EmptyStmt -> return env
 
 -- | Decide the Ctness to assign to a let-bound variable.

--- a/src/Solcore/Frontend/Module/Loader.hs
+++ b/src/Solcore/Frontend/Module/Loader.hs
@@ -1367,6 +1367,7 @@ renameStmtTypeRefs renameMap (For initStmt cond postStmt body) =
     (renameStmtTypeRefs renameMap postStmt)
     (renameBodyTypeRefs renameMap body)
 renameStmtTypeRefs _ Break = Break
+renameStmtTypeRefs _ Continue = Continue
 renameStmtTypeRefs _ EmptyStmt = EmptyStmt
 
 renameEquationTypeRefs :: Map Name Name -> Equation -> Equation

--- a/src/Solcore/Frontend/Parser/Stmt.hs
+++ b/src/Solcore/Frontend/Parser/Stmt.hs
@@ -32,6 +32,7 @@ stmtP =
     <|> try ifP
     <|> forP
     <|> breakP
+    <|> continueP
     <|> matchP
     <|> asmP
     <|> blockP
@@ -39,6 +40,9 @@ stmtP =
 
 breakP :: Parser Stmt
 breakP = Break <$ (keyword "break" *> semicolon)
+
+continueP :: Parser Stmt
+continueP = Continue <$ (keyword "continue" *> semicolon)
 
 letP :: Parser Stmt
 letP = do

--- a/src/Solcore/Frontend/Pretty/SolcorePretty.hs
+++ b/src/Solcore/Frontend/Pretty/SolcorePretty.hs
@@ -333,6 +333,7 @@ instance (Pretty a) => Pretty (Stmt a) where
       $$ nest 3 (ppr body)
       $$ rbrace
   ppr Break = text "break" <> semi
+  ppr Continue = text "continue" <> semi
   ppr EmptyStmt = empty
 
 pprForClause :: (Pretty a) => Stmt a -> Doc

--- a/src/Solcore/Frontend/Pretty/TreePretty.hs
+++ b/src/Solcore/Frontend/Pretty/TreePretty.hs
@@ -313,6 +313,7 @@ instance Pretty Stmt where
       $$ nest 3 (ppr body)
       $$ rbrace
   ppr Break = text "break" <> semi
+  ppr Continue = text "continue" <> semi
   ppr EmptyStmt = empty
 
 pprForClause :: Stmt -> Doc

--- a/src/Solcore/Frontend/Syntax/NameResolution.hs
+++ b/src/Solcore/Frontend/Syntax/NameResolution.hs
@@ -388,6 +388,7 @@ instance Resolve S.Stmt where
   resolve (S.For initStmt cond postStmt body) =
     For <$> resolve initStmt <*> resolve cond <*> resolve postStmt <*> resolve body
   resolve S.Break = pure Break
+  resolve S.Continue = pure Continue
   resolve S.EmptyStmt = pure EmptyStmt
 
 instance Resolve S.Equation where

--- a/src/Solcore/Frontend/Syntax/Stmt.hs
+++ b/src/Solcore/Frontend/Syntax/Stmt.hs
@@ -21,6 +21,7 @@ data Stmt a
   | If (Exp a) (Body a) (Body a) -- If statement
   | For (Stmt a) (Exp a) (Stmt a) (Body a) -- for(init; cond; post) { body }
   | Break -- break out of the innermost enclosing for loop
+  | Continue -- continue to the next iteration of the innermost enclosing for loop
   | EmptyStmt -- empty statement (for empty for init/post)
   deriving (Eq, Ord, Show, Data, Typeable)
 

--- a/src/Solcore/Frontend/Syntax/SyntaxTree.hs
+++ b/src/Solcore/Frontend/Syntax/SyntaxTree.hs
@@ -253,6 +253,7 @@ data Stmt
   | If Exp Body Body -- If statement
   | For Stmt Exp Stmt Body -- for(init; cond; post) { body }
   | Break -- break out of the innermost enclosing for loop
+  | Continue -- continue to the next iteration of the innermost enclosing for loop
   | EmptyStmt -- empty statement (for empty for init/post)
   deriving (Eq, Ord, Show, Data, Typeable)
 

--- a/src/Solcore/Frontend/TypeInference/Erase.hs
+++ b/src/Solcore/Frontend/TypeInference/Erase.hs
@@ -62,6 +62,7 @@ instance Erase (Stmt Id) where
   erase (For initStmt cond postStmt body) =
     For (erase initStmt) (erase cond) (erase postStmt) (erase body)
   erase Break = Break
+  erase Continue = Continue
   erase EmptyStmt = EmptyStmt
 
 instance Erase (Exp Id) where

--- a/src/Solcore/Frontend/TypeInference/SccAnalysis.hs
+++ b/src/Solcore/Frontend/TypeInference/SccAnalysis.hs
@@ -208,6 +208,7 @@ instance Names (Stmt Name) where
   names (For initStmt cond postStmt body) =
     names initStmt `union` names cond `union` names postStmt `union` names body
   names Break = []
+  names Continue = []
   names EmptyStmt = []
 
 instance Names (Equation Name) where

--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -152,6 +152,8 @@ tcStmtWithExpectedReturn mExpectedReturn s@(For initStmt cond postStmt body) =
     withCurrentSubst (For initStmt' cond' postStmt' body', psInit ++ psCond ++ psPost ++ psBody, unit)
 tcStmtWithExpectedReturn _ Break =
   pure (Break, [], unit)
+tcStmtWithExpectedReturn _ Continue =
+  pure (Continue, [], unit)
 tcStmtWithExpectedReturn _ EmptyStmt =
   pure (EmptyStmt, [], unit)
 
@@ -1858,6 +1860,7 @@ instance Vars (Stmt Id) where
     free initStmt `union` ((free cond `union` free postStmt `union` free body) \\ bound initStmt)
   free (Asm _) = []
   free Break = []
+  free Continue = []
   free EmptyStmt = []
 
   bound (Let _ n _ _) = [n]

--- a/src/Solcore/Frontend/TypeInference/TcSubst.hs
+++ b/src/Solcore/Frontend/TypeInference/TcSubst.hs
@@ -265,6 +265,8 @@ instance (HasType a) => HasType (Stmt a) where
     Asm yblk
   apply _ Break =
     Break
+  apply _ Continue =
+    Continue
   apply _ EmptyStmt =
     EmptyStmt
 
@@ -284,6 +286,7 @@ instance (HasType a) => HasType (Stmt a) where
     fv initStmt `union` fv cond `union` fv postStmt `union` fv body
   fv (Asm _) = []
   fv Break = []
+  fv Continue = []
   fv EmptyStmt = []
 
   mv (e1 := e2) =
@@ -302,6 +305,7 @@ instance (HasType a) => HasType (Stmt a) where
     mv initStmt `union` mv cond `union` mv postStmt `union` mv body
   mv (Asm _) = []
   mv Break = []
+  mv Continue = []
   mv EmptyStmt = []
 
   bv (e1 := e2) =
@@ -320,6 +324,7 @@ instance (HasType a) => HasType (Stmt a) where
     bv initStmt `union` bv cond `union` bv postStmt `union` bv body
   bv (Asm _) = []
   bv Break = []
+  bv Continue = []
   bv EmptyStmt = []
 
 instance (HasType a) => HasType (Pat a) where

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -346,6 +346,7 @@ cases =
       runTestForFile "Foo.solc" caseFolder,
       runTestForFile "for-body-shadow.solc" caseFolder,
       runTestForFile "for-break.solc" caseFolder,
+      runTestForFile "for-continue.solc" caseFolder,
       runTestForFile "for-empty-init.solc" caseFolder,
       runTestForFile "for-inner-block.solc" caseFolder,
       runTestForFile "for-init-shadow.solc" caseFolder,

--- a/test/examples/cases/for-continue.solc
+++ b/test/examples/cases/for-continue.solc
@@ -1,0 +1,13 @@
+import std.{lt,Ord,Add,Sub,Bounded,Num,Eq,Typedef};
+contract ContinueTest {
+  public function main() -> word {
+      let result : word = 0;
+      for (let i : word = 0; i < 10; i = i + 1) {
+          if (i < 5) {
+              continue;
+          } else {}
+          result = result + 1;
+      }
+      return result;
+  }
+}

--- a/test/examples/dispatch/forloops.json
+++ b/test/examples/dispatch/forloops.json
@@ -25,6 +25,18 @@
       },
       {
         "input": {
+          "comment": "continue_sum()(uint256) -> 5+6+7+8+9 = 35",
+          "calldata": "e26b41bc",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000023",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
           "comment": "empty_init()(uint256) -> 3+4+5+6 = 18",
           "calldata": "73c5c5b9",
           "value": "0"

--- a/test/examples/dispatch/forloops.solc
+++ b/test/examples/dispatch/forloops.solc
@@ -29,6 +29,20 @@ contract C {
         return s;
     }
 
+    // Sum of 5..9 using `continue` to skip the iterations where i < 5.
+    // The post-statement (i = i + 1) must still run on `continue`, otherwise
+    // the loop would never terminate.
+    public function continue_sum() -> uint256 {
+        let s : uint256 = uint256(0);
+        for (let i : uint256 = uint256(0); i < uint256(10); i = i + uint256(1)) {
+            if (i < uint256(5)) {
+                continue;
+            } else {}
+            s = s + i;
+        }
+        return s;
+    }
+
     // Empty initializer: `i` is declared/initialised outside the loop.
     public function empty_init() -> uint256 {
         let i : uint256 = uint256(3);

--- a/yule/Translate.hs
+++ b/yule/Translate.hs
@@ -240,6 +240,7 @@ genStmt (SFunction name args ret stmts) = withLocalEnv do
       return (flattenLhs loc)
 genStmt (SExpr e) = fst <$> genExpr e
 genStmt SBreak = pure [YBreak]
+genStmt SContinue = pure [YContinue]
 genStmt (SRevert s) = pure (revertStmt s)
 genStmt e = error $ "genStmt unimplemented for: " ++ show e
 


### PR DESCRIPTION
Fixes #490

Add support for `continue` mirroring the existing `break` support across the full pipeline:

- Frontend AST (`Stmt`, `SyntaxTree`), parser (`continueP`), pretty-printers
- Name resolution, module loader, comptime check, SCC analysis
- Type inference (TcStmt, TcSubst, Erase) and desugarers (FieldAccess, IndirectCall, DecisionTreeCompiler)
- Backend: Specialise, new `MastContinue` (Mast/MastEval/ComptimeCheck), EmitHull, new Hull `SContinue` (AST/parser/typecheck/pretty)
- Yul translation: `SContinue` -> existing `YContinue`

`continue` lowers to Yul's `continue`, which jumps to the for-loop post block, so the loop increment still runs and the loop terminates.

Tests: add `for-continue.solc` compile test and a `continue_sum()` case to the `forloops` dispatch integration test.