### PR TITLE
Typechecker performance improvements

### DIFF
--- a/sol-core.cabal
+++ b/sol-core.cabal
@@ -95,6 +95,7 @@ library
       Solcore.Frontend.Syntax.Contract
       Solcore.Frontend.Syntax.Location
       Solcore.Frontend.Syntax.Name
+      Solcore.Frontend.Syntax.Traversal
       Solcore.Frontend.Syntax.NameResolution
       Solcore.Frontend.Syntax.Stmt
       Solcore.Frontend.Syntax.SyntaxTree

--- a/src/Solcore/Backend/Specialise.hs
+++ b/src/Solcore/Backend/Specialise.hs
@@ -28,6 +28,7 @@ import Solcore.Desugarer.IfDesugarer (desugaredBoolTy)
 import Solcore.Frontend.Pretty.ShortName
 import Solcore.Frontend.Pretty.SolcorePretty
 import Solcore.Frontend.Syntax hiding (decls, name)
+import Solcore.Frontend.Syntax.Traversal (everywhereButSpans, everythingButSpans)
 import Solcore.Frontend.TypeInference.Id (Id (..))
 import Solcore.Frontend.TypeInference.NameSupply
 import Solcore.Frontend.TypeInference.TcEnv (TcEnv (instEnv, typeTable), TypeInfo (..))
@@ -114,7 +115,7 @@ flex t = t
 
 -- make all type variables flexible in a syntactic construct
 flexAll :: Data a => a -> a
-flexAll = everywhere (mkT flex)
+flexAll = everywhereButSpans (mkT flex)
 -}
 
 -- | A signature forall tvs . ctx => t is considered ambiguous if a type variable
@@ -970,10 +971,10 @@ instance Pretty TVSubst where
 
 class (Data a) => HasTV a where
   applytv :: TVSubst -> a -> a
-  applytv s = everywhere (mkT (applytv @Ty s))
+  applytv s = everywhereButSpans (mkT (applytv @Ty s))
 
   freetv :: a -> [Tyvar] -- free variables
-  freetv = everything (<>) (mkQ mempty (freetv @Ty))
+  freetv = everythingButSpans (<>) (mkQ mempty (freetv @Ty))
 
   renametv :: a -> SM (a, TVSubst)
   renametv a = pure (a, mempty)
@@ -999,7 +1000,7 @@ instance (HasTV a) => HasTV (Maybe a) where
 
 instance (HasTV a, HasTV b) => HasTV (a, b) -- defaults
 
-instance HasTV Pred -- uses default: freetv = everything (<>) (mkQ mempty (freetv @Ty))
+instance HasTV Pred -- uses default: freetv = everythingButSpans (<>) (mkQ mempty (freetv @Ty))
 
 {-
 instance (HasTV a, HasTV b, HasTV c) => HasTV (a,b,c) where
@@ -1024,8 +1025,8 @@ instance (HasTV a) => HasTV (Stmt a) -- defaults
 instance HasTV (Pat Id)
 
 instance HasTV (Signature Id) where
-  applytv s = everywhere (mkT (applytv @Ty s))
-  freetv sig = (everything (<>) (mkQ mempty (freetv @Ty))) sig \\ sigVars sig
+  applytv s = everywhereButSpans (mkT (applytv @Ty s))
+  freetv sig = (everythingButSpans (<>) (mkQ mempty (freetv @Ty))) sig \\ sigVars sig
   renametv sig = do
     subst <- foldM addRenaming mempty (sigVars sig)
     pure (applytv subst sig, subst)
@@ -1039,7 +1040,7 @@ data FunDef a
 -}
 
 instance HasTV (FunDef Id) where
-  freetv fd = (everything (<>) (mkQ mempty (freetv @Ty))) fd \\ sigVars (funSignature fd)
+  freetv fd = (everythingButSpans (<>) (mkQ mempty (freetv @Ty))) fd \\ sigVars (funSignature fd)
   renametv fd = do
     let sig = funSignature fd
     subst <- foldM addRenaming mempty (sigVars sig)
@@ -1073,7 +1074,7 @@ renameTV :: TVRenaming -> Tyvar -> Tyvar
 renameTV (TVR r) v = fromMaybe v (lookup v r)
 
 renameTy :: TVRenaming -> Ty -> Ty
-renameTy r = everywhere (mkT (renameTV r))
+renameTy r = everywhereButSpans (mkT (renameTV r))
 
 renameSubst :: TVRenaming -> TVSubst -> TVSubst
 renameSubst r = TVSubst . map rename . unTVSubst

--- a/src/Solcore/Backend/Specialise.hs
+++ b/src/Solcore/Backend/Specialise.hs
@@ -28,7 +28,7 @@ import Solcore.Desugarer.IfDesugarer (desugaredBoolTy)
 import Solcore.Frontend.Pretty.ShortName
 import Solcore.Frontend.Pretty.SolcorePretty
 import Solcore.Frontend.Syntax hiding (decls, name)
-import Solcore.Frontend.Syntax.Traversal (everywhereButSpans, everythingButSpans)
+import Solcore.Frontend.Syntax.Traversal (everythingButSpans, everywhereButSpans)
 import Solcore.Frontend.TypeInference.Id (Id (..))
 import Solcore.Frontend.TypeInference.NameSupply
 import Solcore.Frontend.TypeInference.TcEnv (TcEnv (instEnv, typeTable), TypeInfo (..))

--- a/src/Solcore/Desugarer/DecisionTreeCompiler.hs
+++ b/src/Solcore/Desugarer/DecisionTreeCompiler.hs
@@ -6,7 +6,7 @@ import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Writer
-import Data.Generics (everywhere, extT, mkT)
+import Data.Generics (extT, mkT)
 import Data.List
 import Data.Map (Map)
 import Data.Map qualified as Map
@@ -16,6 +16,7 @@ import Language.Yul (YulExp (..))
 import Solcore.Diagnostics qualified as Diag
 import Solcore.Frontend.Pretty.SolcorePretty
 import Solcore.Frontend.Syntax
+import Solcore.Frontend.Syntax.Traversal (everywhereButSpans)
 import Solcore.Frontend.TypeInference.Id
 import Solcore.Primitives.Primitives
 
@@ -352,7 +353,7 @@ buildSubst occMap varBinds = do
 -- Substitute pattern variables in a statement using the given map.
 -- Also substitutes YIdent names inside inline assembly blocks.
 substStmt :: Map Id (Exp Id) -> Stmt Id -> Stmt Id
-substStmt subst = everywhere (mkT goExp `extT` goYul)
+substStmt subst = everywhereButSpans (mkT goExp `extT` goYul)
   where
     goExp e@(Var v) = Map.findWithDefault e v subst
     goExp e = e

