### PR TITLE
Move yule backend logic into the sol-core library

### DIFF
--- a/sol-core.cabal
+++ b/sol-core.cabal
@@ -112,12 +112,21 @@ library
       Solcore.Pipeline.SolcorePipeline
       Solcore.Primitives.Primitives
       Language.Hull
+      Language.Hull.Compress
       Language.Hull.Parser
       Language.Hull.TcEnv
       Language.Hull.TcMonad
       Language.Hull.TypeCheck
       Language.Hull.Types
+      -- Hull -> Yul backend (was the separate `yule` executable); promoted to
+      -- the library so the translation is reusable (CLI, tests, other tools).
+      Language.Hull.ToYul.Assemble
+      Language.Hull.ToYul.Locus
+      Language.Hull.ToYul.Options
+      Language.Hull.ToYul.TM
+      Language.Hull.ToYul.Translate
       Language.Yul
+      Language.Yul.Builtins
       Language.Yul.Parser
       Language.Yul.QuasiQuote
       Common.LightYear
@@ -147,7 +156,7 @@ executable yule
       PatternSynonyms
       BlockArguments
       ImportQualifiedPost
-    other-modules: Locus, Options, TM, Translate, Builtins, Compress
+    -- Locus, Options, TM, Translate, Builtins, Compress now live in the library.
     build-depends:    base ^>=4.19.1.0,
                       pretty >=  1.1,
                       containers >= 0.6,

--- a/src/Language/Hull/Compress.hs
+++ b/src/Language/Hull/Compress.hs
@@ -1,4 +1,4 @@
-module Compress where
+module Language.Hull.Compress where
 
 import Language.Hull
 

