### PR TITLE
Fixes in the specializer for dealing with matches

### DIFF
--- a/run_contests.sh
+++ b/run_contests.sh
@@ -24,5 +24,6 @@ bash ./contest.sh test/examples/dispatch/storage.json
 bash ./contest.sh test/examples/dispatch/generic_sum.json
 bash ./contest.sh test/examples/dispatch/generic_product.json
 bash ./contest.sh test/examples/dispatch/sum_wide_product.json
+bash ./contest.sh test/examples/dispatch/specialise_sum_of_product.json
 bash ./contest.sh test/examples/dispatch/forloops.json
 bash ./contest.sh test/examples/dispatch/weth9.json

--- a/src/Solcore/Backend/Specialise.hs
+++ b/src/Solcore/Backend/Specialise.hs
@@ -746,7 +746,11 @@ specMatch exps alts = do
   -- subst <- getSpSubst
   -- debug ["> specMatch, scrutinee: ", pretty exps, " @ ", pretty subst]
   exps' <- specScruts exps
-  alts' <- forM alts specAlt
+  saved <- getSpSubst
+  alts' <- forM alts $ \alt -> do
+    putSpSubst saved
+    specAlt alt
+  putSpSubst saved
   -- debug ["< specMatch, alts': ", show alts']
   return $ Match exps' alts'
   where

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -121,7 +121,8 @@ dispatches =
       runDispatchTest "empty.solc",
       runDispatchTest "empty_no_constructor.solc",
       runDispatchTest "generic_product.solc",
-      runDispatchTest "generic_sum.solc"
+      runDispatchTest "generic_sum.solc",
+      runDispatchTest "specialise_sum_of_product.solc"
     ]
   where
     runDispatchTest file = runTestForFileWith (emptyOption mempty) file "./test/examples/dispatch"

--- a/test/examples/dispatch/specialise_sum_of_product.json
+++ b/test/examples/dispatch/specialise_sum_of_product.json
@@ -1,0 +1,28 @@
+{
+  "SpecialiseSumOfProduct": {
+    "bytecode": "_CODE",
+    "contract": "SpecialiseSumOfProduct",
+    "tests": [
+      {
+        "input": {
+          "comment": "constructor()",
+          "calldata": "",
+          "value": "0"
+        },
+        "kind": "constructor"
+      },
+      {
+        "input": {
+          "comment": "probe()(uint256) -> 6 : Total over sum((word,word),word) on inl((1,2)) = (1+1)+(2+2). Regression for the specMatch substitution-leak bug (yule used to reject the hull).",
+          "calldata": "b74af5a9",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000006",
+          "status": "success"
+        }
+      }
+    ]
+  }
+}

--- a/test/examples/dispatch/specialise_sum_of_product.solc
+++ b/test/examples/dispatch/specialise_sum_of_product.solc
@@ -1,0 +1,81 @@
+// Regression test: specializer sum-of-product bug (specMatch substitution leak).
+//
+// A binary class method over the primitive `sum(f, g)` whose two sides have
+// DIFFERENT shapes: the inl side carries a product (word, word), the inr side
+// carries a plain word. Specializing the instance at sum((word, word), word)
+// used to leak a substitution binding from one match alternative into the
+// sibling alternative's nested `match`, mistyping its scrutinee. The frontend
+// (sol-core) accepted the program, but `yule` then rejected the emitted .hull:
+//
+//   Type mismatch
+//     expected: sum(word, word)
+//     actual:   sum(pair(word, word), word)
+//
+// Root cause: in Specialise.hs, `specMatch` did not scope `spSubst` (a global
+// accumulator) across match alternatives. While specializing the `inl` branch,
+// a binding leaked into the `inr` branch's nested `match`, collapsing
+// sum(f, g) to sum(g, g). The fix resets spSubst around each alternative.
+//
+// This isolates the SPECIALIZER: no #[derive], no Eq universe instances. The
+// class and its instances are defined locally and exercised directly, so the
+// program must now lower end-to-end and return the expected value.
+
+import std.{*};
+import std.dispatch.{*};
+
+pragma no-patterson-condition;
+pragma no-bounded-variable-condition;
+
+// total(x, y) sums every leaf word of both arguments.
+forall a.
+class a : Total {
+  function total(x : a, y : a) -> word;
+}
+
+instance word : Total {
+  function total(x : word, y : word) -> word {
+    return x + y;
+  }
+}
+
+// product: recurse into both components (this is the shape inl carries).
+forall f g . f : Total, g : Total => instance (f, g) : Total {
+  function total(x : (f, g), y : (f, g)) -> word {
+    match x {
+    | (xa, xb) => match y {
+                  | (ya, yb) => return Total.total(xa, ya) + Total.total(xb, yb);
+                  }
+    }
+  }
+}
+
+// sum: the buggy shape. The inl branch recurses at f (a product here), the inr
+// branch recurses at g (a word here); specializing one must not pollute the
+// other's nested `match y`.
+forall f g . f : Total, g : Total => instance sum(f, g) : Total {
+  function total(x : sum(f, g), y : sum(f, g)) -> word {
+    match x {
+    | inl(xa) => match y {
+                 | inl(ya) => return Total.total(xa, ya);
+                 | inr(yb) => return 0;
+                 }
+    | inr(xb) => match y {
+                 | inl(ya) => return 0;
+                 | inr(yb) => return Total.total(xb, yb);
+                 }
+    }
+  }
+}
+
+contract SpecialiseSumOfProduct {
+    constructor() {}
+
+    // inl carries a product (word, word); the two sum sides differ in shape
+    // (pair vs word), which is what the specializer mishandled.
+    // total(inl((1,2)), inl((1,2))) = total((1,2),(1,2)) = (1+1)+(2+2) = 6.
+    public function probe() -> uint256 {
+        let x : sum((word, word), word) = inl((1, 2));
+        let y : sum((word, word), word) = inl((1, 2));
+        return uint256(Total.total(x, y));
+    }
+}