--- a/src/Solcore/Desugarer/IfDesugarer.hs
+++ b/src/Solcore/Desugarer/IfDesugarer.hs
@@ -2,15 +2,16 @@ module Solcore.Desugarer.IfDesugarer where
 
 import Data.Generics
 import Solcore.Frontend.Syntax
+import Solcore.Frontend.Syntax.Traversal (everywhereButSpans)
 import Solcore.Frontend.TypeInference.Id
 import Solcore.Primitives.Primitives
 
 ifDesugarer :: CompUnit Id -> CompUnit Id
 ifDesugarer cunit =
-  let c1 = everywhere (mkT desugarTyBool) cunit
-      c2 = everywhere (mkT desugarBoolCons) c1
-      c3 = everywhere (mkT desugarBoolPat) c2
-   in everywhere (mkT desugarStmt) c3
+  let c1 = everywhereButSpans (mkT desugarTyBool) cunit
+      c2 = everywhereButSpans (mkT desugarBoolCons) c1
+      c3 = everywhereButSpans (mkT desugarBoolPat) c2
+   in everywhereButSpans (mkT desugarStmt) c3
 
 -- desugaring if stmts
 
@@ -40,7 +41,7 @@ desugarBoolCons (FieldAccess me v) =
 desugarBoolCons (Call me v es) =
   Call (desugarBoolCons <$> me) v (map desugarBoolCons es)
 desugarBoolCons (Lam ps bdy ty) =
-  Lam ps (everywhere (mkT desugarBoolCons) bdy) ty
+  Lam ps (everywhereButSpans (mkT desugarBoolCons) bdy) ty
 desugarBoolCons (Cond e1 e2 e3) = Cond (d e1) (d e2) (d e3) where d = desugarBoolCons
 desugarBoolCons (TyExp e t) =
   TyExp (desugarBoolCons e) t

--- a/src/Solcore/Desugarer/IntLiteralDesugar.hs
+++ b/src/Solcore/Desugarer/IntLiteralDesugar.hs
@@ -2,6 +2,7 @@ module Solcore.Desugarer.IntLiteralDesugar (desugarIntLiterals) where
 
 import Data.Generics
 import Solcore.Frontend.Syntax
+import Solcore.Frontend.Syntax.Traversal (everywhereButSpans)
 import Solcore.Primitives.Primitives (intClassName)
 
 -- Wrap every integer literal in expression position with a call to
@@ -9,7 +10,7 @@ import Solcore.Primitives.Primitives (intClassName)
 -- literals (PLit) are not expressions and are left untouched; they are
 -- handled separately by the type checker.
 desugarIntLiterals :: [TopDecl Name] -> [TopDecl Name]
-desugarIntLiterals = everywhere (mkT desugarExp)
+desugarIntLiterals = everywhereButSpans (mkT desugarExp)
 
 fromIntegerName :: Name
 fromIntegerName = QualName intClassName "fromInteger"

--- a/src/Solcore/Desugarer/ReplaceFunTypeArgs.hs
+++ b/src/Solcore/Desugarer/ReplaceFunTypeArgs.hs
@@ -3,11 +3,12 @@ module Solcore.Desugarer.ReplaceFunTypeArgs where
 import Control.Monad.State
 import Data.Generics
 import Solcore.Frontend.Syntax
+import Solcore.Frontend.Syntax.Traversal (everywhereMButSpans)
 import Solcore.Primitives.Primitives
 
 replaceFunParam :: (Data a) => a -> a
 replaceFunParam m =
-  evalState (everywhereM (mkM replaceFunParamM) m) 0
+  evalState (everywhereMButSpans (mkM replaceFunParamM) m) 0
 
 type ReplaceM a = State Int a
 

--- a/src/Solcore/Desugarer/ReplaceWildcard.hs
+++ b/src/Solcore/Desugarer/ReplaceWildcard.hs
@@ -7,6 +7,7 @@ where
 import Control.Monad.State
 import Data.Generics
 import Solcore.Frontend.Syntax
+import Solcore.Frontend.Syntax.Traversal (everywhereMButSpans)
 
 -- replacing wildcards by fresh pattern variables
 
@@ -20,7 +21,7 @@ replaceWildcards :: (Data a) => a -> a
 replaceWildcards c = fst (runState (replace c) 0)
 
 replace :: (Data a) => a -> State Int a
-replace c = everywhereM (mkM replacePat) c
+replace c = everywhereMButSpans (mkM replacePat) c
 
 replacePat :: Pat Name -> State Int (Pat Name)
 replacePat PWildcard =

--- a/src/Solcore/Frontend/Pretty/SolcorePretty.hs
+++ b/src/Solcore/Frontend/Pretty/SolcorePretty.hs
@@ -6,6 +6,7 @@ module Solcore.Frontend.Pretty.SolcorePretty (module Common.Pretty, pretty) wher
 import Common.Pretty
 import Data.List
 import Data.List.NonEmpty qualified as N
+import Data.Map qualified as Map
 import Language.Yul ()
 import Solcore.Frontend.Syntax.Contract
 import Solcore.Frontend.Syntax.Name
@@ -476,7 +477,7 @@ pprTyParams ts =
   parens (commaSep (map ppr ts))
 
 instance Pretty Subst where
-  ppr = braces . commaSep . map go . unSubst
+  ppr = braces . commaSep . map go . Map.toList . unSubst
     where
       go (v, t) = ppr v <+> text "+->" <+> ppr t
 

--- a/src/Solcore/Frontend/Syntax/Traversal.hs
+++ b/src/Solcore/Frontend/Syntax/Traversal.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Solcore.Frontend.Syntax.Traversal
+  ( opaqueToTypes,
+    everywhereButSpans,
+    everywhereMButSpans,
+    everythingButSpans,
+  )
+where
+
+import Data.Generics (GenericM, GenericQ, GenericT, everywhereBut, extQ, gmapM, gmapQ, mkQ)
+import Solcore.Diagnostics (SourceSpan)
+import Solcore.Frontend.Syntax.Location (NodeLocation)
+import Solcore.Frontend.Syntax.Name (Name)
+
+-- Nodes that carry no 'Ty' and no 'Id': source-location metadata.  A 'Name'
+-- is only spans, strings and nested 'Name's; 'NodeLocation'/'SourceSpan' are
+-- pure position data.  A 'Ty'/'Id' is never reachable *through* one of these,
+-- so it is safe to stop SYB descent here.
+opaqueToTypes :: GenericQ Bool
+opaqueToTypes =
+  False
+    `mkQ` (const True :: Name -> Bool)
+    `extQ` (const True :: NodeLocation -> Bool)
+    `extQ` (const True :: SourceSpan -> Bool)
+
+-- Drop-in replacement for @everywhere t@ that never walks into source-span /
+-- name metadata.  Semantically identical to @everywhere t@
+everywhereButSpans :: GenericT -> GenericT
+everywhereButSpans = everywhereBut opaqueToTypes
+
+-- Monadic 'everywhereM' that stops at source-span / name metadata.  SYB has
+-- no @everywhereMBut@, so we spell it out (bottom-up, same shape as
+-- 'everywhereM').  Safe for the same reason as 'everywhereButSpans'.
+everywhereMButSpans :: forall m. (Monad m) => GenericM m -> GenericM m
+everywhereMButSpans f = go
+  where
+    go :: GenericM m
+    go x
+      | opaqueToTypes x = pure x
+      | otherwise = f =<< gmapM go x
+
+-- 'everything' that stops at source-span / name metadata.  Identical results
+-- for any query that collects from 'Ty'/'Id'/'Exp'/… nodes, since spans/names
+-- contribute the query's empty element and hold no such nodes.
+everythingButSpans :: forall r. (r -> r -> r) -> GenericQ r -> GenericQ r
+everythingButSpans k q = go
+  where
+    go :: GenericQ r
+    go x
+      | opaqueToTypes x = q x
+      | otherwise = foldl k (q x) (gmapQ go x)

