### PR TITLE
Add instance uint256:Int and fix bugs that prevented it

### DIFF
--- a/doc/comptime-integer.md
+++ b/doc/comptime-integer.md
@@ -137,15 +137,24 @@ provides overloaded coercion from `integer` literals to concrete numeric types:
 
 ```
 class a : Int { fromInteger : integer -> a }
-instance word    : Int  -- fromInteger = wordFromInteger
-instance integer : Int  -- fromInteger = identity
+instance word    : Int  -- fromInteger = wordFromInteger (primitive)
+instance integer : Int  -- fromInteger = identity        (primitive)
+instance uint256 : Int  -- fromInteger = uint256(wordFromInteger(x)) (std.solc)
 ```
 
-Both instances are primitive (no source body).  `Int.fromInteger` is injected
-by the desugaring pass around every integer literal, but it is also accessible
-to user code directly (the class and method are registered in the name
-resolver's `emptyEnv`).  Because `Int` is a reserved primitive class name, user
-programs cannot define their own class named `Int`.
+The `word` and `integer` instances are primitive (no source body).  Concrete
+numeric types define their own `Int` instance in `std.solc`; `uint256` wraps
+`wordFromInteger` in its constructor, so `let x : uint256 = 42` truncates the
+literal mod 2^256 exactly like a `word` site.  `Int.fromInteger` is injected by
+the desugaring pass around every integer literal, but it is also accessible to
+user code directly (the class and method are registered in the name resolver's
+`emptyEnv`).  Because `Int` is a reserved primitive class name, user programs
+cannot define their own class named `Int`.
+
+Note: `Int` method names are stored **qualified** in the primitive class's
+`ClassInfo` (like `invokable`), so `verifySignatures` must not re-qualify them
+when checking a source instance body — otherwise the method resolves to the
+double-qualified `Int.Int.fromInteger`.
 
 `Int.fromInteger` is in `integerPrimNames`, so it seeds `builtinPureFuns`
 and is treated as a comptime builtin by the specializer.

--- a/src/Solcore/Backend/MastEval.hs
+++ b/src/Solcore/Backend/MastEval.hs
@@ -959,18 +959,21 @@ eliminateDeadCode cu = cu {mastTopDecls = map elimTopDecl (mastTopDecls cu)}
     elimTopDecl (MastTContr c) = MastTContr (elimContract c)
     elimTopDecl d@(MastTDataDef _) = d
 
-    elimContract c = c {mastContrDecls = filter keepDecl (mastContrDecls c)}
+    elimContract c = c {mastContrDecls = concatMap filterDecl (mastContrDecls c)}
       where
         usedNames = findUsedFunctions c
-        keepDecl (MastCFunDecl fd) = mastFunName fd `Set.member` usedNames
-        keepDecl (MastCMutualDecl ds) =
-          -- Keep mutual block if any function in it is used
-          any isUsedDecl ds
-        keepDecl (MastCDataDecl _) = True
-
-        isUsedDecl (MastCFunDecl fd) = mastFunName fd `Set.member` usedNames
-        isUsedDecl (MastCMutualDecl ds) = any isUsedDecl ds
-        isUsedDecl (MastCDataDecl _) = True
+        -- Drop unreachable functions, recursing into mutual blocks so that
+        -- dead members of a block whose siblings are still reachable are also
+        -- removed (e.g. a helper the deployer only needed before partial
+        -- evaluation folded its call). Data declarations are always kept.
+        filterDecl d@(MastCFunDecl fd)
+          | mastFunName fd `Set.member` usedNames = [d]
+          | otherwise = []
+        filterDecl (MastCMutualDecl ds) =
+          case concatMap filterDecl ds of
+            [] -> []
+            ds' -> [MastCMutualDecl ds']
+        filterDecl d@(MastCDataDecl _) = [d]
 
 -- | Find all functions reachable from root functions
 findUsedFunctions :: MastContract -> Set.Set Name

--- a/src/Solcore/Backend/Specialise.hs
+++ b/src/Solcore/Backend/Specialise.hs
@@ -388,21 +388,32 @@ comptimeBuiltins = integerPrimNames
 specCall :: Id -> [TcExp] -> Ty -> SM (Id, [TcExp])
 specCall i@(Id (Name "revertLit") _) args _ = pure (i, args)
 specCall (Id (QualName (Name "std") "revertLit") ty) args _ = pure (Id (Name "revertLit") ty, args)
--- Int.fromInteger coercion: resolve to the appropriate primitive based on result type.
--- integer -> word    becomes wordFromInteger (handled by MastEval)
--- integer -> integer is identity (handled by MastEval)
-specCall (Id (QualName (Name "Int") "fromInteger") ty) args _ = do
-  args' <- mapM (\a -> specExp a (typeOfTcExp a)) args
+-- Int.fromInteger coercion: resolve based on the result type.
+-- integer -> word     becomes wordFromInteger (handled by MastEval)
+-- integer -> integer  is identity (handled by MastEval)
+-- integer -> other    resolves to the type's `Int` instance body, which
+--                     performs any needed truncation via wordFromInteger.
+specCall self@(Id (QualName (Name "Int") "fromInteger") ty) args callTy = do
   s <- getSpSubst
   let resultTy = snd (splitTy (applytv s ty))
   if resultTy == word
