### PR TITLE
Resurrect doc workflow

### DIFF
--- a/.github/workflows/reference-docs.yml
+++ b/.github/workflows/reference-docs.yml
@@ -1,4 +1,4 @@
-name: Deploy reference docs to github pages
+name: Deploy reference docs to GitHub Pages
 
 on:
   push:

--- a/.github/workflows/reference-docs.yml
+++ b/.github/workflows/reference-docs.yml
@@ -1,0 +1,51 @@
+name: Deploy reference docs to github pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write # required by the deploy-pages action for some reason
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+
+      - name: install nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build with mdbook
+        run: nix shell --inputs-from . nixpkgs#mdbook -c mdbook build doc
+
+      - name: upload pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ./doc/book
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/reference-docs.yml
+++ b/.github/workflows/reference-docs.yml
@@ -15,7 +15,7 @@ concurrency:
 permissions:
   contents: read
   pages: write
-  id-token: write # required by the deploy-pages action for some reason
+  id-token: write # required by actions/deploy-pages to request an OIDC token for GitHub Pages deployment
 
 jobs:
   # Build job


### PR DESCRIPTION
docs were deleted in 855ce66 due to a incorrect merge of main onto the pattern match compiler branch in 8f2f3f0.
The docs themselves have been resurrected in b79e460 (#346), but the workflow file was forgotten.

This PR also updates deprecated `actions/deploy-pages@v4` to v5