--- a/src/Solcore/Frontend/TypeInference/TcContract.hs
+++ b/src/Solcore/Frontend/TypeInference/TcContract.hs
@@ -12,6 +12,7 @@ import Solcore.Diagnostics (CompilerError)
 import Solcore.Frontend.Pretty.ShortName
 import Solcore.Frontend.Pretty.SolcorePretty
 import Solcore.Frontend.Syntax
+import Solcore.Frontend.Syntax.Traversal (everywhereButSpans, everywhereMButSpans)
 import Solcore.Frontend.TypeInference.Id
 import Solcore.Frontend.TypeInference.InvokeGen
 import Solcore.Frontend.TypeInference.TcEnv
@@ -93,7 +94,7 @@ tcTopDeclChecks topDeclChecks =
     setupPragmas ps
     checkSynonymCycles syns
     let st = buildSynTable syns
-    csExpanded <- everywhereM (mkM (expandTyM st)) cs
+    csExpanded <- everywhereMButSpans (mkM (expandTyM st)) cs
     mapM_ checkTopDecl (filter isClass csExpanded)
     mapM_ checkTopDecl (filter (not . isClass) csExpanded)
     trustImportedDecls csExpanded
@@ -278,7 +279,7 @@ tcContract c@(Contract n vs cdecls) =
         clearSubst
         d' <- tcDecl d
         s <- getSubst
