### PR TITLE
std: make erc7201 compile-time over string literals

### DIFF
--- a/src/Solcore/Backend/MastEval.hs
+++ b/src/Solcore/Backend/MastEval.hs
@@ -28,7 +28,8 @@ where
 {- Partial Evaluator for Mast
    Performs compile-time evaluation where possible:
    - Interprets assembly blocks containing supported Yul arithmetic operations
-   - Folds calls to `subWord`, `gtWord`, `bxorWord`, `bandWord`, `borWord`, `eqWord` with literal arguments
+   - Folds calls to `subWord`, `gtWord`, `bxorWord`, `bandWord`, `borWord`, `bnotWord`, `eqWord` with literal arguments
+   - Folds the string-literal builtins `concatLit`, `strlenLit`, `keccakLit`, and `keccakWordLit`
    - Propagates known variable values
    - Inlines simple pure functions with literal arguments
 -}
@@ -490,12 +491,15 @@ evalPrimitive (Name "bandWord") [MastLit (IntLit a), MastLit (IntLit b)] =
   Just (MastLit (IntLit (maskWord (a .&. b))))
 evalPrimitive (Name "borWord") [MastLit (IntLit a), MastLit (IntLit b)] =
   Just (MastLit (IntLit (maskWord (a .|. b))))
+evalPrimitive (Name "bnotWord") [MastLit (IntLit a)] =
+  Just (MastLit (IntLit (maskWord (complement a))))
 evalPrimitive (Name "eqWord") [MastLit (IntLit a), MastLit (IntLit b)] =
   Just $ mkBool (a == b)
 -- String literal primitives (Solidity/Yul semantics):
 -- - treat literals as UTF-8 byte sequences
 -- - strlen returns byte length
 -- - keccak returns the 256-bit big-endian word of keccak256(bytes)
+-- - keccakWord return the 256-bit big-endian word of keccak256(be32(word))
 evalPrimitive (Name "concatLit") [MastLit (StrLit a), MastLit (StrLit b)] =
   Just (MastLit (StrLit (a <> b)))
 evalPrimitive (Name "strlenLit") [MastLit (StrLit s)] =
@@ -503,6 +507,13 @@ evalPrimitive (Name "strlenLit") [MastLit (StrLit s)] =
    in Just (MastLit (IntLit (toInteger (BS.length bs))))
 evalPrimitive (Name "keccakLit") [MastLit (StrLit s)] =
   let bs = TE.encodeUtf8 (T.pack s)
+      digest :: Digest Keccak_256
+      digest = hash bs
+      digestBytes :: BS.ByteString
+      digestBytes = BA.convert digest
+   in Just (MastLit (IntLit (bsToIntegerBE digestBytes)))
+evalPrimitive (Name "keccakWordLit") [MastLit (IntLit n)] =
+  let bs = integerToBE32 n
       digest :: Digest Keccak_256
       digest = hash bs
       digestBytes :: BS.ByteString
@@ -532,6 +543,13 @@ bsToIntegerBE = BS.foldl' step 0
   where
     step :: Integer -> Word8 -> Integer
     step acc w = acc * 256 + fromIntegral w
+
+-- | Encode a 256-bit word as 32 big-endian bytes (EVM word layout).
+integerToBE32 :: Integer -> BS.ByteString
+integerToBE32 n =
+  BS.pack [fromIntegral (m `shiftR` (8 * i)) | i <- [31, 30 .. 0]]
+  where
+    m = maskWord n
 
 -- Construct a boolean value as sum((), ())
 -- true = inr(()), false = inl(())
@@ -1000,10 +1018,12 @@ builtinPureFuns =
       Name "bxorWord",
       Name "bandWord",
       Name "borWord",
+      Name "bnotWord",
       Name "eqWord",
       Name "concatLit",
       Name "strlenLit",
-      Name "keccakLit"
+      Name "keccakLit",
+      Name "keccakWordLit"
     ]
       ++ integerPrimNames
       ++ stringPrimNames

--- a/src/Solcore/Backend/MastEval.hs
+++ b/src/Solcore/Backend/MastEval.hs
@@ -507,18 +507,9 @@ evalPrimitive (Name "strlenLit") [MastLit (StrLit s)] =
    in Just (MastLit (IntLit (toInteger (BS.length bs))))
 evalPrimitive (Name "keccakLit") [MastLit (StrLit s)] =
   let bs = TE.encodeUtf8 (T.pack s)