-    then pure (Id (Name "wordFromInteger") (Prim.integer :-> word), args')
-    else pure (Id (QualName (Name "Int") "fromInteger") (Prim.integer :-> resultTy), args')
-specCall i args _ty
+    then do
+      args' <- mapM (\a -> specExp a (typeOfTcExp a)) args
+      pure (Id (Name "wordFromInteger") (Prim.integer :-> word), args')
+    else
+      if resultTy == Prim.integer
+        then do
+          args' <- mapM (\a -> specExp a (typeOfTcExp a)) args
+          pure (Id (QualName (Name "Int") "fromInteger") (Prim.integer :-> resultTy), args')
+        else specCallResolve self args callTy
+specCall i args ty
   | idName i `elem` comptimeBuiltins = do
       args' <- mapM (\a -> specExp a (typeOfTcExp a)) args
       pure (i, args')
-specCall i args ty = do
+  | otherwise = specCallResolve i args ty
+
+specCallResolve :: Id -> [TcExp] -> Ty -> SM (Id, [TcExp])
+specCallResolve i args ty = do
   i' <- atCurrentSubst i
   ty' <- atCurrentSubst ty
   -- debug ["> specCall: ", pretty i', show args, " : ", pretty ty']

--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -1088,7 +1088,10 @@ verifySignatures instd@(Instance _ _ ps n ts t funs) =
     s <- match classc' ih `wrapError` instd
     -- getting method types
     let qnames = map qual (methods cinfo)
-        qual v = if v == invoke then v else qualifyName n v
+        -- Primitive classes (invokable, Int) store their method names already
+        -- qualified; source classes store them unqualified. Only qualify the
+        -- latter, so we don't double-qualify into e.g. Int.Int.fromInteger.
+        qual v = if isQual v then v else qualifyName n v
     -- getting most general types and instantiate them
     aqts <-
       mapM

--- a/std/std.solc
+++ b/std/std.solc
@@ -654,6 +654,12 @@ instance uint256:Bounded {
   }
 }
 
+instance uint256:Int {
+  function fromInteger(x:integer) -> uint256 {
+    return uint256(wordFromInteger(x));
+  }
+}
+
 function addmod(x: uint256, y: uint256, k: uint256) -> uint256 {
     require(k != uint256(0), Error(0x7125cbb9)); // AddModWithZero()
     return Typedef.abs(addmod_(Typedef.rep(x), Typedef.rep(y), Typedef.rep(k)));

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -55,6 +55,7 @@ comptime =
       runTestForFile "integer-lit-poly.solc" comptimeFolder,
       runTestForFile "integer-lit-cond.solc" comptimeFolder,
       runTestForFile "integer-lit-pat.solc" comptimeFolder,
+      runTestForFile "uint256-lit.solc" comptimeFolder,
       runTestForFile "match_labels.solc" comptimeFolder,
       -- comptime verification: negative cases (must be rejected)
       runTestExpectingFailure "ct_param_runtime.solc" comptimeFolder,

--- a/test/examples/comptime/uint256-lit.solc
+++ b/test/examples/comptime/uint256-lit.solc
@@ -1,0 +1,13 @@
+// Bare integer literals at uint256-typed sites use `instance uint256 : Int`.
+// The instance's fromInteger wraps `wordFromInteger`, so an out-of-range
+// literal is truncated mod 2^256, matching the `word` site behaviour.
+import std.{*};
+
+contract Uint256Lit {
+  function main() -> word {
+    let a : uint256 = 3;
+    // 2^256 + 5 must truncate to 5.
+    let b : uint256 = 0x10000000000000000000000000000000000000000000000000000000000000005;
+    return Typedef.rep(a) + Typedef.rep(b);
+  }
+}

--- a/test/examples/dispatch/counter.solc
+++ b/test/examples/dispatch/counter.solc
@@ -1,21 +1,14 @@
 import std.{*};
 import std.dispatch.{*};
 contract Counter {
-  // some dummy fields to test offset calculation
-  fld0 : word;
-  fld1 : uint256;
-  fld2 : address;
   counter : uint256;
   
   constructor() {
-    counter = uint256(41);
-//    fld2 = address(0);
-//     fld1 = uint256(11);
-//     fld0 = 7;
+    counter = 41;
   }
   
   public function test() -> uint256 {
-    counter = counter + uint256(1);
+    counter = counter + 1;
     return counter;
   }
 }

--- a/test/examples/dispatch/miniERC20.solc
+++ b/test/examples/dispatch/miniERC20.solc
@@ -22,7 +22,7 @@ contract MiniERC20 {
     name = name_;
     symbol = symbol_;
     owner = caller();
-    decimals = uint256(18);
+    decimals = 18;
     mint(totalSupply_);
   }
 
@@ -89,8 +89,8 @@ contract MiniERC20 {
   }
 
   public function test() -> uint256 {
-      approve(address(0), uint256(10));
-      transferFrom(caller(), address(0), uint256(958));
+      approve(address(0), 10);
+      transferFrom(caller(), address(0), 958);
       return getMyBalance();
   }
 


### PR DESCRIPTION
`uint256` did not have `Int` instance required to automatically convert literals.
With these changes assignments like `counter=42` do not need explicit `uint256`