### PR TITLE
Extract array length into a generic Length class

### DIFF
--- a/std/std.solc
+++ b/std/std.solc
@@ -28,6 +28,7 @@ export {
   IndexAccess,
   LVA,
   LValueIdxAccess,
+  Length,
   MemberAccessProxy(*),
   MemoryEncode,
   MemoryPointer,
@@ -1798,10 +1799,13 @@ instance array(member):StorageSize {
     }
 }
 
+forall self . class self:Length {
+    function length(arr:self) -> uint256;
+}
+
 // Dynamic storage arrays carry their length at the slot itself (matching the
 // Solidity convention) while elements live at keccak256(slot) + i.
 forall self . class self:Array {
-    function length(arr:self) -> uint256;
     function setLength(arr:self, n:uint256) -> ();
     function pop(arr:self) -> ();
 }
@@ -1814,10 +1818,14 @@ forall self elem . class self:ArrayPush(elem) {
 }
 
 forall t .
-instance storage(array(t)):Array {
+instance storage(array(t)):Length {
     function length(arr:storage(array(t))) -> uint256 {
         return uint256(sload(Typedef.rep(arr)));
     }
+}
+
+forall t .
+instance storage(array(t)):Array {
     // Shrinking clears the abandoned slots, matching solc's resize_array.
     // For string/bytes elements this zeroes the inline slot, which makes any
     // keccak-derived tail unreachable (reads are governed by the length word) but

--- a/test/examples/cases/array-elem-no-storagecopy.solc
+++ b/test/examples/cases/array-elem-no-storagecopy.solc
@@ -14,6 +14,6 @@ contract NoCopy {
   xs : array(Odd);
 
   function main() -> uint256 {
-    return Array.length(xs);
+    return Length.length(xs);
   }
 }

--- a/test/examples/dispatch/array_copy.solc
+++ b/test/examples/dispatch/array_copy.solc
@@ -37,7 +37,7 @@ contract ArrayCopy {
   }
 
   public function lenA() -> uint256 {
-    return Array.length(a);
+    return Length.length(a);
   }
 
   public function getA(i : uint256) -> uint256 {

--- a/test/examples/dispatch/array_nested.solc
+++ b/test/examples/dispatch/array_nested.solc
@@ -25,7 +25,7 @@ contract NestedArray {
   }
 
   public function innerLen(i : uint256) -> uint256 {
-    return Array.length(grid[i]);
+    return Length.length(grid[i]);
   }
 
   public function get2(i : uint256, j : uint256) -> uint256 {
@@ -48,7 +48,7 @@ contract NestedArray {
   }
 
   public function flatLen() -> uint256 {
-    return Array.length(flat);
+    return Length.length(flat);
   }
 
   public function getFlat(i : uint256) -> uint256 {

--- a/test/examples/dispatch/array_ops.solc
+++ b/test/examples/dispatch/array_ops.solc
@@ -20,7 +20,7 @@ contract ArrayOps {
   }
 
   public function len() -> uint256 {
-    return Array.length(xs);
+    return Length.length(xs);
   }
 
   public function get(i : uint256) -> uint256 {

--- a/test/examples/dispatch/array_string.solc
+++ b/test/examples/dispatch/array_string.solc
@@ -26,7 +26,7 @@ contract ArrayString {
   }
 
   public function len() -> uint256 {
-    return Array.length(names);
+    return Length.length(names);
   }
 
   // backup = names
@@ -39,6 +39,6 @@ contract ArrayString {
   }
 
   public function lenBackup() -> uint256 {
-    return Array.length(backup);
+    return Length.length(backup);
   }
 }

--- a/test/examples/dispatch/storage_array.solc
+++ b/test/examples/dispatch/storage_array.solc
@@ -14,18 +14,18 @@ contract MemberRegistry {
   // MemberNotFound() selector
   public function removeMember(addr : address) -> () {
     // foundIdx == length() acts as the "not found" sentinel.
-    let foundIdx : uint256 = Array.length(members);
+    let foundIdx : uint256 = Length.length(members);
     let i : uint256;
-    for (i = uint256(0); i < Array.length(members); i = i + uint256(1)) {
+    for (i = uint256(0); i < Length.length(members); i = i + uint256(1)) {
       if (members[i] == addr) {
         // NOTE: solcore has no `break`, so we keep scanning.
         foundIdx = i;
       }
     }
-    require(foundIdx != Array.length(members), Error(0xdeadbeef));
+    require(foundIdx != Length.length(members), Error(0xdeadbeef));
 
     // Shift subsequent elements down one slot to close the gap.
-    for (; foundIdx < Array.length(members) - uint256(1); foundIdx = foundIdx + uint256(1)) {
+    for (; foundIdx < Length.length(members) - uint256(1); foundIdx = foundIdx + uint256(1)) {
       members[foundIdx] = members[foundIdx + uint256(1)];
     }
     // Drop the (now-duplicated) last item and adjust the length.
@@ -33,11 +33,11 @@ contract MemberRegistry {
   }
 
   public function numberOfMembers() -> uint256 {
-    return Array.length(members);
+    return Length.length(members);
   }
 
   public function getMembers() -> memory(DynArray(address)) {
-    let count : word = Typedef.rep(Array.length(members));
+    let count : word = Typedef.rep(Length.length(members));
     let totalBytes : word = (count + 1) * 32;
     let ptr : word = allocate_memory(totalBytes);
     mstore(ptr, count);

--- a/test/examples/dispatch/ufcs_array.solc
+++ b/test/examples/dispatch/ufcs_array.solc
@@ -11,7 +11,7 @@ import std.opcodes.{mload, mstore};
 // call is rewritten to Class.method(recv, args).  So:
 //
 //   members.push(addr)  ==>  ArrayPush.push(members, addr)
-//   members.length()    ==>  Array.length(members)
+//   members.length()    ==>  Length.length(members)
 //   members.pop()       ==>  Array.pop(members)
 //
 // It runs against the SAME assertions as storage_array.json (see

--- a/test/examples/spec/129arraystorage.solc
+++ b/test/examples/spec/129arraystorage.solc
@@ -18,7 +18,7 @@ contract ArrayStorage {
 
     // `arr[i]` syntax only desugars for contract fields, so use the
     // explicit ridx helper for this local-variable array. ridx dispatches
-    // through RValueIdxAccess, which bounds-checks against Array.length.
+    // through RValueIdxAccess, which bounds-checks against Length.length.
     return ridx(arr, uint256(0)) + ridx(arr, uint256(1));
   }
 }

--- a/test/examples/spec/133arraystring.solc
+++ b/test/examples/spec/133arraystring.solc
@@ -12,6 +12,6 @@ contract ArrayOfDynamic {
   blobs : array(bytes);
 
   function main() -> uint256 {
-    return Array.length(names) + Array.length(blobs);
+    return Length.length(names) + Length.length(blobs);
   }
 }

--- a/test/examples/spec/135aliaspush.solc
+++ b/test/examples/spec/135aliaspush.solc
@@ -13,6 +13,6 @@ contract AliasPush {
     let p : storage(array(uint256)) = xs;
     ArrayPush.push(p, uint256(1));
     // The push went through the alias, so the field sees it.
-    return Array.length(xs);
+    return Length.length(xs);
   }
 }


### PR DESCRIPTION
`length` lived on the `Array` typeclass alongside the storage-only mutators `setLength`/`pop`, which tied the `.length()` UFCS sugar to storage arrays. Split it into its own single-method class `Length` so read-only consumers can depend on just `self:Length`, and so non-storage array representations (e.g. calldata(array(t)) in the ABI layer) can provide `.length()` by implementing one method.

- Add `forall self . class self:Length { length }`; drop `length` from `Array`.
- Move the storage implementation into `instance storage(array(t)):Length`; the `Array` instance keeps `setLength`/`pop`.
- Export `Length` from std.
- Update explicit `Array.length(...)` call sites (and comments) to `Length.length(...)` across the array tests.

UFCS `arr.length()` still resolves uniformly: `length` is now owned by exactly one class, so NameResolution's findClassWithMethod rewrites it to `Length.length(arr)` regardless of where the array lives. The no-context single-parameter instance needs no coverage/Patterson pragmas. Behaviour is unchanged, so the dispatch JSON expectations are untouched.