### PR DESCRIPTION
Consider the following contrived example:

```
forall f g . f:Total, g:Total => instance sum(f, g) : Total {
  total(x : sum(f,g), y : sum(f,g)) =
    match x {
    | inl(xa) => match y { inl(ya) => Total.total(xa, ya)   // recurses at f
                         | inr(yb) => 0 }
    | inr(xb) => match y { inl(ya) => 0
                         | inr(yb) => Total.total(xb, yb) }  // recurses at g
    }
}
```

Specializing the call at `sum((word,word), word)` gives `f = pair(word,word)` and `g = word`. Note
that the two outer branches recurse at **different types**: the `inl` branch at `f` (a pair), the
`inr` branch at `g` (a word).

1. Specializing the `inl` branch, the recursive call `Total.total(xa, ya)` is resolved at `f`. That
   triggers `extSpSubst`, pinning down that branch's metavariables. In particular, a payload
   metavariable that is unused/free in this branch ends up identified, and the net effect is an
   identification `f ~ g` in the global accumulator.
2. The loop proceeds to the `inr` branch **without clearing `spSubst`**. Recomputing the scrutinee
   of that branch's `match y`, `atCurrentSubst` applies the inherited binding to `y : sum(f,g)` and
   collapses it to `sum(g,g)`, that is, `sum(word,word)`.
3. The emitted `.hull` then annotates that inner `match` with `sum(word,word)`, while the value that
   actually flows in is `sum(pair(word,word), word)`.

The frontend does not notice (it type-checked before specialization). But `yule` revalidates types
structurally and aborts:

```
Type mismatch
  expected: sum(word, word)              -- sum(g,g), collapsed
  actual:   sum(pair(word,word), word)   -- sum(f,g), correct
```

* Why only "sum of product" breaks

If the two sides of the sum have the **same shape** (for example `sum(word, word)`, an enum, and so
on), the `f ~ g` collapse is a no-op: `word` becomes `word`, the corrupted type coincides with the
correct one, and `yule` sees no discrepancy. The bug only becomes **visible** when `f` and `g` have
different shapes (pair vs word), which is exactly the "constructor with more than one field" case.
That is why enums and uniform sums always passed, and only sum-of-product failed.

* How the fix works

```haskell
exps' <- specScruts exps
saved <- getSpSubst               -- snapshot AFTER the scrutinees
alts' <- forM alts $ \alt -> do
  putSpSubst saved                -- each alt starts from the same clean state
  specAlt alt
putSpSubst saved                  -- nothing leaks past the match
return $ Match exps' alts'
```

The idea is to give each alternative the **substitution scope** it should have:

- `saved` is captured *after* `specScruts`, so it includes everything the call context and the
  scrutinees legitimately determined (`f = pair`, `g = word`). That is what all alternatives share.
- `putSpSubst saved` before each alternative ensures it is specialized under exactly that shared
  context, **without** the bindings a sibling discovered internally. So each branch's `match y`
  scrutinee is seen as the intact `sum(f,g)`.
- `putSpSubst saved` after the loop prevents a branch-local binding from escaping into statements
  that come after the `match`.