--- a/src/Language/Hull/ToYul/Assemble.hs
+++ b/src/Language/Hull/ToYul/Assemble.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+-- | Assemble a translated Yul object into final Yul text, and drive the whole
+-- hull -> Yul step in-process. This holds the wrapping logic that used to live
+-- in @yule/Main.hs@, so both the @yule@ CLI and the in-memory API share it.
+module Language.Hull.ToYul.Assemble
+  ( defaultYuleOptions,
+    objectToYul,
+    wrapInObject,
+  )
+where
+
+import Common.Pretty
+import Control.Exception (SomeException, evaluate, try)
+import Language.Hull (Object)
+import Language.Hull.TcEnv (emptyHullTcEnv)
+import Language.Hull.TcMonad (runHullTcM)
+import Language.Hull.ToYul.Options (Options (..))
+import Language.Hull.ToYul.TM (runTM)
+import Language.Hull.ToYul.Translate (translateObject)
+import Language.Hull.TypeCheck (checkObject)
+import Language.Yul
+import Language.Yul.QuasiQuote
+
+-- | Options for driving the Yul backend in-process, matching the @yule@ CLI
+-- defaults (deployment code on, type checking on).
+defaultYuleOptions :: Options
+defaultYuleOptions =
+  Options
+    { input = "",
+      contract = "Output",
+      output = "Output.sol",
+      verbose = False,
+      debug = False,
+      compress = False,
+      wrap = False,
+      runOnce = False,
+      noTypeCheck = False
+    }
+
+-- | Type-check, translate and render one hull object to Yul (with deployment
+-- code). Returns @Left@ with a diagnostic on a Hull/Yul type error or an
+-- unimplemented translation case.
+objectToYul :: Object -> IO (Either String String)
+objectToYul obj = do
+  tcResult <- runHullTcM (checkObject obj) emptyHullTcEnv
+  case tcResult of
+    Left err -> pure (Left err)
+    Right () -> do
+      -- The translator uses `error` for unimplemented cases; force the rendered
+      -- output inside `try` so those surface as diagnostics rather than crashes.
+      outcome <-
+        try $ do
+          yulPreobject <- runTM defaultYuleOptions (translateObject obj)
+          let rendered = render (wrapInObject True yulPreobject)
+          _ <- evaluate (length rendered)
+          pure rendered
+      pure $ case (outcome :: Either SomeException String) of
+        Left ex -> Left ("Yul translation error:\n" ++ show ex)
+        Right rendered -> Right rendered
+
+-- wrap in a Yul object with the given name
+wrapInObject :: Bool -> YulObject -> Doc
+wrapInObject deploy yulo@(YulObject name code inners)
+  | deploy = ppr (createDeployment yulo)
+  | otherwise = ppr (YulObject name (addMemInit (addRetCode code)) inners)
+
+addMemInit :: YulCode -> YulCode
+addMemInit c = YulCode [[yulStmt| mstore(64, memoryguard(128)) |]] <> c
+
+addRetCode :: YulCode -> YulCode
+addRetCode c = c <> retCode
+  where
+    retCode =
+      YulCode
+        [yulBlock|
+    {
+      mstore(0, _mainresult)
+      return(0, 32)
+    }
+    |]
+
+deployCode :: String -> Bool -> YulCode
+deployCode _name withStart = YulCode $ go withStart
+  where
+    go True = [[yulStmt| usr$_start() |]]
+    go False = []
+
+createDeployment :: YulObject -> YulObject
+createDeployment (YulObject yulName yulCode [InnerObject (YulObject innerName innerCode [])]) =
+  YulObject yulName yulCode' [yulInner']
+  where
+    yulCode' = yulCode <> deployCode innerName True
+    yulInner' = InnerObject (YulObject innerName (addRetCode innerCode) [])
+createDeployment (YulObject yulName yulCode []) =
+  YulObject yulName' yulCode' [yulInner']
+  where
+    yulName' = yulName <> "Deploy"
+    yulCode' = deployCode yulName False
+    yulInner' = InnerObject (YulObject yulName (addRetCode yulCode) [])
+createDeployment _ = error ("createDeployment not implemented for this type of object")

--- a/src/Language/Hull/ToYul/Locus.hs
+++ b/src/Language/Hull/ToYul/Locus.hs
@@ -1,4 +1,4 @@
-module Locus where
+module Language.Hull.ToYul.Locus where
 
 import Data.String
 

--- a/src/Language/Hull/ToYul/Options.hs
+++ b/src/Language/Hull/ToYul/Options.hs
@@ -1,4 +1,4 @@
-module Options where
+module Language.Hull.ToYul.Options where
 
 import Options.Applicative
 

--- a/src/Language/Hull/ToYul/TM.hs
+++ b/src/Language/Hull/ToYul/TM.hs
@@ -1,9 +1,9 @@
-module TM
+module Language.Hull.ToYul.TM
   ( TM,
     runTM,
     CEnv (..),
     -- , module RIO
-    module Locus,
+    module Language.Hull.ToYul.Locus,
     FunInfo (..),
     getCounter,
     setCounter,
@@ -25,9 +25,9 @@ import Control.Monad (when)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Language.Hull qualified as Hull
-import Locus
-import Options (Options)
-import Options qualified
+import Language.Hull.ToYul.Locus
+import Language.Hull.ToYul.Options (Options)
+import Language.Hull.ToYul.Options qualified as Options
 
 type VarEnv = Map String Location
 

--- a/src/Language/Hull/ToYul/Translate.hs
+++ b/src/Language/Hull/ToYul/Translate.hs
@@ -1,17 +1,17 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Translate where
+module Language.Hull.ToYul.Translate where
 
-import Builtins
 import Data.List (partition)
 import Data.Map qualified as Map
 import Data.String
 import GHC.Stack
 import Language.Hull hiding (Name)
 import Language.Hull qualified as Hull
+import Language.Hull.ToYul.TM
 import Language.Yul
+import Language.Yul.Builtins
 import Solcore.Frontend.Syntax.Name
-import TM
 
 genExpr :: Expr -> TM ([YulStmt], Location)
 genExpr (EWord n) = pure ([], LocWord n)
@@ -242,7 +242,10 @@ genStmt (SExpr e) = fst <$> genExpr e
 genStmt SBreak = pure [YBreak]
 genStmt SContinue = pure [YContinue]
 genStmt (SRevert s) = pure (revertStmt s)
-genStmt e = error $ "genStmt unimplemented for: " ++ show e
+-- Comments carry no runtime meaning. The hull parser skips block comments, so
+-- the standalone yule binary never sees these; drop them here too so the
+-- in-memory backend behaves identically.
+genStmt (SComment _) = pure []
 
 -- If the statement is a function definition, record its type
 scanStmt :: Stmt -> TM ()

--- a/src/Language/Yul/Builtins.hs
+++ b/src/Language/Yul/Builtins.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Builtins (yulBuiltins, revertStmt) where
+module Language.Yul.Builtins (yulBuiltins, revertStmt) where
 
 import Language.Yul
 

--- a/yule/Main.hs
+++ b/yule/Main.hs
@@ -5,23 +5,25 @@ module Main where
 
 -- FIXME: move Name to Common
 -- (Doc, Pretty(..), nest, render)
-import Builtins (yulBuiltins)
+
 import Common.Pretty
-import Compress
 import Control.Monad (unless, when)
 import GHC.IO.Encoding (setLocaleEncoding, utf8)
+import Language.Hull.Compress
 import Language.Hull.Parser (parseObject)
 import Language.Hull.TcEnv (emptyHullTcEnv)
 import Language.Hull.TcMonad (runHullTcM)
+import Language.Hull.ToYul.Assemble (wrapInObject)
+import Language.Hull.ToYul.Options (parseOptions)
+import Language.Hull.ToYul.Options qualified as Options
+import Language.Hull.ToYul.TM
+import Language.Hull.ToYul.Translate
 import Language.Hull.TypeCheck (checkObject)
 import Language.Yul
+import Language.Yul.Builtins (yulBuiltins)
 import Language.Yul.QuasiQuote
-import Options (parseOptions)
-import Options qualified
 import Solcore.Frontend.Syntax.Name
 import System.Exit (exitFailure)
-import TM
-import Translate
 
 main :: IO ()
 main = do
@@ -55,47 +57,6 @@ main = do
           else wrapInObject withDeployment yulPreobject
   putStrLn ("writing output to " ++ Options.output options)
   writeFile (Options.output options) (render doc)
-
--- wrap in a Yul object with the given name
-wrapInObject :: Bool -> YulObject -> Doc
-wrapInObject deploy yulo@(YulObject name code inners)
-  | deploy = ppr (createDeployment yulo)
-  | otherwise = ppr (YulObject name (addMemInit (addRetCode code)) inners)
-
-addMemInit :: YulCode -> YulCode
-addMemInit c = YulCode [[yulStmt| mstore(64, memoryguard(128)) |]] <> c
-
-addRetCode :: YulCode -> YulCode
-addRetCode c = c <> retCode
-  where
-    retCode =
-      YulCode
-        [yulBlock|
-    {
-      mstore(0, _mainresult)
-      return(0, 32)
-    }
-    |]
-
-deployCode :: String -> Bool -> YulCode
-deployCode _name withStart = YulCode $ go withStart
-  where
-    go True = [[yulStmt| usr$_start() |]]
-    go False = []
-
-createDeployment :: YulObject -> YulObject
-createDeployment (YulObject yulName yulCode [InnerObject (YulObject innerName innerCode [])]) =
-  YulObject yulName yulCode' [yulInner']
-  where
-    yulCode' = yulCode <> deployCode innerName True
-    yulInner' = InnerObject (YulObject innerName (addRetCode innerCode) [])
-createDeployment (YulObject yulName yulCode []) =
-  YulObject yulName' yulCode' [yulInner']
-  where
-    yulName' = yulName <> "Deploy"
-    yulCode' = deployCode yulName False
-    yulInner' = InnerObject (YulObject yulName (addRetCode yulCode) [])
-createDeployment _ = error ("createDeployment not implemented for this type of object")
 
 -- | wrap a Yul chunk in a Solidity function with the given name
 --   assumes result is in a variable named "_result"


### PR DESCRIPTION
The Yul backend lived in the `yule` executable's own top-level modules. Move them into the library under a proper namespace and extract the Yul-object assembly logic out of `yule/Main.hs`, so the hull -> Yul step is reusable from the library (CLI, tests and other tools):

  Compress  -> Language.Hull.Compress
  Builtins  -> Language.Yul.Builtins
  Locus, Options, TM, Translate, and the new assembly module
            -> Language.Hull.ToYul.*

- The yule executable now contains only Main.hs; it imports wrapInObject from Language.Hull.ToYul.Assemble and the translation modules by their new names.
- Translate: treat SComment as a no-op in genStmt. The hull parser skips block comments, so the CLI never saw them, but emitHull emits comment statements and they hit genStmt's error catch-all when a hull object is translated in-process (without a serialize/parse round-trip).

Assisted-By: Claude Opus 4.8 <noreply@anthropic.com>