-      digest :: Digest Keccak_256
-      digest = hash bs
-      digestBytes :: BS.ByteString
-      digestBytes = BA.convert digest
-   in Just (MastLit (IntLit (bsToIntegerBE digestBytes)))
+   in Just (MastLit (IntLit (keccak256BE bs)))
 evalPrimitive (Name "keccakWordLit") [MastLit (IntLit n)] =
-  let bs = integerToBE32 n
-      digest :: Digest Keccak_256
-      digest = hash bs
-      digestBytes :: BS.ByteString
-      digestBytes = BA.convert digest
-   in Just (MastLit (IntLit (bsToIntegerBE digestBytes)))
+  Just (MastLit (IntLit (keccak256BE (integerToBE32 n))))
 -- Integer (comptime-only, unlimited precision) primitives:
 evalPrimitive (Name "wordToInteger") [MastLit (IntLit n)] =
   Just (MastLit (IntLit n)) -- value-level identity
@@ -550,6 +541,10 @@ integerToBE32 n =
   BS.pack [fromIntegral (m `shiftR` (8 * i)) | i <- [31, 30 .. 0]]
   where
     m = maskWord n
+
+-- | keccak256 of a byte string, returned as a big-endian integer word.
+keccak256BE :: BS.ByteString -> Integer
+keccak256BE bs = bsToIntegerBE (BA.convert (hash bs :: Digest Keccak_256))
 
 -- Construct a boolean value as sum((), ())
 -- true = inr(()), false = inl(())

--- a/std/std.solc
+++ b/std/std.solc
@@ -89,6 +89,7 @@ export {
   hash2,
   keccak256_,
   keccakLit,
+  keccakWordLit,
   le,
   lidx,
   loadBytesFromStorage,
@@ -1072,7 +1073,15 @@ function strlenLit(comptime a: string) -> word {
   return 0;
 }
 
+// Keccak-256 hash of the string-literal as UTF-8 bytes.
 function keccakLit(comptime a: string) -> word {
+  unimplemented(); // Sanity check if folding ignores it.
+  return 0;
+}
+
+// Keccak-256 hash of a word's 32-byte big-endian representation.
+// NOTE: this could be deprecated if we have comptime `to_bytes`.
+function keccakWordLit(comptime a: word) -> word {
   unimplemented(); // Sanity check if folding ignores it.
   return 0;
 }
@@ -2702,17 +2711,11 @@ function ecrecover(hash: bytes32, v: uint256, r: bytes32, s: bytes32) -> address
     return address(res);
 }
 
