### PR TITLE
Move to GHC 9.10

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ nix develop
 ```
 
 The development shell includes:
-- Haskell tools: GHC 9.8, cabal, HLS
+- Haskell tools: GHC 9.10, cabal, HLS
 - Solidity tools: solc, foundry-bin, hevm
 - C++ tools: cmake, boost (for testrunner)
 - Utilities: jq, go-ethereum, goevmlab

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
           inherit system;
           overlays = [ inputs.foundry.overlay ];
         };
-        hspkgs = pkgs.haskell.packages.ghc98;
+        hspkgs = pkgs.haskell.packages.ghc910;
 
         gitignore = pkgs.nix-gitignore.gitignoreSourcePure [ ./.gitignore ];
         sol-core = pkgs.haskell.lib.overrideCabal

--- a/sol-core.cabal
+++ b/sol-core.cabal
@@ -161,7 +161,7 @@ executable yule
       BlockArguments
       ImportQualifiedPost
     -- Locus, Options, TM, Translate, Builtins, Compress now live in the library.
-    build-depends:    base ^>=4.19.1.0,
+    build-depends:    base >=4.19.1.0,
                       pretty >=  1.1,
                       containers >= 0.6,
                       mtl >= 2.3,

--- a/src/Solcore/Backend/ComptimeCheck.hs
+++ b/src/Solcore/Backend/ComptimeCheck.hs
@@ -54,8 +54,8 @@ checkFunDef ft pure_ fd =
     initEnv =
       Set.fromList
         [ mastParamName p
-          | p <- mastFunParams fd,
-            mastParamComptime p || mastFunRetComptime fd
+        | p <- mastFunParams fd,
+          mastParamComptime p || mastFunRetComptime fd
         ]
 
 -- | Check a sequence of statements, threading the comptime environment.

--- a/src/Solcore/Backend/MastEval.hs
+++ b/src/Solcore/Backend/MastEval.hs
@@ -40,7 +40,6 @@ import Crypto.Hash.Algorithms (Keccak_256)
 import Data.Bits (complement, shiftL, shiftR, xor, (.&.), (.|.))
 import Data.ByteArray qualified as BA
 import Data.ByteString qualified as BS
-import Data.List (foldl')
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as T

--- a/src/Solcore/Backend/MastEval.hs
+++ b/src/Solcore/Backend/MastEval.hs
@@ -631,7 +631,7 @@ venvToSubst :: VEnv -> Map.Map Name YulExp
 venvToSubst env =
   Map.fromList
     [ (mastIdName k, yulLit l)
-      | (k, MastLit l) <- Map.toList env
+    | (k, MastLit l) <- Map.toList env
     ]
   where
     yulLit (IntLit v) = YLit (YulNumber v)

--- a/src/Solcore/Backend/Specialise.hs
+++ b/src/Solcore/Backend/Specialise.hs
@@ -592,13 +592,13 @@ tryResolveMPTC clsName mainTy' extras = do
                 eqSubst =
                   TVSubst
                     [ (v, t)
-                      | (TyVar v :~: t) <- appliedQ,
-                        null (freetv t)
+                    | (TyVar v :~: t) <- appliedQ,
+                      null (freetv t)
                     ]
                     <> TVSubst
                       [ (v, t)
-                        | (t :~: TyVar v) <- appliedQ,
-                          null (freetv t)
+                      | (t :~: TyVar v) <- appliedQ,
+                        null (freetv t)
                       ]
                 phi' = phi <> eqSubst
             debug ["  tryResolve match: phi=", pretty phi, " q=", show q, " appliedQ=", show appliedQ, " eqSubst=", pretty eqSubst, " phi'=", pretty phi', " instExtras=", show instExtras]

--- a/src/Solcore/Desugarer/DecisionTreeCompiler.hs
+++ b/src/Solcore/Desugarer/DecisionTreeCompiler.hs
@@ -613,8 +613,8 @@ defaultMatrix = concatMap defaultRow
 specializedBoundActs :: Id -> Occurrence -> PatternMatrix -> [BoundAction] -> [BoundAction]
 specializedBoundActs k testOcc rows bacts =
   [ (addVarBinding row binds, a)
-    | (row, (binds, a)) <- zip rows bacts,
-      rowMatchesCon row
+  | (row, (binds, a)) <- zip rows bacts,
+    rowMatchesCon row
   ]
   where
     rowMatchesCon [] = False
@@ -630,10 +630,10 @@ specializedBoundActs k testOcc rows bacts =
 defaultBoundActs :: Occurrence -> PatternMatrix -> [BoundAction] -> [BoundAction]
 defaultBoundActs testOcc rows bacts =
   [ (addVarBinding row binds, a)
-    | (row, (binds, a)) <- zip rows bacts,
-      case row of
-        (p : _) -> isVarPat p
-        [] -> False
+  | (row, (binds, a)) <- zip rows bacts,
+    case row of
+      (p : _) -> isVarPat p
+      [] -> False
   ]
   where
     addVarBinding (PVar v : _) binds = binds ++ [(v, testOcc)]
@@ -642,8 +642,8 @@ defaultBoundActs testOcc rows bacts =
 atomicSpecializedBoundActs :: AtomicPat -> Occurrence -> PatternMatrix -> [BoundAction] -> [BoundAction]
 atomicSpecializedBoundActs apat testOcc rows bacts =
   [ (addVarBinding row binds, a)
-    | (row, (binds, a)) <- zip rows bacts,
-      rowMatchesAtomic row
+  | (row, (binds, a)) <- zip rows bacts,
+    rowMatchesAtomic row
   ]
   where
     rowMatchesAtomic [] = False

--- a/src/Solcore/Desugarer/DeriveGeneric.hs
+++ b/src/Solcore/Desugarer/DeriveGeneric.hs
@@ -16,16 +16,16 @@ deriveGenericTopDecls localData allDecls
     hasInst = existingGenericTypes allDecls
     conflicts =
       [ dataName dt
-        | dt <- localData,
-          dataName dt `elem` hasInst,
-          dataName dt `notElem` excluded
+      | dt <- localData,
+        dataName dt `elem` hasInst,
+        dataName dt `notElem` excluded
       ]
     newInsts =
       [ TInstDef (buildInstance dt)
-        | dt <- localData,
-          not (null (dataConstrs dt)),
-          dataName dt `notElem` excluded,
-          dataName dt `notElem` hasInst
+      | dt <- localData,
+        not (null (dataConstrs dt)),
+        dataName dt `notElem` excluded,
+        dataName dt `notElem` hasInst
       ]
     conflictError n =
       "type '"

--- a/src/Solcore/Desugarer/FieldAccess.hs
+++ b/src/Solcore/Desugarer/FieldAccess.hs
@@ -44,7 +44,7 @@ fieldDesugarTopDecls topdecls = extras <> topdecls'
     existingDataTypes =
       Set.fromList
         [ dataName dt
-          | TDataDef dt <- topdecls
+        | TDataDef dt <- topdecls
         ]
     (extras, topdecls') = mapAccumL go mempty topdecls
     go acc (TContr c) =

--- a/src/Solcore/Desugarer/FieldAccess.hs
+++ b/src/Solcore/Desugarer/FieldAccess.hs
@@ -4,7 +4,7 @@ module Solcore.Desugarer.FieldAccess (fieldDesugarTopDecls, fieldDesugarer) wher
 
 import Control.Monad.Reader (MonadReader (..))
 -- import Data.Generics(Data, mkT, everywhere)
-import Data.List (foldl', mapAccumL)
+import Data.List (mapAccumL)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (isJust)

--- a/src/Solcore/Diagnostics.hs
+++ b/src/Solcore/Diagnostics.hs
@@ -229,8 +229,8 @@ findTokenSpansInSource source needle
   | null needle = []
   | otherwise =
       [ sourceTokenSpan sourceToken
-        | sourceToken <- sourceTokens source,
-          sourceTokenText sourceToken == needle
+      | sourceToken <- sourceTokens source,
+        sourceTokenText sourceToken == needle
       ]
 
 findTextSpansInSource :: SourceFile -> String -> [SourceSpan]
@@ -238,8 +238,8 @@ findTextSpansInSource source needle
   | null needle = []
   | otherwise =
       [ lineSpan lineNo lineStart column
-        | (lineNo, lineStart, lineText) <- sourceLinesWithOffsets source,
-          column <- findColumns needle lineText
+      | (lineNo, lineStart, lineText) <- sourceLinesWithOffsets source,
+        column <- findColumns needle lineText
       ]
   where
     needleLen = length needle
@@ -566,7 +566,7 @@ computeSourceTokens :: FilePath -> String -> [SourceToken]
 computeSourceTokens path content =
   concat
     [ lineTokens path lineNo lineStart lineText
-      | (lineNo, lineStart, lineText) <- zip3 [1 ..] (computeLineStarts content) (sourceLinesFromText content)
+    | (lineNo, lineStart, lineText) <- zip3 [1 ..] (computeLineStarts content) (sourceLinesFromText content)
     ]
 
 sourceLinesFromText :: String -> [String]

--- a/src/Solcore/Diagnostics.hs
+++ b/src/Solcore/Diagnostics.hs
@@ -46,7 +46,7 @@ where
 
 import Data.Char (isAlpha, isAlphaNum)
 import Data.Generics (Data, Typeable)
-import Data.List (foldl', isPrefixOf, sortOn, stripPrefix, tails)
+import Data.List (isPrefixOf, sortOn, stripPrefix, tails)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Prettyprinter (Doc, LayoutOptions (..), PageWidth (..), layoutPretty, pretty, vsep)

--- a/src/Solcore/Frontend/ComptimeCheck.hs
+++ b/src/Solcore/Frontend/ComptimeCheck.hs
@@ -96,7 +96,7 @@ checkFunDef st ctx fd = checkBody st (sigRetComptime sig) ctx initEnv (funDefBod
     initEnv =
       Map.fromList
         [ (idName (paramName p), if paramComptime p || sigRetComptime sig then CTComptime else CTRuntime)
-          | p <- sigParams sig
+        | p <- sigParams sig
         ]
 
 -- | Check an instance method, including the instance head in error context.

--- a/src/Solcore/Frontend/Module/Loader.hs
+++ b/src/Solcore/Frontend/Module/Loader.hs
@@ -381,15 +381,15 @@ buildGroupMap :: Map Mod.ModuleId LoadedModule -> Map Mod.ModuleId [Mod.ModuleId
 buildGroupMap loaded depMap =
   Map.fromList
     [ (moduleId, group)
-      | group <- groups,
-        moduleId <- group
+    | group <- groups,
+      moduleId <- group
     ]
   where
     groups =
       map sccGroupModuleIds $
         stronglyConnComp
           [ (moduleId, moduleId, Map.findWithDefault [] moduleId depMap)
-            | moduleId <- Map.keys loaded
+          | moduleId <- Map.keys loaded
           ]
 
     sccGroupModuleIds (AcyclicSCC moduleId) = [moduleId]
@@ -486,7 +486,7 @@ normalizePublicInterface publicInterface =
 
     normalizeModuleBindings bindings =
       [ chosen Map.! bindingName
-        | bindingName <- sortOn show orderedNames
+      | bindingName <- sortOn show orderedNames
       ]
       where
         (orderedNames, chosen) = foldl step ([], Map.empty) bindings
@@ -645,8 +645,8 @@ publicItemDeclsForModuleSeen graph seen modulePath = do
   let localDecls =
         selectPublicItemDecls
           [ itemRef
-            | itemRef <- publicItemRefs publicInterface,
-              exportedItemOrigin itemRef == modulePath
+          | itemRef <- publicItemRefs publicInterface,
+            exportedItemOrigin itemRef == modulePath
           ]
           (topDeclsFrom unit)
   remoteDecls <- concat <$> mapM materializeRemoteRef (publicItemRefs publicInterface)
@@ -697,13 +697,13 @@ moduleImportTypeAliasMap graph modulePath = do
     typeBindingsForImport (ImportModule importPath) publicDecls =
       pure
         [ (typeName, QualName qualifier (show typeName))
-          | typeName <- uniqueNames (concatMap topDeclImportedTypeNames publicDecls),
-            qualifier <- importModuleQualifiers importPath
+        | typeName <- uniqueNames (concatMap topDeclImportedTypeNames publicDecls),
+          qualifier <- importModuleQualifiers importPath
         ]
     typeBindingsForImport (ImportAlias _ qualifier) publicDecls =
       pure
         [ (typeName, QualName qualifier (show typeName))
-          | typeName <- uniqueNames (concatMap topDeclImportedTypeNames publicDecls)
+        | typeName <- uniqueNames (concatMap topDeclImportedTypeNames publicDecls)
         ]
 
     canonicalImportedTypeName collidingTypeNames qualifier publicDecls typeName =
@@ -936,8 +936,8 @@ visibleExportRefsForNameFixed graph groupModules currentInterfaces currentModule
   let localRefs = localExportRefsForName currentModule itemName (topDeclsFrom unit)
       matchingImportedRefs =
         [ ref
-          | ref <- importedRefs,
-            exportedItemName ref == itemName
+        | ref <- importedRefs,
+          exportedItemName ref == itemName
         ]
   pure (localRefs ++ matchingImportedRefs)
 
@@ -1045,8 +1045,8 @@ selectExportedItemRefs names refs =
   where
     pick itemName =
       [ ref
-        | ref <- refs,
-          exportedItemName ref == itemName
+      | ref <- refs,
+        exportedItemName ref == itemName
       ]
 
 selectImportedItemRefs :: [(Name, Name)] -> [ExportedItemRef] -> [ExportedItemRef]
@@ -1055,8 +1055,8 @@ selectImportedItemRefs bindings refs =
   where
     pick (sourceName, localName) =
       [ ref {exportedItemName = localName}
-        | ref <- refs,
-          exportedItemName ref == sourceName
+      | ref <- refs,
+        exportedItemName ref == sourceName
       ]
 
 selectRemoteExportRefs ::
@@ -1099,7 +1099,7 @@ selectRemoteExportRefs sourcePath exportPath (SelectExportItems items) available
                   (primaryNameLabels "unknown re-exported constructor" (missingVisibleConstructors constructorSelector ref))
                   ( sourcePath
                       : [ "  " ++ Mod.modulePathDisplay exportPath ++ "." ++ show typeName ++ "." ++ show constructorName
-                          | constructorName <- missingVisibleConstructors constructorSelector ref
+                        | constructorName <- missingVisibleConstructors constructorSelector ref
                         ]
                   )
                   ["re-export constructors provided by the target module"]
@@ -1130,8 +1130,8 @@ selectConstructorSubset SelectAllConstructors visibleConstructorNames =
   visibleConstructorNames
 selectConstructorSubset (SelectConstructors constructorNames) visibleConstructorNames =
   [ constructorName
-    | constructorName <- uniqueNames constructorNames,
-      constructorName `elem` visibleConstructorNames
+  | constructorName <- uniqueNames constructorNames,
+    constructorName `elem` visibleConstructorNames
   ]
 
 missingVisibleConstructors :: ConstructorSelector -> ExportedItemRef -> [Name]
@@ -1139,8 +1139,8 @@ missingVisibleConstructors SelectAllConstructors _ =
   []
 missingVisibleConstructors (SelectConstructors constructorNames) itemRef =
   [ constructorName
-    | constructorName <- uniqueNames constructorNames,
-      constructorName `notElem` fromMaybe [] (exportedItemConstructors itemRef)
+  | constructorName <- uniqueNames constructorNames,
+    constructorName `notElem` fromMaybe [] (exportedItemConstructors itemRef)
   ]
 
 availableExportRefs :: Mod.ModuleId -> [TopDecl] -> [ExportedItemRef]
@@ -1170,7 +1170,7 @@ localExportRefsForDecl currentModule decl =
       [localDataExportRef currentModule n []]
     _ ->
       [ ExportedItemRef currentModule itemName itemName Nothing
-        | itemName <- topDeclNames decl
+      | itemName <- topDeclNames decl
       ]
 
 localDataExportRef :: Mod.ModuleId -> Name -> [Name] -> ExportedItemRef
@@ -1191,8 +1191,8 @@ ensureNoDuplicateExportedItems modulePath itemRefs =
   where
     conflicts =
       [ itemName
-        | (itemName, refs) <- Map.toList groupedRefs,
-          Set.size (Set.fromList [(exportedItemOrigin ref, exportedItemSourceName ref) | ref <- refs]) > 1
+      | (itemName, refs) <- Map.toList groupedRefs,
+        Set.size (Set.fromList [(exportedItemOrigin ref, exportedItemSourceName ref) | ref <- refs]) > 1
       ]
     groupedRefs = Map.fromListWith (++) [(exportedItemName ref, [ref]) | ref <- itemRefs]
 
@@ -1210,8 +1210,8 @@ ensureNoDuplicateExportedModules modulePath moduleBindings =
   where
     conflicts =
       [ bindingName
-        | (bindingName, bindings) <- Map.toList groupedBindings,
-          Set.size (Set.fromList [exportedModuleTarget binding | binding <- bindings]) > 1
+      | (bindingName, bindings) <- Map.toList groupedBindings,
+        Set.size (Set.fromList [exportedModuleTarget binding | binding <- bindings]) > 1
       ]
     groupedBindings = Map.fromListWith (++) [(exportedModuleName binding, [binding]) | binding <- moduleBindings]
 
@@ -1356,7 +1356,7 @@ qualifyFunctionSignature qualifier (FunDef p sig body) =
 qualifiedFunctionStubDecls :: Name -> CompUnit -> [TopDecl]
 qualifiedFunctionStubDecls qualifier cunit =
   [ TFunDef (stubFunction (qualifyName qualifier (sigName (funSignature fd))))
-    | TFunDef fd <- topDeclsFrom cunit
+  | TFunDef fd <- topDeclsFrom cunit
   ]
 
 qualifierFromExpVarChain :: Exp -> Maybe Name
@@ -1658,13 +1658,13 @@ qualifiedTypeAliasDecls typeRenameMap qualifier cunit =
   where
     dataAliases =
       [ TSym (qualifyTyCon qualifier n vs)
-        | TDataDef (DataTy n vs _) <- topDeclsFrom cunit,
-          not (Map.member n typeRenameMap)
+      | TDataDef (DataTy n vs _) <- topDeclsFrom cunit,
+        not (Map.member n typeRenameMap)
       ]
     symAliases =
       [ TSym (qualifyTyCon qualifier n vs)
-        | TSym (TySym n vs _) <- topDeclsFrom cunit,
-          not (Map.member n typeRenameMap)
+      | TSym (TySym n vs _) <- topDeclsFrom cunit,
+        not (Map.member n typeRenameMap)
       ]
 
 qualifiedTypeStubDecls :: Name -> CompUnit -> [TopDecl]
@@ -1678,11 +1678,11 @@ qualifiedTypeStubDecls qualifier cunit =
               []
               [Constr (constructorLeafName (constrName c)) [] | c <- cs]
           )
-        | TDataDef (DataTy n _ cs) <- topDeclsFrom cunit
+      | TDataDef (DataTy n _ cs) <- topDeclsFrom cunit
       ]
     symAliases =
       [ TSym (stubType (qualifyName qualifier n))
-        | TSym (TySym n _ _) <- topDeclsFrom cunit
+      | TSym (TySym n _ _) <- topDeclsFrom cunit
       ]
 
 constructorLeafName :: Name -> Name
@@ -1765,8 +1765,8 @@ typeCheckQualifiedImportDecls collidingTypeNames graph (imp, modulePath) =
 qualifiedFunctionSignatureDecls :: Map Name Name -> Name -> CompUnit -> [TopDecl]
 qualifiedFunctionSignatureDecls typeRenameMap qualifier cunit =
   [ TFunDef (stubFunDefBody (qualifyFunctionSignature qualifier fd'))
-    | TFunDef fd <- topDeclsFrom cunit,
-      let fd' = renameFunDefTypeRefs typeRenameMap fd
+  | TFunDef fd <- topDeclsFrom cunit,
+    let fd' = renameFunDefTypeRefs typeRenameMap fd
   ]
 
 typeCheckImportedDecls :: Set Name -> ModuleGraph -> (Import, Mod.ModuleId) -> Either String [TopDecl]
@@ -1791,14 +1791,14 @@ typeCheckImportedDecls collidingTypeNames graph (imp, modulePath) =
                 stubFunDefBody $
                   renameFunDefTypeRefs selectedTypeRenameMap $
                     renameFunDefTypeRefs typeRenameMap fd
-              | TFunDef fd <- selectedPublicDecls
+            | TFunDef fd <- selectedPublicDecls
             ]
           selectedNonFunctionDecls =
             [ stubTopDeclBody $
                 renameTopDeclTypeRefs selectedTypeRenameMap $
                   renameTopDeclTypeRefs typeRenameMap decl
-              | decl <- selectedPublicDecls,
-                not (isFunctionTopDecl decl)
+            | decl <- selectedPublicDecls,
+              not (isFunctionTopDecl decl)
             ]
           supportNonFunctionDecls =
             map
@@ -1899,7 +1899,7 @@ importedPartialTypes collidingTypeNames graph (imp, modulePath) =
 normalizePartialImportedTypes :: [(Name, [Name])] -> [(Name, [Name])]
 normalizePartialImportedTypes partialTypes =
   [ (typeName, constructorNames)
-    | (typeName, constructorNames) <- Map.toAscList merged
+  | (typeName, constructorNames) <- Map.toAscList merged
   ]
   where
     merged =
@@ -1924,18 +1924,18 @@ importedTypeRenameMap :: Set Name -> Name -> [TopDecl] -> Map Name Name
 importedTypeRenameMap collidingTypeNames qualifier ds =
   Map.fromList
     [ (n, qualifyName qualifier n)
-      | d <- ds,
-        n <- topDeclImportedTypeNames d,
-        n `Set.member` collidingTypeNames
+    | d <- ds,
+      n <- topDeclImportedTypeNames d,
+      n `Set.member` collidingTypeNames
     ]
 
 selectedImportTypeRenameMap :: [TopDecl] -> [(Name, Name)] -> Map Name Name
 selectedImportTypeRenameMap publicDecls bindings =
   Map.fromList
     [ (sourceName, localName)
-      | (sourceName, localName) <- bindings,
-        sourceName /= localName,
-        sourceName `elem` publicTypeNames
+    | (sourceName, localName) <- bindings,
+      sourceName /= localName,
+      sourceName `elem` publicTypeNames
     ]
   where
     publicTypeNames =
@@ -1954,8 +1954,8 @@ collidingImportedTypeNames graph importPairs = do
   pure $
     Set.fromList
       [ n
-        | (n, count) <- Map.toList counts,
-          count > 1
+      | (n, count) <- Map.toList counts,
+        count > 1
       ]
   where
     namesFromImport (ImportModule _, modulePath) =
@@ -2166,8 +2166,8 @@ ensureNoAmbiguousSelectedImports graph importPairs = do
 
     ambiguous selectedPairs =
       [ (item, uniqueModulePaths mods)
-        | (item, mods) <- Map.toList selections,
-          length (uniqueModulePaths mods) > 1
+      | (item, mods) <- Map.toList selections,
+        length (uniqueModulePaths mods) > 1
       ]
       where
         selections :: Map Name [ModulePath]
@@ -2248,8 +2248,8 @@ uniqueTopDecls = reverse . fst . foldl step ([], Map.empty)
 duplicateNames :: [Name] -> [Name]
 duplicateNames names =
   [ n
-    | (n, count) <- Map.toList counts,
-      count > 1
+  | (n, count) <- Map.toList counts,
+    count > 1
   ]
   where
     counts = Map.fromListWith (+) [(n, 1 :: Int) | n <- names]
@@ -2305,13 +2305,13 @@ ensureNoDuplicateSelectedItems (CompUnit imps _) =
   where
     duplicateItems (ImportOnly moduleName selector) =
       [ (Mod.modulePathDisplay moduleName ++ "." ++ show item, item)
-        | item <- duplicateNames (explicitSelectorNames selector)
+      | item <- duplicateNames (explicitSelectorNames selector)
       ]
         ++ [ (Mod.modulePathDisplay moduleName ++ " as " ++ show item, item)
-             | item <- duplicateNames (explicitSelectorLocalNames selector)
+           | item <- duplicateNames (explicitSelectorLocalNames selector)
            ]
         ++ [ (Mod.modulePathDisplay moduleName ++ " hiding " ++ show item, item)
-             | item <- duplicateNames (explicitHiddenNames selector)
+           | item <- duplicateNames (explicitHiddenNames selector)
            ]
     duplicateItems _ = []
 
@@ -2368,31 +2368,31 @@ modulePathSourceSpan modulePath =
 explicitSelectorNames :: ItemSelector -> [Name]
 explicitSelectorNames (SelectItems items _) =
   [ itemName
-    | item <- items,
-      itemName <- case item of
-        SelectItem itemName -> [itemName]
-        SelectItemAs itemName _ -> [itemName]
-        SelectAllItems -> []
+  | item <- items,
+    itemName <- case item of
+      SelectItem itemName -> [itemName]
+      SelectItemAs itemName _ -> [itemName]
+      SelectAllItems -> []
   ]
 
 explicitSelectorLocalNames :: ItemSelector -> [Name]
 explicitSelectorLocalNames (SelectItems items _) =
   [ itemName
-    | item <- items,
-      itemName <- case item of
-        SelectItem itemName -> [itemName]
-        SelectItemAs _ aliasName -> [aliasName]
-        SelectAllItems -> []
+  | item <- items,
+    itemName <- case item of
+      SelectItem itemName -> [itemName]
+      SelectItemAs _ aliasName -> [aliasName]
+      SelectAllItems -> []
   ]
 
 explicitExportSelectorNames :: ExportSelector -> [Name]
 explicitExportSelectorNames (SelectExportItems items) =
   [ itemName
-    | item <- items,
-      itemName <- case item of
-        SelectExportItem exportItemName -> [exportItemName]
-        SelectExportConstructors typeName _ -> [typeName]
-        SelectExportAllItems -> []
+  | item <- items,
+    itemName <- case item of
+      SelectExportItem exportItemName -> [exportItemName]
+      SelectExportConstructors typeName _ -> [typeName]
+      SelectExportAllItems -> []
   ]
 
 explicitHiddenNames :: ItemSelector -> [Name]

--- a/src/Solcore/Frontend/Syntax/NameResolution.hs
+++ b/src/Solcore/Frontend/Syntax/NameResolution.hs
@@ -159,8 +159,8 @@ ensureNoDuplicateNamesIn ctx ns names =
     counts = Map.fromListWith (+) [(n, 1) | n <- names]
     duplicates =
       [ n
-        | (n, c) <- Map.toList counts,
-          c > 1
+      | (n, c) <- Map.toList counts,
+        c > 1
       ]
 
 -- type class for name resolution

--- a/src/Solcore/Frontend/TypeInference/TcContract.hs
+++ b/src/Solcore/Frontend/TypeInference/TcContract.hs
@@ -52,7 +52,7 @@ typeInferTopDeclChecks opts imps trustedInstances partialTypes topDeclChecks =
               partialDataTypeConstructors =
                 Map.fromList
                   [ (partialTypeName, Set.fromList constructorNames)
-                    | (partialTypeName, constructorNames) <- partialTypes
+                  | (partialTypeName, constructorNames) <- partialTypes
                   ]
             }
         )
@@ -110,8 +110,8 @@ tcTopDeclChecks topDeclChecks =
       mapM_
         (withPartialDataTypesDisabled . trustImportedTopDecl)
         [ expandedDecl
-          | (topDeclCheck, expandedDecl) <- zip topDeclChecks expandedDecls,
-            topDeclCheckMode topDeclCheck == TrustTopDeclBody
+        | (topDeclCheck, expandedDecl) <- zip topDeclChecks expandedDecls,
+          topDeclCheckMode topDeclCheck == TrustTopDeclBody
         ]
     tcTopDeclWithVisibility topDeclCheck expandedDecl =
       case topDeclCheckMode topDeclCheck of

--- a/src/Solcore/Frontend/TypeInference/TcModule.hs
+++ b/src/Solcore/Frontend/TypeInference/TcModule.hs
@@ -127,7 +127,7 @@ mkModuleResolvedTypeCheckInput surface (resolved, resolvedSegments) =
             moduleResolvedInputImportedDecls = resolvedImportedDecls,
             moduleResolvedInputTrustedInstanceHeads =
               [ instanceHeadKey inst
-                | TInstDef inst <- resolvedImportedDecls
+              | TInstDef inst <- resolvedImportedDecls
               ],
             moduleResolvedInputPartialImportedTypes = moduleSurfacePartialImportedTypes surface
           }
@@ -259,8 +259,8 @@ retaggedDeclSegment keySegments topDecl =
   where
     knownSegments =
       [ segment
-        | key <- topDeclKeys topDecl,
-          Just segment <- [Map.lookup key keySegments]
+      | key <- topDeclKeys topDecl,
+        Just segment <- [Map.lookup key keySegments]
       ]
     chooseSegment segments
       | ModuleLocalDecl `elem` segments = ModuleLocalDecl
@@ -389,9 +389,9 @@ importForwardingWrappers graph checkedModules =
                   (Map.lookup targetModuleId checkedModules)
               pure
                 [ TFunDef (typedAliasingWrapper aliasName fd)
-                  | (sourceName, aliasName) <- aliases,
-                    TFunDef fd <- contracts (checkedModuleTyped targetModule),
-                    sigName (funSignature fd) == sourceName
+                | (sourceName, aliasName) <- aliases,
+                  TFunDef fd <- contracts (checkedModuleTyped targetModule),
+                  sigName (funSignature fd) == sourceName
                 ]
 
     wrappersForQualifiers loadedModule importPath qualifiers = do
@@ -407,8 +407,8 @@ importForwardingWrappers graph checkedModules =
           (Map.lookup targetModuleId checkedModules)
       pure
         [ TFunDef (typedForwardingWrapper qualifier fd)
-          | qualifier <- qualifiers,
-            TFunDef fd <- contracts (checkedModuleTyped targetModule)
+        | qualifier <- qualifiers,
+          TFunDef fd <- contracts (checkedModuleTyped targetModule)
         ]
 
 defaultImportQualifiers :: Parsed.ModulePath -> [Name]

--- a/src/Solcore/Frontend/TypeInference/TcModule.hs
+++ b/src/Solcore/Frontend/TypeInference/TcModule.hs
@@ -28,7 +28,6 @@ module Solcore.Frontend.TypeInference.TcModule
   )
 where
 
-import Data.List (foldl')
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Set qualified as Set

--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -850,12 +850,12 @@ findPhantomPredBindings pann pinf = do
 phantomMatchingPreds :: [MetaTv] -> [Pred] -> [Pred] -> [(Pred, Pred)]
 phantomMatchingPreds dom_s0 pann pinf =
   [ (pa, pi_)
-    | pa@(InCls cls mt_a _) <- pann,
-      hasPhantomMeta pa, -- skip annotation preds already fully resolved in s0
-      pi_@(InCls cls' mt_i _) <- pinf,
-      cls == cls',
-      hasPhantomMeta pi_,
-      mt_a == mt_i -- self-types must agree to avoid cross-pairing same-class constraints
+  | pa@(InCls cls mt_a _) <- pann,
+    hasPhantomMeta pa, -- skip annotation preds already fully resolved in s0
+    pi_@(InCls cls' mt_i _) <- pinf,
+    cls == cls',
+    hasPhantomMeta pi_,
+    mt_a == mt_i -- self-types must agree to avoid cross-pairing same-class constraints
   ]
   where
     hasPhantomMeta (InCls _ mt exts) = any (`notElem` dom_s0) (mv mt `union` mv exts)
@@ -1592,7 +1592,7 @@ constructorAcceptsArguments n argTys mExpected = do
             pure ()
           Nothing -> pure ()
         pure True
-      )
+    )
       `catchError` const (pure False)
   putSubst s0
   pure r

--- a/src/Solcore/Pipeline/SolcorePipeline.hs
+++ b/src/Solcore/Pipeline/SolcorePipeline.hs
@@ -368,7 +368,7 @@ inferDuplicateLabels sources diagnostic =
       take 2 $
         concat
           [ spansForTerm sources diagnostic term
-            | term <- duplicateSearchTerms diagnostic
+          | term <- duplicateSearchTerms diagnostic
           ]
 
 firstMatchTerm :: SourceMap -> Diagnostic -> [String] -> Maybe String
@@ -842,8 +842,8 @@ prepareInferenceDeclsForTypeInference opts emitOutput imps inferenceDecls = do
   liftIO $ when (optEmitAbi opts) $ do
     let localTopDecls =
           [ moduleInferenceDeclTopDecl d
-            | d <- accessed,
-              moduleInferenceDeclSegment d == ModuleLocalDecl
+          | d <- accessed,
+            moduleInferenceDeclSegment d == ModuleLocalDecl
           ]
     writeContractAbis (optOutputDir opts) localTopDecls
 


### PR DESCRIPTION
This PR moves from GHC 9.8 to 9.10 both in Cabal and nix environment.

Formatting changes needed because Ormolu 0.8 which is part of 9.10 toolchain has different requirements than 0.7