### PR TITLE
Preserve multi-return arity for Yul functions in type checker

### DIFF
--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -1729,13 +1729,19 @@ tcYulStmt (YFun fnName args rets body) =
   do
     -- Yul functions are word-typed; register the name (so calls resolve and
     -- recursion type-checks) and check the body with the parameters and named
-    -- returns bound. A zero-return function has type '... -> unit'.
-    let fnRetTy = maybe unit (\rs -> if null rs then unit else word) rets
+    -- returns bound. The return arity is preserved by encoding the named
+    -- returns as a tuple of words: zero returns -> 'unit', one -> 'word', and
+    -- N >= 2 -> a right-nested 'pair' of N words. This keeps multi-return Yul
+    -- functions at their true arity for the call-site check (see
+    -- 'checkYulAssignArity' / 'yulReturnArity') instead of collapsing every
+    -- non-empty return list to a single 'word'.
+    let retNames = concat rets
+        fnRetTy = tupleTyFromList (map (const word) retNames)
         fnTy = funtype (map (const word) args) fnRetTy
     extEnv fnName (monotype fnTy)
     _ <- withLocalEnv do
       mapM_ (flip extEnv mword) args
-      mapM_ (flip extEnv mword) (concat rets)
+      mapM_ (flip extEnv mword) retNames
       tcYulBlock body
     pure ([], unit)
 tcYulStmt YBreak = pure ([], unit)
@@ -1743,13 +1749,18 @@ tcYulStmt YContinue = pure ([], unit)
 tcYulStmt YLeave = pure ([], unit)
 tcYulStmt (YComment _) = pure ([], unit)
 
--- Yul builtins/opcodes return either 0 values (type 'unit') or 1 value
--- (any other type). Compare the number of names on the left-hand side of
--- an assignment with the actual return arity of the right-hand side.
+-- Recover the Yul return arity from a type. Builtins/opcodes return either
+-- 0 values ('unit') or 1 value (any other single word-typed value).
+-- Multi-return Yul functions encode their N >= 2 results as a right-nested
+-- 'pair' of words (see 'tcYulStmt (YFun ...)'), so unfold the pair spine to
+-- recover the true arity. Compare this against the number of names on the
+-- left-hand side of an assignment.
 yulReturnArity :: Ty -> Int
 yulReturnArity t
   | t == unit = 0
-  | otherwise = 1
+  | otherwise = case t of
+      TyCon (Name "pair") [_, t2] -> 1 + yulReturnArity t2
+      _ -> 1
 
 checkYulAssignArity :: YulStmt -> [Name] -> YulExp -> Ty -> TcM ()
 checkYulAssignArity s ns e t =

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -481,6 +481,8 @@ cases =
       runTestExpectingFailure "xref.solc" caseFolder,
       runTestForFile "yul-function-typing.solc" caseFolder,
       runTestForFile "yul-return.solc" caseFolder,
+      runTestForFile "yul-multi-return.solc" caseFolder,
+      runTestExpectingFailure "yul-multi-return-arity-fail.solc" caseFolder,
       runTestExpectingFailure "pragma_merge_fail_patterson.solc" caseFolder,
       runTestExpectingFailure "pragma_merge_fail_coverage.solc" caseFolder,
       runTestForFile "single-lambda.solc" caseFolder,

--- a/test/examples/cases/yul-multi-return-arity-fail.solc
+++ b/test/examples/cases/yul-multi-return-arity-fail.solc
@@ -1,0 +1,18 @@
+// The arity check must still reject a genuine mismatch: 'pair' returns 2
+// values but 3 names are being assigned, so this Yul is invalid and the type
+// checker must report the arity error.
+contract YulMultiRetBad {
+  public function main() -> word {
+    let x : word;
+    let y : word;
+    let z : word;
+    assembly {
+      function pair() -> a, b {
+        a := 1
+        b := 2
+      }
+      x, y, z := pair()
+    }
+    return x;
+  }
+}

--- a/test/examples/cases/yul-multi-return.solc
+++ b/test/examples/cases/yul-multi-return.solc
@@ -1,0 +1,18 @@
+// A Yul function with multiple named returns must keep its true return arity:
+// 'x, y := pair()' assigns 2 values from a 2-return function and is valid Yul,
+// so the type checker must accept it (regression for the arity check that used
+// to collapse every non-empty return list to a single 'word').
+contract YulMultiRet {
+  public function main() -> word {
+    let x : word;
+    let y : word;
+    assembly {
+      function pair() -> a, b {
+        a := 1
+        b := 2
+      }
+      x, y := pair()
+    }
+    return x;
+  }
+}


### PR DESCRIPTION
tcYulStmt for YFun collapsed any non-empty return list to a single `word`, so the call-site arity check (checkYulAssignArity via yulReturnArity) rejected valid multi-return Yul functions such as `x, y := pair()` with "produces 1 value(s), but 2 value(s) are being assigned." — even though solc accepts the same Yul.

Encode the named returns as a tuple of words (0 -> unit, 1 -> word, N>=2 -> a right-nested pair of N words) via tupleTyFromList, and teach yulReturnArity to unfold the pair spine to recover the true arity. The 0/1-return cases are unchanged; N>=2 now type-checks. There are no pair-typed Yul values, so the encoding is unambiguous within the Yul sublanguage, and the downstream Yul emitter already preserves multi-name YFun/YAssign unchanged.

Add a positive regression test (yul-multi-return.solc) and a negative arity-mismatch test (yul-multi-return-arity-fail.solc).

Example from docs: https://docs.soliditylang.org/en/v0.8.35/yul.html#function-calls