### PR TITLE
Add word bitwise NOT with `~` and `~=` sugar

### DIFF
--- a/src/Solcore/Frontend/Module/Loader.hs
+++ b/src/Solcore/Frontend/Module/Loader.hs
@@ -1423,6 +1423,8 @@ renameStmtTypeRefs renameMap (StmtBOrEq e1 e2) =
   StmtBOrEq (renameExpTypeRefs renameMap e1) (renameExpTypeRefs renameMap e2)
 renameStmtTypeRefs renameMap (StmtModEq e1 e2) =
   StmtModEq (renameExpTypeRefs renameMap e1) (renameExpTypeRefs renameMap e2)
+renameStmtTypeRefs renameMap (StmtBNotEq e1) =
+  StmtBNotEq (renameExpTypeRefs renameMap e1)
 renameStmtTypeRefs renameMap (Let ct n mt me) =
   Let ct n (renameTyTypeRefs renameMap <$> mt) (renameExpTypeRefs renameMap <$> me)
 renameStmtTypeRefs renameMap (StmtExp e) =
@@ -1538,6 +1540,8 @@ renameExpTypeRefs renameMap (ExpLOr e1 e2) =
   ExpLOr (renameExpTypeRefs renameMap e1) (renameExpTypeRefs renameMap e2)
 renameExpTypeRefs renameMap (ExpLNot e) =
   ExpLNot (renameExpTypeRefs renameMap e)
+renameExpTypeRefs renameMap (ExpBNot e) =
+  ExpBNot (renameExpTypeRefs renameMap e)
 renameExpTypeRefs renameMap (ExpCond e1 e2 e3) =
   ExpCond
     (renameExpTypeRefs renameMap e1)

--- a/src/Solcore/Frontend/Parser/Expr.hs
+++ b/src/Solcore/Frontend/Parser/Expr.hs
@@ -54,6 +54,10 @@ opTable =
   [ [ Prefix
         ( unaryExp ExpLNot
             <$ try (lexeme (char '!' <* notFollowedBy (char '=')))
+        ),
+      Prefix
+        ( unaryExp ExpBNot
+            <$ try (lexeme (char '~' <* notFollowedBy (char '=')))
         )
     ],
     [ InfixL (binaryExp ExpTimes <$ try (symbol "*")),

--- a/src/Solcore/Frontend/Parser/Stmt.hs
+++ b/src/Solcore/Frontend/Parser/Stmt.hs
@@ -99,6 +99,7 @@ exprOrAssignP = locatedP locatedStmt $ do
       do rhs <- symbol "&=" *> expP; _ <- semicolon; return (StmtBAndEq lhs rhs),
       do rhs <- symbol "|=" *> expP; _ <- semicolon; return (StmtBOrEq lhs rhs),
       do rhs <- symbol "%=" *> expP; _ <- semicolon; return (StmtModEq lhs rhs),
+      do _ <- symbol "~="; _ <- semicolon; return (StmtBNotEq lhs),
       StmtExp lhs <$ optional semicolon
     ]
 
@@ -141,6 +142,7 @@ forAssignP = locatedP locatedStmt $ do
       do rhs <- symbol "&=" *> expP; return (StmtBAndEq lhs rhs),
       do rhs <- symbol "|=" *> expP; return (StmtBOrEq lhs rhs),
       do rhs <- symbol "%=" *> expP; return (StmtModEq lhs rhs),
+      do _ <- symbol "~="; return (StmtBNotEq lhs),
       return (StmtExp lhs)
     ]
 

--- a/src/Solcore/Frontend/Pretty/TreePretty.hs
+++ b/src/Solcore/Frontend/Pretty/TreePretty.hs
@@ -283,6 +283,8 @@ instance Pretty Stmt where
     hsep [ppr e1, text "|=", ppr e2]
   ppr (StmtModEq e1 e2) =
     hsep [ppr e1, text "%=", ppr e2]
+  ppr (StmtBNotEq e1) =
+    hsep [ppr e1, text "~="]
   ppr (Let c n ty m) =
     text "let" <+> ppr n <+> pprOptTy c ty <+> pprInitOpt m
   ppr (Block body) =