-        pure (everywhere (mkT (apply @Id s)) d')
+        pure (everywhereButSpans (mkT (apply @Id s)) d')
 
 -- initializing context for a contract
 
@@ -409,7 +410,7 @@ tcBindGroup binds =
     let names = map (sigName . funSignature) funs'
     mapM_ (uncurry extEnv) (zip names schs)
     noDesugarCalls <- getNoDesugarCalls
-    let funs1 = everywhere (mkT gen) funs'
+    let funs1 = everywhereButSpans (mkT gen) funs'
     unless noDesugarCalls $ generateTopDeclsFor (zip funs1 schs)
     pure funs1
 

--- a/src/Solcore/Frontend/TypeInference/TcModule.hs
+++ b/src/Solcore/Frontend/TypeInference/TcModule.hs
@@ -77,7 +77,6 @@ data CheckedModule
   = CheckedModule
   { checkedModuleId :: Mod.ModuleId,
     checkedModuleInput :: ModuleTypeCheckInput,
-    checkedModuleNoDesugar :: CompUnit Id,
     checkedModuleTyped :: CompUnit Id,
     checkedModuleEnv :: TcEnv
   }

--- a/src/Solcore/Frontend/TypeInference/TcMonad.hs
+++ b/src/Solcore/Frontend/TypeInference/TcMonad.hs
@@ -263,10 +263,7 @@ instance Fresh Scheme where
   freshInst sch@(Forall _ qt) =
     do
       let vs = bv sch
-          ns = map tyvarName vs
-      ns' <- gets nameSupply
-      modify (\env -> env {nameSupply = ns' \\ ns})
-      mvs <- mapM (const freshTyVar) ns
+      mvs <- mapM (const freshTyVar) vs
       let qt' = insts (zip vs mvs) qt
       pure qt'
 
@@ -548,7 +545,12 @@ getClassEnv =
 
 askInstEnv :: Name -> TcM [Inst]
 askInstEnv n =
-  maybe [] id . Map.lookup n <$> getInstEnv
+  do
+    -- Only alpha-rename the instances of the queried class, instead of
+    -- renaming the entire instance table (as getInstEnv does) and discarding
+    -- all but this bucket.
+    bucket <- maybe [] id . Map.lookup n <$> gets instEnv
+    mapM freshInst bucket
 
 getInstEnv :: TcM InstTable
 getInstEnv =

--- a/src/Solcore/Frontend/TypeInference/TcResolution.hs
+++ b/src/Solcore/Frontend/TypeInference/TcResolution.hs
@@ -601,9 +601,9 @@ byUniqueGroundInstUnify insts inst goal
   where
     groundUnifiers =
       [ result
-        | candidate <- insts,
-          isGroundInstHead candidate,
-          Just result <- [byInstUnify candidate goal]
+      | candidate <- insts,
+        isGroundInstHead candidate,
+        Just result <- [byInstUnify candidate goal]
       ]
 
 isGroundInstHead :: Inst -> Bool
@@ -867,7 +867,7 @@ entailBranches itable qs p@(InCls n _ _) =
     Nothing -> []
     Just its ->
       [ EntailBranch (apply s qs) (apply s ps)
-        | (ps, s, _) <- byInstsM its p
+      | (ps, s, _) <- byInstsM its p
       ]
 entailBranches _ _ _ = []
 

--- a/src/Solcore/Frontend/TypeInference/TcResolution.hs
+++ b/src/Solcore/Frontend/TypeInference/TcResolution.hs
@@ -345,7 +345,7 @@ answerFingerprint answer =
 
 relevantSubst :: ResolutionAnswer -> Subst
 relevantSubst answer =
-  Subst [(v, t) | v <- relevantMetas, Just t <- [lookup v substItems]]
+  Subst (Map.fromList [(v, t) | v <- relevantMetas, Just t <- [Map.lookup v substItems]])
   where
     substItems = unSubst (answerSubst answer)
     roots = mv (answerGoal answer : answerResidual answer)
@@ -355,13 +355,13 @@ relevantSubst answer =
     close seen (v : vs)
       | v `elem` seen = close seen vs
       | otherwise =
-          case lookup v substItems of
+          case Map.lookup v substItems of
             Nothing -> close (v : seen) vs
             Just t -> close (v : seen) (mv t ++ vs)
 
 substPreds :: Subst -> [Pred]
 substPreds (Subst xs) =
-  [Meta v :~: t | (v, t) <- xs]
+  [Meta v :~: t | (v, t) <- Map.toList xs]
 
 markExhausted :: TableKey -> TabledM ()
 markExhausted key =
@@ -392,7 +392,9 @@ instantiateAnswer answer goal =
 
 instantiateSubst :: Subst -> Subst -> Subst
 instantiateSubst theta (Subst xs) =
-  Subst (mapMaybe instantiateOne xs)
+  -- fromListWith keeping the earlier binding preserves the previous
+  -- list `lookup` (first-wins) semantics when two source keys alias.
+  Subst (Map.fromListWith (\_new old -> old) (mapMaybe instantiateOne (Map.toList xs)))
   where
     instantiateOne (v, t) =
       case apply theta (Meta v) of

--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -15,6 +15,7 @@ import Solcore.Diagnostics (SourceSpan)
 import Solcore.Frontend.Pretty.ShortName
 import Solcore.Frontend.Pretty.SolcorePretty
 import Solcore.Frontend.Syntax
+import Solcore.Frontend.Syntax.Traversal (everywhereButSpans, everythingButSpans)
 import Solcore.Frontend.TypeInference.Id
 import Solcore.Frontend.TypeInference.InvokeGen
 import Solcore.Frontend.TypeInference.NameSupply
@@ -567,7 +568,7 @@ createClosureType ids vs ty =
     s <- getSubst
     let ts = map idType ids
         dn = Name $ "t_closure" ++ show i
-        ts' = everywhere (mkT gen) ts
+        ts' = everywhereButSpans (mkT gen) ts
         ns = map Var $ (apply s ids)
         vs' = nub $ (mv ts) `union` (map (MetaTv . var) vs)
         ty' = TyCon dn (Meta <$> vs')
@@ -589,8 +590,8 @@ createClosureFun fn freeIds cdt args bdy ps ty =
   do
     j <- incCounter
     ct <- closureTyCon cdt
-    let args0 = everywhere (mkT gen) args
-        ps0 = everywhere (mkT gen) ps
+    let args0 = everywhereButSpans (mkT gen) args
+        ps0 = everywhereButSpans (mkT gen) ps
         cName = Name $ "env" ++ show j
         cParam = Typed False (Id cName ct) ct
         args' = cParam : args0
@@ -600,7 +601,7 @@ createClosureFun fn freeIds cdt args bdy ps ty =
         sig = Signature vs' ps0 fn args' False (Just retTy1) False
     bdy' <- createClosureBody cName cdt freeIds bdy
     sch <- generalize (ps0, ty')
-    pure (everywhere (mkT gen) $ FunDef False sig bdy', sch)
+    pure (everywhereButSpans (mkT gen) $ FunDef False sig bdy', sch)
 
 closureTyCon :: DataTy -> TcM Ty
 closureTyCon (DataTy dn vs _) =
@@ -627,7 +628,7 @@ createClosureFreeFun fn args bdy ps ty =
     let (_, retTy1) = splitTy ty
         vs = bv ty `union` bv ps
         sig = Signature vs ps fn args False (Just retTy1) False
-    pure (everywhere (mkT gen) $ FunDef False sig bdy)
+    pure (everywhereButSpans (mkT gen) $ FunDef False sig bdy)
 
 tcArgs :: [Param Name] -> TcM ([Param Id], [(Name, Scheme)], [Ty])
 tcArgs params =
@@ -747,8 +748,8 @@ tcFunDef incl vs' qs d@(FunDef isPub sig@(Signature vs ps n _ _ _ _) _)
       -- instantiate signatures in function definition
       sks <- mapM (const freshTyVar) vars
       let env = zip vars sks
-          FunDef _ sig1@(Signature _ ps1 _ args1 _ rt1 _) bd1 = everywhere (mkT (insts @Ty env)) d
-          qs1 = everywhere (mkT (insts @Ty env)) qs
+          FunDef _ sig1@(Signature _ ps1 _ args1 _ rt1 _) bd1 = everywhereButSpans (mkT (insts @Ty env)) d
+          qs1 = everywhereButSpans (mkT (insts @Ty env)) qs
       -- checking if all constraints have a respective class and are well kinded
       checkConstraints ps `wrapError` d
       info ["## predicates in signature:", pretty (ps1 ++ qs1)]
@@ -806,8 +807,8 @@ elabFunDef ::
   TcM (FunDef Id)
 elabFunDef isPub vs sig bdy (Forall _ (pinf :=> tinf)) ann@(Forall _ (pann :=> tann)) =
   do
-    let tinf' = everywhere (mkT toMeta) tinf
-        tann' = everywhere (mkT toMeta) tann
+    let tinf' = everywhereButSpans (mkT toMeta) tinf
+        tann' = everywhereButSpans (mkT toMeta) tann
     s <- unify tinf' tann'
     -- Find bindings for phantom predicate variables (those appearing only in
     -- predicates, not in the function type).  sig2's context uses annotation
@@ -818,9 +819,9 @@ elabFunDef isPub vs sig bdy (Forall _ (pinf :=> tinf)) ann@(Forall _ (pann :=> t
         substTVPhantom t@(TyVar v) = fromMaybe t (lookup v tvs)
         substTVPhantom t = t
     sig2 <- elabSignature vs sig ann
-    let sig2' = everywhere (mkT substTVPhantom) sig2
-    let fd2 = everywhere (mkT (apply @Ty s)) (FunDef isPub sig2' bdy)
-    pure (everywhere (mkT gen) fd2)
+    let sig2' = everywhereButSpans (mkT substTVPhantom) sig2
+    let fd2 = everywhereButSpans (mkT (apply @Ty s)) (FunDef isPub sig2' bdy)
+    pure (everywhereButSpans (mkT gen) fd2)
 
 -- Unify annotation predicates against inferred predicates locally to discover
 -- mappings for phantom type variables (those absent from the function type).
@@ -847,13 +848,13 @@ findPhantomPredBindings pann pinf = do
   -- substituted to their source-named counterparts (e.g. Meta "a"), matching the
   -- source-named metas in pann.  Phantom extras (e.g. "$94362" for "rep") remain
   -- free in s0 and stay as fresh metas in pinf', making them identifiable.
-  let pann' = apply s0 (everywhere (mkT toMeta) pann)
-      pinf' = apply s0 (everywhere (mkT toMeta) pinf)
-      dom_s0 = map fst (unSubst s0)
+  let pann' = apply s0 (everywhereButSpans (mkT toMeta) pann)
+      pinf' = apply s0 (everywhereButSpans (mkT toMeta) pinf)
+      dom_s0 = Map.keys (unSubst s0)
   forM_ (phantomMatchingPreds dom_s0 pann' pinf') $ \(pa, pi_) ->
     catchError (unifyPredExtras pa pi_) (\_ -> return ())
   s_full <- getSubst
-  let delta = filter (\(v, _) -> v `notElem` dom_s0) (unSubst s_full)
+  let delta = filter (\(v, _) -> v `notElem` dom_s0) (Map.toList (unSubst s_full))
   putSubst s0 -- restore global subst
   return delta
 
@@ -948,7 +949,7 @@ outerTyCon (TyCon n _) = Just n
 outerTyCon _ = Nothing
 
 conResultMetaVars :: (Data a) => a -> [MetaTv]
-conResultMetaVars = nub . everything (++) (mkQ [] collectConMVs)
+conResultMetaVars = nub . everythingButSpans (++) (mkQ [] collectConMVs)
   where
     collectConMVs :: Exp Id -> [MetaTv]
     collectConMVs (Con (Id _ ty) args) = mv (applyConArgs ty args)
@@ -1065,7 +1066,7 @@ tcInstance' idecl@(Instance d vs predCtx n ts t funs) =
     checkCompleteInstDef n (map (sigName . funSignature) funs) `wrapError` idecl
     (funs1, _) <- unzip <$> mapM (tcFunDef False vs predCtx) funs `wrapError` idecl
     instd <- withCurrentSubst (Instance d vs predCtx n ts t funs1)
-    let ind@(Instance _ _ ctx' _ ts' t' funs2) = everywhere (mkT gen) instd
+    let ind@(Instance _ _ ctx' _ ts' t' funs2) = everywhereButSpans (mkT gen) instd
         vs1 = bv ind
         funs3 =
           sortBy
@@ -1468,7 +1469,7 @@ hnfEntails qs ps =
 -- comptime-only type and cannot survive to hull emission regardless of whether
 -- the user wrote `comptime`.  Applied after the full substitution is known.
 markIntegerComptime :: FunDef Id -> FunDef Id
-markIntegerComptime = everywhere (mkT fix)
+markIntegerComptime = everywhereButSpans (mkT fix)
   where
     fix (Let _ i mt me) | idType i == Prim.integer = Let True i mt me
     fix s = s
@@ -1481,7 +1482,7 @@ generalize (ps, t) =
     envVars <- getEnvMetaVars
     (ps1, t1) <- withCurrentSubst (ps, t)
     let vs = map gvar $ mv (ps1, t1) \\ envVars
-        sch = Forall vs (everywhere (mkT gen) $ ps1 :=> t1)
+        sch = Forall vs (everywhereButSpans (mkT gen) $ ps1 :=> t1)
     return sch
 
 tcBody :: Body Name -> TcM (Body Id, [Pred], Ty)

--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -420,10 +420,23 @@ tcExpWithExpected' _ (FieldAccess (Just e) n) =
     withCurrentSubst (FieldAccess (Just e') (Id n t'), ps ++ ps', t')
 tcExpWithExpected' _ ex@(Call me n args) =
   tcCall me n args `wrapError` ex
-tcExpWithExpected' _ (Lam args bd _) =
+tcExpWithExpected' mExpected (Lam args bd _) =
   do
     (args', schs, ts') <- tcArgs args
     (bd', ps, t') <- withLocalCtx schs (tcBody bd)
+    -- Reconcile the lambda's functional type with an expected function type
+    -- (e.g. an annotated return type) *before* closure conversion.  Closure
+    -- conversion replaces the arrow type with an opaque closure type, which
+    -- would otherwise mask parameter/result type mismatches (this is the
+    -- check the retired no-desugar validation pass provided for free by
+    -- returning the un-converted arrow type; see
+    -- instance-closure-error-invalid-member.solc).
+    case mExpected of
+      Just expected@(_ :-> _) -> do
+        s0 <- getSubst
+        _ <- unify (funtype (apply s0 ts') (apply s0 t')) expected
+        pure ()
+      _ -> pure ()
     s <- getSubst
     let ps1 = apply s ps
         ts1 = apply s ts'

--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -15,7 +15,7 @@ import Solcore.Diagnostics (SourceSpan)
 import Solcore.Frontend.Pretty.ShortName
 import Solcore.Frontend.Pretty.SolcorePretty
 import Solcore.Frontend.Syntax
-import Solcore.Frontend.Syntax.Traversal (everywhereButSpans, everythingButSpans)
+import Solcore.Frontend.Syntax.Traversal (everythingButSpans, everywhereButSpans)
 import Solcore.Frontend.TypeInference.Id
 import Solcore.Frontend.TypeInference.InvokeGen
 import Solcore.Frontend.TypeInference.NameSupply

--- a/src/Solcore/Frontend/TypeInference/TcSubst.hs
+++ b/src/Solcore/Frontend/TypeInference/TcSubst.hs
@@ -3,35 +3,48 @@
 module Solcore.Frontend.TypeInference.TcSubst where
 
 import Data.List
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Set qualified as Set
 import Solcore.Frontend.Syntax
 
 -- basic substitution infrastructure
 
 newtype Subst
-  = Subst {unSubst :: [(MetaTv, Ty)]}
+  = Subst {unSubst :: Map MetaTv Ty}
   deriving (Eq, Show)
+
+-- O(n log n) order-preserving dedup (keeps first occurrence), used to replace
+-- the O(n^2) Data.List.union accumulation in the list instance of fv/mv/bv.
+ordNub :: (Ord a) => [a] -> [a]
+ordNub = go Set.empty
+  where
+    go _ [] = []
+    go seen (x : xs)
+      | x `Set.member` seen = go seen xs
+      | otherwise = x : go (Set.insert x seen) xs
 
 restrict :: Subst -> [MetaTv] -> Subst
 restrict (Subst s) vs =
-  Subst [(v, t) | (v, t) <- s, v `notElem` vs]
+  Subst (Map.withoutKeys s (Set.fromList vs))
 
 emptySubst :: Subst
-emptySubst = Subst []
+emptySubst = Subst Map.empty
 
 -- composition operators
 
 instance Semigroup Subst where
-  s1 <> s2 = Subst (outer ++ inner)
-    where
-      outer = [(u, apply s1 t) | (u, t) <- unSubst s2]
-      inner = [(v, t) | (v, t) <- unSubst s1, v `notElem` dom2]
-      dom2 = map fst (unSubst s2)
+  s1 <> (Subst s2) =
+    -- Apply s1 across the range of s2, then union with s1's own bindings.
+    -- Map.union is left-biased, so the (updated) s2 keys win over s1 on
+    -- overlap, matching the previous list-based `outer ++ inner` semantics.
+    Subst (Map.map (apply s1) s2 `Map.union` unSubst s1)
 
 instance Monoid Subst where
   mempty = emptySubst
 
 (+->) :: MetaTv -> Ty -> Subst
-u +-> t = Subst [(u, t)]
+u +-> t = Subst (Map.singleton u t)
 
 class (Show a) => HasType a where
   apply :: Subst -> a -> a
@@ -53,9 +66,11 @@ instance (HasType a, HasType b) => HasType (a, b) where
 
 instance (HasType a) => HasType [a] where
   apply s = map (apply s)
-  fv = foldr (union . fv) []
-  mv = foldr (union . mv) []
-  bv = foldr (union . bv) []
+  -- Single terminal dedup instead of O(n^2) `foldr (union . _) []`; ordNub
+  -- preserves first-occurrence order, so quantifier ordering is unchanged.
+  fv = ordNub . concatMap fv
+  mv = ordNub . concatMap mv
+  bv = ordNub . concatMap bv
 
 instance (HasType a) => HasType (Maybe a) where
   apply :: (HasType a) => Subst -> Maybe a -> Maybe a
@@ -72,7 +87,7 @@ instance HasType Name where
 
 instance HasType Ty where
   apply (Subst s) t@(Meta v) =
-    maybe t id (lookup v s)
+    Map.findWithDefault t v s
   apply s (TyCon n ts) =
     TyCon n (apply s ts)
   apply _ t = t

--- a/src/Solcore/Frontend/TypeInference/TcSubst.hs
+++ b/src/Solcore/Frontend/TypeInference/TcSubst.hs
@@ -66,6 +66,7 @@ instance (HasType a, HasType b) => HasType (a, b) where
 
 instance (HasType a) => HasType [a] where
   apply s = map (apply s)
+
   -- Single terminal dedup instead of O(n^2) `foldr (union . _) []`; ordNub
   -- preserves first-occurrence order, so quantifier ordering is unchanged.
   fv = ordNub . concatMap fv

--- a/src/Solcore/Frontend/TypeInference/TcUnify.hs
+++ b/src/Solcore/Frontend/TypeInference/TcUnify.hs
@@ -3,6 +3,8 @@ module Solcore.Frontend.TypeInference.TcUnify where
 import Common.Pretty
 import Control.Monad.Except
 import Data.List
+import Data.Map qualified as Map
+import Data.Set qualified as Set
 import Solcore.Diagnostics
 import Solcore.Frontend.Pretty.ShortName
 import Solcore.Frontend.Pretty.SolcorePretty
@@ -146,18 +148,18 @@ unifyAllTypes (t : ts) =
 merge :: (MonadError CompilerError m) => Subst -> Subst -> m Subst
 merge s1@(Subst p1) s2@(Subst p2) =
   if agree
-    then pure (Subst $ nub (p1 ++ p2))
+    then pure (Subst (Map.union p1 p2))
     else mergeError disagree
   where
-    disagree = foldr step [] (dom p1 `intersect` dom p2)
+    overlap = Set.toList (Map.keysSet p1 `Set.intersection` Map.keysSet p2)
+    disagree = foldr step [] overlap
     step v ac
       | (apply s1 (Meta v)) == (apply s2 (Meta v)) = ac
       | otherwise = (apply s1 (Meta v), apply s2 (Meta v)) : ac
     agree =
       all
         (\v -> (apply s1 (Meta v)) == (apply s2 (Meta v)))
-        (dom p1 `intersect` dom p2)
-    dom s = map fst s
+        overlap
 
 mergeError :: (MonadError CompilerError m) => [(Ty, Ty)] -> m a
 mergeError ts =

--- a/src/Solcore/Pipeline/Options.hs
+++ b/src/Solcore/Pipeline/Options.hs
@@ -90,16 +90,6 @@ emptyOption path =
 stdOpt :: Option
 stdOpt = emptyOption mempty
 
-noDesugarOpt :: Option
-noDesugarOpt =
-  stdOpt
-    { optNoGenDispatch = True,
-      optNoDesugarCalls = True,
-      optNoSpec = True,
-      optNoMatchCompiler = True,
-      optNoIfDesugar = True
-    }
-
 options :: Parser Option
 options =
   Option

--- a/src/Solcore/Pipeline/SolcorePipeline.hs
+++ b/src/Solcore/Pipeline/SolcorePipeline.hs
@@ -67,7 +67,7 @@ import Solcore.Frontend.TypeInference.Id
 import Solcore.Frontend.TypeInference.SccAnalysis
 import Solcore.Frontend.TypeInference.TcEnv
 import Solcore.Frontend.TypeInference.TcModule
-import Solcore.Pipeline.Options (Option (..), WarningPolicy (..), argumentsParser, diagnosticRenderOptions, noDesugarOpt)
+import Solcore.Pipeline.Options (Option (..), WarningPolicy (..), argumentsParser, diagnosticRenderOptions)
 import System.Directory (createDirectoryIfMissing, doesFileExist, makeAbsolute)
 import System.Exit (ExitCode (..), exitWith)
 import System.FilePath ((</>))
@@ -728,24 +728,18 @@ typeCheckModuleFromGraph opts graph moduleId = do
       first (moduleTypeCheckError sourcePath "input") <$> loadModuleLocalTypeCheckInput graph moduleId
   liftIO $ dumpModuleResolvedAST opts sourcePath resolvedInput
   moduleInput <- prepareModuleTypeCheckInput opts resolvedInput
-  let noDesugarTypecheckOpt =
-        noDesugarOpt {optTypeClassResolution = optTypeClassResolution opts}
-  (noDesugarChecked, _noDesugarEnv) <-
+  (typed, tcEnv) <-
     ExceptT $
-      first (moduleTypeCheckError sourcePath "no desugaring") <$> typeInferModuleLocals noDesugarTypecheckOpt moduleInput
+      first (moduleTypeCheckError sourcePath "") <$> typeInferModuleLocals opts moduleInput
   liftIO $
     when (optVerbose opts) $
       putStrLn ("No type errors found for " ++ sourcePath ++ "!")
-  (typed, tcEnv) <-
-    ExceptT $
-      first (moduleTypeCheckError sourcePath "desugaring") <$> typeInferModuleLocals opts moduleInput
   liftIO $ dumpModuleTypeInference opts sourcePath typed tcEnv
   pure
     ( moduleId,
       CheckedModule
         { checkedModuleId = moduleId,
           checkedModuleInput = moduleInput,
-          checkedModuleNoDesugar = noDesugarChecked,
           checkedModuleTyped = typed,
           checkedModuleEnv = tcEnv
         }
@@ -803,8 +797,12 @@ dumpModuleTypeInference opts sourcePath typed tcEnv =
 moduleTypeCheckError :: FilePath -> String -> CompilerError -> CompilerError
 moduleTypeCheckError sourcePath phase err =
   decorateCompilerDiagnosticContext
-    ("module typecheck failed for " ++ sourcePath ++ " (" ++ phase ++ ")")
+    ("module typecheck failed for " ++ sourcePath ++ phaseSuffix)
     err
+  where
+    phaseSuffix
+      | null phase = ""
+      | otherwise = " (" ++ phase ++ ")"
 
 decorateDiagnosticContext :: String -> String -> String
 decorateDiagnosticContext context err =

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -509,6 +509,17 @@ cases =
       runTestExpectingFailure "instance-context-wrong-kind.solc" caseFolder,
       runTestForFile "instance-closure-error.solc" caseFolder,
       runTestExpectingFailure "instance-closure-error-invalid-member.solc" caseFolder,
+      -- functions returning functions: validate that the single type-inference
+      -- pass still catches lambda type errors that closure conversion could mask.
+      runTestForFile "return-fun-adder.solc" caseFolder,
+      runTestForFile "return-fun-const.solc" caseFolder,
+      runTestForFile "return-fun-instance.solc" caseFolder,
+      runTestForFile "return-fun-eq.solc" caseFolder,
+      runTestExpectingFailure "return-fun-bad-param.solc" caseFolder,
+      runTestExpectingFailure "return-fun-bad-return.solc" caseFolder,
+      runTestExpectingFailure "return-fun-bad-arity.solc" caseFolder,
+      runTestExpectingFailure "return-fun-bad-sig.solc" caseFolder,
+      runTestExpectingFailure "return-fun-not-fun.solc" caseFolder,
       runTestForFile "field-name-error.solc" caseFolder,
       runTestForFile "field-helper-cxt-collision.solc" caseFolder,
       runTestExpectingFailure "field-access.solc" caseFolder,

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -267,7 +267,7 @@ cases =
       runTestForFile "Add1.solc" caseFolder,
       runTestExpectingFailure "add-moritz.solc" caseFolder,
       runTestForFile "another-subst.solc" caseFolder,
-      runTestForFileWith noDesugarOpt "app.solc" caseFolder,
+      runTestForFile "app.solc" caseFolder,
       runTestForFile "array.solc" caseFolder,
       runTestForFile "assembly.solc" caseFolder,
       runTestExpectingFailure "asm-assign-no-return.solc" caseFolder,
@@ -288,12 +288,18 @@ cases =
       runTestForFile "class-context.solc" caseFolder,
       runTestForFile "closure.solc" caseFolder,
       runTestForFile "closure-capture-only.solc" caseFolder,
-      runTestForFileWith noDesugarOpt "Compose.solc" caseFolder,
+      runTestForFile "Compose.solc" caseFolder,
       runTestForFile "Compose3.solc" caseFolder,
       -- The following test makes the test runner throw an exception
       -- , runTestForFile "comp.solc" caseFolder
       runTestForFile "compose0.solc" caseFolder,
-      runTestForFileWith noDesugarOpt "compose_desugared.solc" caseFolder,
+      -- compose_desugared.solc exercises the desugared closure/invoke encoding.
+      -- The generated `invoke` instance requires rank-N polymorphism that the
+      -- type checker cannot infer, so the full pipeline fails typechecking with
+      -- SC0209 ("type is not polymorphic enough"). It previously passed only by
+      -- disabling the desugaring phases via noDesugarOpt; now that that helper is
+      -- gone it is expected to fail.
+      runTestExpectingFailure "compose_desugared.solc" caseFolder,
       runTestForFile "comparisons.solc" caseFolder,
       runTestForFile "bitwise.solc" caseFolder,
       runTestForFile "match-bitwise.solc" caseFolder,

--- a/test/DiagnosticCliTests.hs
+++ b/test/DiagnosticCliTests.hs
@@ -66,7 +66,7 @@ diagnosticCliTests =
             "note: in: function main () -> word {",
             "      return true;",
             "      }",
-            "note: module typecheck failed for <cwd>/test/diagnostics/type-mismatch.solc (no desugaring)"
+            "note: module typecheck failed for <cwd>/test/diagnostics/type-mismatch.solc"
           ],
       testCase "missing signature uses signature span" $
         expectFailure
@@ -77,7 +77,7 @@ diagnosticCliTests =
             "1 | function foo() {",
             "  |          ^^^ incomplete signature",
             "note: signature: function foo ()",
-            "note: module typecheck failed for <cwd>/test/diagnostics/missing-signature.solc (no desugaring)",
+            "note: module typecheck failed for <cwd>/test/diagnostics/missing-signature.solc",
             "help: annotate every parameter (name : Type) and provide a return type (-> Type)"
           ],
       testCase "polymorphic type error uses signature span" $
@@ -98,7 +98,7 @@ diagnosticCliTests =
             "      }",
             "      return result;",
             "      }",
-            "note: module typecheck failed for <cwd>/test/diagnostics/not-polymorphic-enough.solc (no desugaring)"
+            "note: module typecheck failed for <cwd>/test/diagnostics/not-polymorphic-enough.solc"
           ],
       testCase "missing instance" $
         expectFailure
@@ -117,7 +117,7 @@ diagnosticCliTests =
             "      return Typedef.abs(MemoryType.load(ptr) : word);",
             "      }",
             "      }",
-            "note: module typecheck failed for <cwd>/test/examples/cases/missing-instance.solc (no desugaring)",
+            "note: module typecheck failed for <cwd>/test/examples/cases/missing-instance.solc",
             "help: add a matching instance or strengthen the surrounding type context"
           ],
       testCase "dot shorthand constructor error" $
@@ -133,7 +133,7 @@ diagnosticCliTests =
             "note: in: function bad () -> Option {",
             "      return .Nope(Int.fromInteger(1));",
             "      }",
-            "note: module typecheck failed for <cwd>/test/examples/cases/dot-expression-unknown-fail.solc (no desugaring)",
+            "note: module typecheck failed for <cwd>/test/examples/cases/dot-expression-unknown-fail.solc",
             "help: use a constructor that is visible for the expected type"
           ],
       testCase "import error" $

--- a/test/LocationTests.hs
+++ b/test/LocationTests.hs
@@ -14,7 +14,7 @@ import Solcore.Frontend.Syntax.NameResolution (nameResolution)
 import Solcore.Frontend.Syntax.SyntaxTree qualified as Parsed
 import Solcore.Frontend.TypeInference.SccAnalysis (sccAnalysis)
 import Solcore.Frontend.TypeInference.TcModule
-import Solcore.Pipeline.Options (noDesugarOpt)
+import Solcore.Pipeline.Options (stdOpt)
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -69,7 +69,7 @@ test_typeInferencePreservesSourceLocations = do
   (typedUnit, _) <-
     assertCompilerRight
       "type inference"
-      (typeInferModuleLocals noDesugarOpt (moduleInputFromUnit resolved))
+      (typeInferModuleLocals stdOpt (moduleInputFromUnit resolved))
   assertSpansPreserved "type inference" resolved typedUnit
 
 hasSourceSpan :: (HasSourceSpan a) => a -> Bool

--- a/test/ModuleTypeCheckTests.hs
+++ b/test/ModuleTypeCheckTests.hs
@@ -6,7 +6,7 @@ where
 import Solcore.Diagnostics (CompilerError, compilerErrorText)
 import Solcore.Frontend.Syntax
 import Solcore.Frontend.TypeInference.TcModule
-import Solcore.Pipeline.Options (noDesugarOpt)
+import Solcore.Pipeline.Options (stdOpt)
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -47,13 +47,13 @@ moduleTypeCheckTests =
       testCase "type inference trusts imported bodies while checking local bodies" $ do
         result <-
           typeInferModuleLocals
-            noDesugarOpt
+            stdOpt
             (moduleInput [ModuleInferenceDecl ModuleImportedDecl badImportedFun, ModuleInferenceDecl ModuleLocalDecl usesImportedFun])
         assertRight "imported body should be trusted" result,
       testCase "type inference checks local bodies" $ do
         result <-
           typeInferModuleLocals
-            noDesugarOpt
+            stdOpt
             (moduleInput [ModuleInferenceDecl ModuleLocalDecl badImportedFun])
         assertLeft "local body should be checked" result
     ]

--- a/test/examples/cases/return-fun-adder.solc
+++ b/test/examples/cases/return-fun-adder.solc
@@ -1,0 +1,20 @@
+// Returns a function with CORRECT type annotations.
+// Validates the single-pass type checker: closure conversion must not hide
+// that the returned lambda really has type (word) -> word.
+// Uses an assembly block instead of primAddWord so it lowers end-to-end.
+function makeAdder(x : word) -> ((word) -> word) {
+  return lam (y : word) -> word {
+    let res : word;
+    assembly {
+      res := add(x, y)
+    }
+    return res;
+  };
+}
+
+contract C {
+  public function main() -> word {
+    let f = makeAdder(10);
+    return f(5);
+  }
+}

--- a/test/examples/cases/return-fun-bad-arity.solc
+++ b/test/examples/cases/return-fun-bad-arity.solc
@@ -1,0 +1,11 @@
+// INCORRECT: the signature promises a one-argument function (word) -> word,
+// but the returned lambda takes two arguments.
+function makeF(x : word) -> ((word) -> word) {
+  return lam (y : word, z : word) -> word {
+    let res : word;
+    assembly {
+      res := add(y, z)
+    }
+    return res;
+  };
+}

--- a/test/examples/cases/return-fun-bad-param.solc
+++ b/test/examples/cases/return-fun-bad-param.solc
@@ -1,0 +1,8 @@
+// INCORRECT: the returned lambda's parameter is `bool`, but the signature
+// promises (word) -> word.  Closure conversion would erase the arrow type;
+// the single-pass checker must still reject this.
+function makeAdder(x : word) -> ((word) -> word) {
+  return lam (y : bool) -> word {
+    return x;
+  };
+}

--- a/test/examples/cases/return-fun-bad-return.solc
+++ b/test/examples/cases/return-fun-bad-return.solc
@@ -1,0 +1,7 @@
+// INCORRECT: the returned lambda's body has type bool, but the signature
+// promises the result is word.
+function makeConst(x : word) -> ((word) -> word) {
+  return lam (y : word) -> bool {
+    return true;
+  };
+}

--- a/test/examples/cases/return-fun-bad-sig.solc
+++ b/test/examples/cases/return-fun-bad-sig.solc
@@ -1,0 +1,7 @@
+// INCORRECT: signature says the result consumes a bool ((bool) -> word),
+// but the returned lambda consumes a word.
+function makeF(x : word) -> ((bool) -> word) {
+  return lam (y : word) -> word {
+    return x;
+  };
+}

--- a/test/examples/cases/return-fun-const.solc
+++ b/test/examples/cases/return-fun-const.solc
@@ -1,0 +1,7 @@
+// Returns a constant function that closes over its argument.
+// Correct annotations: (word) -> word, body returns the captured word.
+function constFn(x : word) -> ((word) -> word) {
+  return lam (y : word) -> word {
+    return x;
+  };
+}

--- a/test/examples/cases/return-fun-eq.solc
+++ b/test/examples/cases/return-fun-eq.solc
@@ -1,0 +1,18 @@
+// Returns a function comparing against a captured word, CORRECT annotations.
+// Uses an assembly `eq` instead of primEqWord so it lowers end-to-end.
+function makeEq(x : word) -> ((word) -> word) {
+  return lam (y : word) -> word {
+    let res : word;
+    assembly {
+      res := eq(x, y)
+    }
+    return res;
+  };
+}
+
+contract C {
+  public function main() -> word {
+    let f = makeEq(7);
+    return f(7);
+  }
+}

--- a/test/examples/cases/return-fun-instance.solc
+++ b/test/examples/cases/return-fun-instance.solc
@@ -1,0 +1,13 @@
+// Instance member returning a function with CORRECT annotations.
+// The compiled-away validation pass used to check this; the single pass must too.
+forall t . class t:CtFun {
+    function ct(x : t) -> ((t) -> t);
+}
+
+instance word:CtFun {
+    function ct(x : word) -> ((word) -> word) {
+        return lam (y : word) -> word {
+            return x;
+        };
+    }
+}

--- a/test/examples/cases/return-fun-not-fun.solc
+++ b/test/examples/cases/return-fun-not-fun.solc
@@ -1,0 +1,5 @@
+// INCORRECT: the signature promises a function (word) -> word, but the body
+// returns a plain word instead of a function.
+function makeF(x : word) -> ((word) -> word) {
+  return x;
+}


### PR DESCRIPTION
This PR makes some changes on type inference to improve performance.

- Single type-inference pass: merged the two full inference passes into one.
- SYB span-stopping: A lot of typing time is spent by SYB traversals. The improvement is to make them not to check the AST Span information using new combinators in `Traversal.hs`
- `Subst` as `Data.Map`: `apply` is now `O(log n)` instead of a linear association-list scan.
- `ordNub` in `fv`/`mv`/`bv`: replaced `O(n^2)` `Data.List.union` accumulation.
- Minor optimizations: removed dead `nameSupply` mutation in `freshInst`; `askInstEnv`
  alpha-renames only the queried class's instances, not the whole table.

Times in seconds (minimum of several warm runs on my machine). `main` is the original
two-pass baseline; `optimized` is this branch. `tc` = "Typecheck modules" phase; `wall` = total
compile time.

| Program     | tc: main | tc: optimized | tc speed-up | wall: main | wall: optimized | wall speed-up |
|-------------|---------:|--------------:|:-----------:|-----------:|----------------:|:-------------:|
| storage     |   4.16   |     0.74      |   5.62x     |    5.21    |      1.04       |    5.00x      |
| generic_sum |   6.01   |     1.01      |   5.95x     |    7.43    |      1.39       |    5.33x      |
| weth9       |   4.86   |     0.86      |   5.65x     |    6.09    |      1.22       |    5.00x      |
| forloops    |   4.53   |     0.82      |   5.52x     |    5.68    |      1.16       |    4.88x      |
| miniERC20   |   5.30   |     0.97      |   5.46x     |    6.50    |      1.30       |    5.00x      |

**~5.6x faster type checking, ~5.0x faster total compile.** Full unit suite (793 tests) went from
~100 s to 23.8 s; all 793 tests + 22 contest suites still pass.