### PR TITLE
Unify a call's result with its expected type

### DIFF
--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -419,8 +419,8 @@ tcExpWithExpected' _ (FieldAccess (Just e) n) =
     s <- askField tn n
     (ps' :=> t') <- freshInst s
     withCurrentSubst (FieldAccess (Just e') (Id n t'), ps ++ ps', t')
-tcExpWithExpected' _ ex@(Call me n args) =
-  tcCall me n args `wrapError` ex
+tcExpWithExpected' mExpected ex@(Call me n args) =
+  tcCall mExpected me n args `wrapError` ex
 tcExpWithExpected' mExpected (Lam args bd _) =
   do
     (args', schs, ts') <- tcArgs args
@@ -1502,8 +1502,23 @@ tcBodyWithExpectedReturn mExpectedReturn (s : ss) =
     (bd', ps1, t1) <- tcBodyWithExpectedReturn mExpectedReturn ss
     pure (s' : bd', ps' ++ ps1, t1)
 
-tcCall :: Maybe (Exp Name) -> Name -> [Exp Name] -> TcM (Exp Id, [Pred], Ty)
-tcCall Nothing n args =
+-- | The expected type of a call's result, when known, has to be unified with
+-- the call itself rather than left to the caller.  A method resolved by its
+-- result type has nothing else to determine it, and the statement type that
+-- would otherwise carry the information upwards is discarded for every
+-- statement but the last (see `tcBodyWithExpectedReturn`) — so a call in a
+-- non-tail `return` would keep an unresolved result variable and be rejected
+-- as ambiguous.  Mirrors what the `Con` case of `tcExpWithExpected'` does.
+unifyExpectedResult :: Maybe Ty -> Ty -> TcM ()
+unifyExpectedResult Nothing _ = pure ()
+unifyExpectedResult (Just expectedTy) resultTy =
+  do
+    expectedTy' <- maybeExpandSynonym expectedTy
+    s <- unify resultTy expectedTy'
+    void $ extSubst s
+
+tcCall :: Maybe Ty -> Maybe (Exp Name) -> Name -> [Exp Name] -> TcM (Exp Id, [Pred], Ty)
+tcCall mExpected Nothing n args =
   do
     s <- askEnv n `wrapError` (Call Nothing n args)
     (ps :=> t) <- freshInst s
@@ -1511,6 +1526,7 @@ tcCall Nothing n args =
     expectedArgTys <- mapM (const freshTyVar) args
     s0 <- unify t (funtype expectedArgTys t')
     _ <- extSubst s0
+    unifyExpectedResult mExpected t'
     (es', pss', ts') <-
       unzip3 <$> zipWithM (\e expectedTy -> tcExpWithExpected (Just expectedTy) e) args (apply s0 expectedArgTys)
     s1 <- unify t (funtype ts' t')
@@ -1518,7 +1534,7 @@ tcCall Nothing n args =
     let ps' = foldr union [] (ps : pss')
         t1 = funtype ts' t'
     withCurrentSubst (Call Nothing (Id n t1) es', ps', t')
-tcCall (Just e) n args =
+tcCall mExpected (Just e) n args =
   do
     (e', ps, _) <- tcExp e
     s <- askEnv n `wrapError` (Call (Just e) n args)
@@ -1527,6 +1543,7 @@ tcCall (Just e) n args =
     expectedArgTys <- mapM (const freshTyVar) args
     s0 <- unify (foldr (:->) t' expectedArgTys) t
     _ <- extSubst s0
+    unifyExpectedResult mExpected t'
     (es', pss', ts') <-
       unzip3 <$> zipWithM (\arg expectedTy -> tcExpWithExpected (Just expectedTy) arg) args (apply s0 expectedArgTys)
     s' <- unify (foldr (:->) t' ts') t

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -585,6 +585,7 @@ cases =
       runTestForFile "pars.solc" caseFolder,
       runTestForFile "bug-rep-name-capture.solc" caseFolder,
       runTestForFile "bug-import-default-inst-shadow.solc" caseFolder,
+      runTestForFile "bug-call-expected-nontail-return.solc" caseFolder,
       runTestExpectingFailure "array-elem-no-storagecopy.solc" caseFolder,
       runTestExpectingFailure "array-push-no-canstore.solc" caseFolder,
       -- Storage derivation for ADTs. These need dispatch generation: without a

--- a/test/examples/cases/bug-call-expected-nontail-return.solc
+++ b/test/examples/cases/bug-call-expected-nontail-return.solc
@@ -1,0 +1,38 @@
+// A class-method call in a `return` that is not the last statement of the
+// function must take its result type from the declared return type.
+//
+// The method is resolved by its *result* type alone, so nothing else can pin
+// it down.  In tail position this always worked, because the body's type flows
+// up to the function level and is unified there; in a non-tail position that
+// type is discarded, so the expected type has to reach the call itself.
+// Without that, `pick` fails to compile with an ambiguous `a:FromWord`.
+
+data Box(a) = Box(a);
+
+forall a.
+class a:FromWord {
+  function fromWord(x: word) -> a;
+}
+
+instance Box(word):FromWord {
+  function fromWord(x: word) -> Box(word) {
+    return Box(x);
+  }
+}
+
+function pick(cond: bool, w: word) -> Box(word) {
+  if (cond) { return FromWord.fromWord(w); }
+  return Box(w);
+}
+
+function unbox(b: Box(word)) -> word {
+  match b {
+    | Box(x) => return x;
+  }
+}
+
+contract CallExpectedNonTailReturn {
+  function main() -> word {
+    return unbox(pick(true, 42));
+  }
+}


### PR DESCRIPTION
This PR attempts to fix #527

A class method resolved by its result type was rejected as ambiguous when called from a `return` that is not the last statement of a function:

    function pick(cond: bool, w: word) -> Box(word) {
      if (cond) { return FromWord.fromWord(w); }   // ambiguous a:FromWord
      return Box(w);
    }

Two behaviours combined to produce this.  `tcExpWithExpected'` discarded the expected type for `Call`, unlike `Con` which unifies with it, so the call's result stayed a fresh variable carrying the unresolved constraint.  Nothing else determined it either: `tcBodyWithExpectedReturn` returns only the *last* statement's type upwards, and that is what normally reaches the function level to be unified with the declared return type.  In tail position the second mechanism happened to cover for the first, which is why the same call compiles as the final statement.

`tcCall` now takes the expected result type and unifies with it, mirroring the `Con` case.  This resolves the constraint at the call, independently of the statement's position.  Programs that were wrongly rejected as ambiguous now either compile or report the real error (a missing instance); a non-tail return with a genuinely wrong type is still rejected, as before, since the `Con` path already covered that.