@@ -332,6 +334,7 @@ pprForClause (StmtBXorEq e1 e2) = hsep [ppr e1, text "^=", ppr e2]
 pprForClause (StmtBAndEq e1 e2) = hsep [ppr e1, text "&=", ppr e2]
 pprForClause (StmtBOrEq e1 e2) = hsep [ppr e1, text "|=", ppr e2]
 pprForClause (StmtModEq e1 e2) = hsep [ppr e1, text "%=", ppr e2]
+pprForClause (StmtBNotEq e1) = hsep [ppr e1, text "~="]
 pprForClause (Let ct n ty m) = text "let" <+> ppr n <+> pprOptTy ct ty <+> pprForInitOpt m
 pprForClause (StmtExp e) = ppr e
 pprForClause EmptyStmt = empty
@@ -431,6 +434,8 @@ instance Pretty Exp where
     hsep [ppr e1, text "||", ppr e2]
   ppr (ExpLNot e1) =
     hsep [text "!", ppr e1]
+  ppr (ExpBNot e1) =
+    hsep [text "~", ppr e1]
   ppr (ExpCond e1 e2 e3) =
     hsep
       [ text "if",

--- a/src/Solcore/Frontend/Syntax/NameResolution.hs
+++ b/src/Solcore/Frontend/Syntax/NameResolution.hs
@@ -386,6 +386,8 @@ instance Resolve S.Stmt where
     locatedLike s locatedStmt <$> ((:=) <$> resolve lhs <*> resolve (S.ExpBOr lhs rhs))
   resolve s@(S.StmtModEq lhs rhs) =
     locatedLike s locatedStmt <$> ((:=) <$> resolve lhs <*> resolve (S.ExpModulo lhs rhs))
+  resolve s@(S.StmtBNotEq lhs) =
+    locatedLike s locatedStmt <$> ((:=) <$> resolve lhs <*> resolve (S.ExpBNot lhs))
   resolve s@(S.Let c n mt me) =
     locatedLike s locatedStmt <$> do
       mt' <- resolve mt `wrapError` s
@@ -853,6 +855,11 @@ resolveExp c@(S.ExpBOr e1 e2) =
     e2' <- resolve e2 `wrapError` c
     let fun = QualName (Name "BitOr") "bor"
     pure $ Call Nothing fun [e1', e2']
+resolveExp c@(S.ExpBNot e) =
+  do
+    e' <- resolve e `wrapError` c
+    let fun = QualName (Name "BitNot") "bnot"
+    pure $ Call Nothing fun [e']
 resolveExp c@(S.ExpIndexed array idx) = do
   arr' <- resolve array `wrapError` c
   idx' <- resolve idx `wrapError` c

--- a/src/Solcore/Frontend/Syntax/SyntaxTree.hs
+++ b/src/Solcore/Frontend/Syntax/SyntaxTree.hs
@@ -391,6 +391,7 @@ data Stmt
   | StmtBAndEqWithLocation NodeLocation Exp Exp -- e1 &= e2
   | StmtBOrEqWithLocation NodeLocation Exp Exp -- e1 |= e2
   | StmtModEqWithLocation NodeLocation Exp Exp -- e1 %= e2
+  | StmtBNotEqWithLocation NodeLocation Exp -- e ~= (in-place bitwise NOT, i.e. e := ~e)
   | LetWithLocation NodeLocation Bool Name (Maybe Ty) (Maybe Exp) -- local variable; Bool is True when 'comptime' modifier is present
   | BlockWithLocation NodeLocation Body -- lexical block
   | StmtExpWithLocation NodeLocation Exp -- expression level statements
@@ -438,6 +439,11 @@ pattern StmtModEq :: Exp -> Exp -> Stmt
 pattern StmtModEq lhs rhs <- StmtModEqWithLocation _ lhs rhs
   where
     StmtModEq lhs rhs = StmtModEqWithLocation unlocatedNode lhs rhs
+
+pattern StmtBNotEq :: Exp -> Stmt
+pattern StmtBNotEq lhs <- StmtBNotEqWithLocation _ lhs
+  where
+    StmtBNotEq lhs = StmtBNotEqWithLocation unlocatedNode lhs
 
 pattern Let :: Bool -> Name -> Maybe Ty -> Maybe Exp -> Stmt
 pattern Let ct n ty value <- LetWithLocation _ ct n ty value
@@ -494,7 +500,7 @@ pattern EmptyStmt <- EmptyStmtWithLocation _
   where
     EmptyStmt = EmptyStmtWithLocation unlocatedNode
 
-{-# COMPLETE Assign, StmtPlusEq, StmtMinusEq, StmtBXorEq, StmtBAndEq, StmtBOrEq, StmtModEq, Let, Block, StmtExp, Return, Match, Asm, If, For, Break, Continue, EmptyStmt #-}
+{-# COMPLETE Assign, StmtPlusEq, StmtMinusEq, StmtBXorEq, StmtBAndEq, StmtBOrEq, StmtModEq, StmtBNotEq, Let, Block, StmtExp, Return, Match, Asm, If, For, Break, Continue, EmptyStmt #-}
 
 type Body = [Stmt]
 
@@ -518,6 +524,9 @@ locatedStmt sourceSpan (StmtBOrEq lhs rhs) = StmtBOrEqWithLocation location lhs 
   where
     location = locatedNode sourceSpan
 locatedStmt sourceSpan (StmtModEq lhs rhs) = StmtModEqWithLocation location lhs rhs
+  where
+    location = locatedNode sourceSpan
+locatedStmt sourceSpan (StmtBNotEq lhs) = StmtBNotEqWithLocation location lhs
   where
     location = locatedNode sourceSpan
 locatedStmt sourceSpan (Let ct n ty value) = LetWithLocation location ct n ty value
@@ -549,6 +558,8 @@ instance HasSourceSpan Stmt where
     firstSourceSpan [sourceSpanOf location, sourceSpanOf lhs, sourceSpanOf rhs]
   sourceSpanOf (StmtModEqWithLocation location lhs rhs) =
     firstSourceSpan [sourceSpanOf location, sourceSpanOf lhs, sourceSpanOf rhs]
+  sourceSpanOf (StmtBNotEqWithLocation location lhs) =
+    firstSourceSpan [sourceSpanOf location, sourceSpanOf lhs]
   sourceSpanOf (LetWithLocation location _ n ty value) =
     firstSourceSpan [sourceSpanOf location, sourceSpanOf n, sourceSpanOf ty, sourceSpanOf value]
   sourceSpanOf (BlockWithLocation location body) =
@@ -610,6 +621,7 @@ data Exp
   | ExpLAndWithLocation NodeLocation Exp Exp -- e1 && e2
   | ExpLOrWithLocation NodeLocation Exp Exp -- e1 || e2
   | ExpLNotWithLocation NodeLocation Exp -- ! e
+  | ExpBNotWithLocation NodeLocation Exp -- ~ e
   | ExpCondWithLocation NodeLocation Exp Exp Exp -- if e1 then e2 else e3
   | ExpAtWithLocation NodeLocation Ty -- proxy sugar
   deriving (Eq, Ord, Show, Data, Typeable)
@@ -734,6 +746,11 @@ pattern ExpLNot exp <- ExpLNotWithLocation _ exp
   where
     ExpLNot exp = ExpLNotWithLocation unlocatedNode exp
 
+pattern ExpBNot :: Exp -> Exp
+pattern ExpBNot exp <- ExpBNotWithLocation _ exp
+  where
+    ExpBNot exp = ExpBNotWithLocation unlocatedNode exp
+
 pattern ExpCond :: Exp -> Exp -> Exp -> Exp
 pattern ExpCond cond thenExp elseExp <- ExpCondWithLocation _ cond thenExp elseExp
   where
@@ -744,7 +761,7 @@ pattern ExpAt ty <- ExpAtWithLocation _ ty
   where
     ExpAt ty = ExpAtWithLocation unlocatedNode ty
 
-{-# COMPLETE Lit, ExpName, ExpVar, ExpDotName, Lam, TyExp, ExpIndexed, ExpPlus, ExpMinus, ExpTimes, ExpDivide, ExpModulo, ExpBXor, ExpBAnd, ExpBOr, ExpLT, ExpGT, ExpLE, ExpGE, ExpEE, ExpNE, ExpLAnd, ExpLOr, ExpLNot, ExpCond, ExpAt #-}
+{-# COMPLETE Lit, ExpName, ExpVar, ExpDotName, Lam, TyExp, ExpIndexed, ExpPlus, ExpMinus, ExpTimes, ExpDivide, ExpModulo, ExpBXor, ExpBAnd, ExpBOr, ExpLT, ExpGT, ExpLE, ExpGE, ExpEE, ExpNE, ExpLAnd, ExpLOr, ExpLNot, ExpBNot, ExpCond, ExpAt #-}
 
 locatedExp :: SourceSpan -> Exp -> Exp
 locatedExp sourceSpan (Lit lit) = LitWithLocation location lit
@@ -773,6 +790,7 @@ locatedExp sourceSpan (ExpNE lhs rhs) = ExpNEWithLocation (locatedNode sourceSpa
 locatedExp sourceSpan (ExpLAnd lhs rhs) = ExpLAndWithLocation (locatedNode sourceSpan) lhs rhs
 locatedExp sourceSpan (ExpLOr lhs rhs) = ExpLOrWithLocation (locatedNode sourceSpan) lhs rhs
 locatedExp sourceSpan (ExpLNot exp) = ExpLNotWithLocation (locatedNode sourceSpan) exp
+locatedExp sourceSpan (ExpBNot exp) = ExpBNotWithLocation (locatedNode sourceSpan) exp
 locatedExp sourceSpan (ExpCond cond thenExp elseExp) = ExpCondWithLocation (locatedNode sourceSpan) cond thenExp elseExp
 locatedExp sourceSpan (ExpAt ty) = ExpAtWithLocation (locatedNode sourceSpan) ty
 
@@ -823,6 +841,8 @@ instance HasSourceSpan Exp where
   sourceSpanOf (ExpLOrWithLocation location lhs rhs) =
     firstSourceSpan [sourceSpanOf location, sourceSpanOf lhs, sourceSpanOf rhs]
   sourceSpanOf (ExpLNotWithLocation location exp) =
+    firstSourceSpan [sourceSpanOf location, sourceSpanOf exp]
+  sourceSpanOf (ExpBNotWithLocation location exp) =
     firstSourceSpan [sourceSpanOf location, sourceSpanOf exp]
   sourceSpanOf (ExpCondWithLocation location cond thenExp elseExp) =
     firstSourceSpan [sourceSpanOf location, sourceSpanOf cond, sourceSpanOf thenExp, sourceSpanOf elseExp]

--- a/std/std.solc
+++ b/std/std.solc
@@ -14,6 +14,7 @@ export {
   ArrayPush,
   Assign,
   BitAnd,
+  BitNot,
   BitOr,
   BitXor,
   Bounded,
@@ -386,6 +387,10 @@ forall t . class t:BitXor {
     function bxor(l: t, r: t) -> t;
 }
 
+forall t . class t:BitNot {
+    function bnot(x: t) -> t;
+}
+
 forall t . class t:Bounded {
   function minVal() -> t;
   function maxVal() -> t;
@@ -532,6 +537,12 @@ instance word:BitXor {
     }
 }
 
+instance word:BitNot {
+    function bnot(x: word) -> word {
+        return bnotWord(x);
+    }
+}
+
 instance integer : Eq {
   function eq(x : integer, y : integer) -> bool {
     return integerEq(x, y);
@@ -654,6 +665,12 @@ instance uint256:BitOr {
 instance uint256:BitXor {
   function bxor(x : uint256, y : uint256) -> uint256 {
     return Typedef.abs(BitXor.bxor(Typedef.rep(x), Typedef.rep(y)));
+  }
+}
+
+instance uint256:BitNot {
+  function bnot(x : uint256) -> uint256 {
+    return Typedef.abs(BitNot.bnot(Typedef.rep(x)));
   }
 }
 

--- a/test/examples/cases/bitwise.solc
+++ b/test/examples/cases/bitwise.solc
@@ -3,8 +3,9 @@ pragma no-patterson-condition ;
 pragma no-coverage-condition ;
 pragma no-bounded-variable-condition ;
 
-// Exercises the `^` / `&` / `|` operators, the `^=` / `&=` / `|=`
-// compound assignments, and the bxorWord / bandWord / borWord constant
+// Exercises the `^` / `&` / `|` binary operators, the unary `~`, the
+// `^=` / `&=` / `|=` compound assignments and the unary `~=` in-place
+// complement, plus the bxorWord / bandWord / borWord / bnotWord constant
 // folding (mirrors gtWord).
 function fxor(x: word, y: word) -> word {
   let acc : word = x ^ y;
@@ -19,7 +20,16 @@ function fbitwise(x: word, y: word) -> word {
   return acc | 0;    // identity: a | 0 == a
 }
 
+// `~x` complements every bit, so `~(~x) == x` and `x & ~0 == x` (`~0` is
+// all ones, the AND identity).
+function fnot(x: word) -> word {
+  let acc : word = ~x;   // acc = ~x
+  acc ~=;                // acc = ~(~x) == x   (in-place `~=`)
+  return acc & ~0;       // identity: a & ~0 == a
+}
+
 contract Bitwise {
-  // fxor(5, 3) == 3, fbitwise(6, 3) == 2, 3 ^ 2 == 1 — folded at compile time.
-  public function main() -> word { return fxor(5, 3) ^ fbitwise(6, 3); }
+  // fxor(5, 3) == 3, fbitwise(6, 3) == 2, fnot(4) == 4;
+  // 3 ^ 2 ^ 4 == 5 — folded at compile time.
+  public function main() -> word { return fxor(5, 3) ^ fbitwise(6, 3) ^ fnot(4); }
 }

--- a/test/examples/dispatch/basic.json
+++ b/test/examples/dispatch/basic.json
@@ -145,6 +145,30 @@
       },
       {
         "input": {
+          "comment": "bnot1(uint256)(uint256) 10 -> ~10 = 2^256-1-10 (sugar: unary ~)",
+          "calldata": "0xf7347a59000000000000000000000000000000000000000000000000000000000000000a",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "bnotEq(uint256)(uint256) 10 -> acc=10; acc ~=; == ~10 (sugar: in-place ~=)",
+          "calldata": "0xf384d580000000000000000000000000000000000000000000000000000000000000000a",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
           "comment": "mod2(uint256,uint256)(uint256) 252 10 -> 252 % 10 = 2 (sugar: %)",
           "calldata": "0x519f91cd00000000000000000000000000000000000000000000000000000000000000fc000000000000000000000000000000000000000000000000000000000000000a",
           "value": "0"

--- a/test/examples/dispatch/basic.solc
+++ b/test/examples/dispatch/basic.solc
@@ -69,6 +69,18 @@ contract C {
         return x & y;
     }
 
+    // Unary bitwise NOT via the sugar only: `~` -> BitNot.bnot, and the
+    // in-place `~=` statement, which desugars to `acc := ~acc`.
+    public function bnot1(x : uint256) -> uint256 {
+        return ~x;
+    }
+
+    public function bnotEq(x : uint256) -> uint256 {
+        let acc : uint256 = x;
+        acc ~=;
+        return acc;
+    }
+
     public function mod2(x : uint256, y : uint256) -> uint256 {
         return x % y;
     }


### PR DESCRIPTION
This follows #485 where this was missed. It uses `~` which is the same as Solidity.

Mirror the binary bitwise operators (`&`/`|`/`^` from #485) for the unary bitwise NOT, reusing the existing `bnotWord` primitive (already constant-folded via the `not` opcode in MastEval):

- std: add a `BitNot` type class with `word` (backed by `bnotWord`) and `uint256` (via `Typedef.rep`/`abs`) instances, and export the class. Method name `bnot` is kept distinct from the boolean `not` used by `!`.
- Parser: `~` prefix operator (same precedence level as `!`, guarded against `~=`) and the unary `~=` compound assignment.
- AST: `ExpBNot` and `StmtBNotEq` (a single operand — it is unary), with name resolution desugaring `~` -> `BitNot.bnot` and `e ~=` to the in-place `e := ~e`.
- Pretty printer and module type-ref renamer handle the new nodes.
- Test: extend cases/bitwise.solc to exercise `~`, `~=`, and the bnotWord constant folding (`~(~x) == x`, `a & ~0 == a`).

`~` (not `!`) matches Solidity, which uses `~` for bitwise NOT and `!` for logical NOT; `!` is already taken here for logical NOT (`ExpLNot`).