-// TODO: use string here
-// TODO: eventually this needs to become comptime
-function erc7201(id: memory(bytes)) -> bytes32 {
-//    return keccak256_(to_bytes(keccak256_(id) - 1)) & ~0xff;
-    return Typedef.abs(
-        Typedef.rep(
-            keccak256_(
-                to_bytes(bytes32(Typedef.rep(keccak256_(id)) - 1))
-            )
-        ) & ~0xff
-    );
+// ERC-7201 namespaced storage slot, computed entirely at compile time from a
+// string-literal namespace `id`:
+//   keccak256(abi.encode(uint256(keccak256(bytes(id))) - 1)) & ~bytes32(uint256(0xff))
+function erc7201(comptime id: string) -> comptime bytes32 {
+    return bytes32(keccakWordLit(keccakLit(id) - 1) & ~0xff);
 }
 
 forall a . a:MemorySize, a:MemoryPointer => function raw_call(target: address, value: uint256, payload: a) -> (bool, memory(bytes)) {

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -34,6 +34,7 @@ comptime =
       runTestForFile "string-lit-ops.solc" comptimeFolder,
       runTestForFile "string-lit-len.solc" comptimeFolder,
       runTestForFile "string-lit-keccak.solc" comptimeFolder,
+      runTestForFile "erc7201-lit.solc" comptimeFolder,
       runTestForFile "comptime_syntax.solc" comptimeFolder,
       -- comptime verification: positive cases (must compile)
       runTestForFile "ct_param_ok.solc" comptimeFolder,

--- a/test/examples/comptime/erc7201-lit.solc
+++ b/test/examples/comptime/erc7201-lit.solc
@@ -1,0 +1,17 @@
+import std.{*};
+
+// erc7201 is comptime-only: given a string-literal namespace it folds the two
+// nested keccaks and the word arithmetic down to a single bytes32 slot
+// constant, with no runtime hashing.
+contract Erc7201Lit {
+  public function main() -> bytes32 {
+    // keccak256(abi.encode(uint256(keccak256("example.main")) - 1)) & ~0xff
+    // == 0x183a6125c38840424c4a85fa12bab2ab606c4b6d0e7cc73c0c06ba5300eab500
+    return erc7201("example.main");
+  }
+
+  // keccakWordLit on its own: keccak of a word's 32-byte big-endian form.
+  public function wordHash() -> word {
+    return keccakWordLit(0);
+  }
+}

--- a/test/examples/dispatch/hashes.json
+++ b/test/examples/dispatch/hashes.json
@@ -49,13 +49,49 @@
       },
       {
         "input": {
-          "comment": "erc7201_(bytes)(bytes32) with \"example.main\"",
-          "calldata": "cd9e2a5b0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000c6578616d706c652e6d61696e0000000000000000000000000000000000000000",
+          "comment": "keccakWord()(bytes32) -- comptime keccakWordLit(0) == keccak256(bytes32(0))",
+          "calldata": "6c632152",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "erc7201Example()(bytes32) -- comptime erc7201(\"example.main\")",
+          "calldata": "36663f67",
           "value": "0"
         },
         "kind": "call",
         "output": {
           "returndata": "183a6125c38840424c4a85fa12bab2ab606c4b6d0e7cc73c0c06ba5300eab500",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "erc7201Ownable()(bytes32) -- comptime erc7201(\"openzeppelin.storage.Ownable\")",
+          "calldata": "c4bc0281",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c199300",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "erc7201Empty()(bytes32) -- comptime erc7201(\"\")",
+          "calldata": "8fdc47eb",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "4318a0031e4d2f411be9017543511db04d79cf580aaff6bae7539a4a49eacc00",
           "status": "success"
         }
       }

--- a/test/examples/dispatch/hashes.solc
+++ b/test/examples/dispatch/hashes.solc
@@ -25,7 +25,23 @@ contract C {
         return ripemd160(abcBytes());
     }
 
-    public function erc7201_(id: memory(bytes)) -> bytes32 {
-        return erc7201(id);
+    // keccakWordLit folds keccak256 of a word's 32-byte big-endian form at
+    // compile time; keccakWordLit(0) == keccak256(bytes32(0)).
+    public function keccakWord() -> bytes32 {
+        return bytes32(keccakWordLit(0));
+    }
+
+    // ERC-7201 namespaced storage slots, folded to constants at compile time
+    // from the string-literal namespace (no runtime keccak of the id).
+    public function erc7201Example() -> bytes32 {
+        return erc7201("example.main");
+    }
+
+    public function erc7201Ownable() -> bytes32 {
+        return erc7201("openzeppelin.storage.Ownable");
+    }
+
+    public function erc7201Empty() -> bytes32 {
+        return erc7201("");
     }
 }


### PR DESCRIPTION
Rewrite `erc7201` to take a string-literal namespace and fold the ERC-7201 storage slot to a `bytes32` constant at compile time, instead of hashing a runtime `memory(bytes)` id. The signature is `-> comptime bytes32`, and the body uses the `-` / `&` / `~` operator sugar now that word bitwise NOT exists:

    function erc7201(id: string) -> comptime bytes32 {
        return bytes32(keccakWordLit(keccakLit(id) - 1) & ~0xff);
    }

The formula keccak256(abi.encode(uint256(keccak256(id)) - 1)) & ~0xff needs a second keccak over the (word-sized) `- 1` preimage, so add a comptime `keccakWordLit` primitive (keccak of a word's 32-byte big-endian form) as the counterpart to the string-literal `keccakLit`. Also give `bnotWord` a folding rule (placed with the other bitwise word ops) so `~0xff` collapses too; both new primitives are registered in MastEval's pure-builtin set.

Tests:
- dispatch/hashes: replace the runtime `erc7201_(bytes)` call with three zero-arg functions returning the comptime slots for "example.main", "openzeppelin.storage.Ownable" (canonical OZ value) and "".
- comptime/erc7201-lit: new folding test for erc7201 + keccakWordLit.