### PR TITLE
Add `bytes:ABIAttribs`

### DIFF
--- a/run_contests.sh
+++ b/run_contests.sh
@@ -36,6 +36,7 @@ bash ./contest.sh test/examples/dispatch/storage_adt_enum.json
 bash ./contest.sh test/examples/dispatch/storage_adt_bool.json
 bash ./contest.sh test/examples/dispatch/storage_adt_mapping.json
 bash ./contest.sh test/examples/dispatch/storage_adt_abi.json
+bash ./contest.sh test/examples/dispatch/abi_adt_dynamic_branch.json
 bash ./contest.sh test/examples/dispatch/storage_dynamic_field.json
 bash ./contest.sh test/examples/dispatch/forloops.json
 bash ./contest.sh test/examples/dispatch/weth9.json

--- a/std/std.solc
+++ b/std/std.solc
@@ -1146,6 +1146,10 @@ instance string:ABIAttribs {
     function headSize(ty: Proxy(string)) -> word { return 32; }
     function isStatic(ty : Proxy(string)) -> bool { return false; }
 }
+instance bytes:ABIAttribs {
+    function headSize(ty: Proxy(bytes)) -> word { return 32; }
+    function isStatic(ty : Proxy(bytes)) -> bool { return false; }
+}
 
 // computes the attribs for a pair of two types that implement attribs
 forall a b . a:ABIAttribs, b:ABIAttribs => instance (a,b):ABIAttribs {

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -135,6 +135,7 @@ dispatches =
       runDispatchTest "storage_adt_bool.solc",
       runDispatchTest "storage_adt_mapping.solc",
       runDispatchTest "storage_adt_abi.solc",
+      runDispatchTest "abi_adt_dynamic_branch.solc",
       runDispatchTest "storage_dynamic_field.solc",
       runDispatchTest "storage_array.solc",
       runDispatchTest "ufcs_array.solc",

--- a/test/examples/dispatch/abi_adt_dynamic_branch.json
+++ b/test/examples/dispatch/abi_adt_dynamic_branch.json
@@ -1,0 +1,28 @@
+{
+  "abi_adt_dynamic_branch": {
+    "bytecode": "",
+    "contract": "C",
+    "tests": [
+      {
+        "input": {
+          "comment": "constructor() asserts headSize(D)==64 and isStatic(D)==false; reverts before the bytes:ABIAttribs fix (was 32 / true)",
+          "calldata": "",
+          "value": "0"
+        },
+        "kind": "constructor"
+      },
+      {
+        "input": {
+          "comment": "getA(0xaa) -> A(0xaa): tag 0 + address, a full 64-byte return, not a truncated 0x00 tag word",
+          "calldata": "4ed33ace00000000000000000000000000000000000000000000000000000000000000aa",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000aa",
+          "status": "success"
+        }
+      }
+    ]
+  }
+}

--- a/test/examples/dispatch/abi_adt_dynamic_branch.solc
+++ b/test/examples/dispatch/abi_adt_dynamic_branch.solc
@@ -1,0 +1,36 @@
+import std.{*};
+import std.dispatch.{*};
+import std.Generic.{*};
+import std.ABIGeneric.{*};
+
+// Regression test: an ADT with a *dynamic* branch (`memory(bytes)`) must not
+// collapse its `ABIAttribs` to the static 32-byte default when returned over
+// the ABI.
+//
+// Before `bytes:ABIAttribs` was added, `memory(bytes)` resolved `ABIAttribs`
+// only through the catch-all `default instance t:ABIAttribs` (headSize 32,
+// isStatic true) — `string` had an instance but `bytes` did not. That default
+// cannot satisfy the `g:ABIAttribs` context of `sum(f,g):ABIAttribs`, so the
+// moment a data type carries one `memory(bytes)` branch its ENTIRE `ABIAttribs`
+// collapsed to static/32. `abi_encode` then reserved a single word and
+// truncated every returned constructor — even the static `A(address)` one — to
+// the sum tag (`0x00` / `0x01`), dropping the payload.
+//
+//   rep(D) = sum(address, memory(bytes))
+//   headSize = 32 (tag) + max(headSize address = 32, headSize memory(bytes) = 32) = 64
+//   isStatic = and(isStatic address = true, isStatic memory(bytes) = false) = false
+data D = A(address) | B(memory(bytes));
+
+contract C {
+    constructor() {
+        // Exactly the two values that were wrong (32 / true) before the fix.
+        assert(ABIAttribs.headSize(Proxy : Proxy(D)) == 64);
+        assert(!ABIAttribs.isStatic(Proxy : Proxy(D)));
+    }
+
+    // Returns the STATIC constructor of a dynamic ADT. Must encode as
+    // tag(0) + address — a full 64-byte return — not a bare `0x00` tag word.
+    public function getA(x : address) -> D {
+        return D.A(x);
+    }
+}


### PR DESCRIPTION
This fixes miscompilation in the ABI encoder when `bytes` is used in a sum type.