### PR TITLE
Parse break/continue/leave in inline assembly

### DIFF
--- a/run_contests.sh
+++ b/run_contests.sh
@@ -7,6 +7,7 @@ cd "$root_dir"
 
 bash ./contest.sh test/examples/dispatch/basic.json
 bash ./contest.sh test/examples/dispatch/assembly.json
+bash ./contest.sh test/examples/dispatch/asm_break_continue_leave.json
 bash ./contest.sh test/examples/dispatch/neg.json
 bash ./contest.sh test/examples/dispatch/miniERC20.json
 bash ./contest.sh test/examples/dispatch/Revert.json

--- a/src/Language/Yul/Parser.hs
+++ b/src/Language/Yul/Parser.hs
@@ -87,6 +87,9 @@ yulStmt =
           <$> (pKeyword "switch" *> yulExp)
           <*> many yulCase
           <*> optional (pKeyword "default" *> yulBlock),
+        YBreak <$ pKeyword "break",
+        YContinue <$ pKeyword "continue",
+        YLeave <$ pKeyword "leave",
         try (YAssign <$> commaSep pName <*> (symbol ":=" *> yulExp)),
         YExp <$> yulExp
       ]

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -603,6 +603,7 @@ cases =
       runTestForFile "simpleDiscount.solc" caseFolder,
       runTestForFile "yul-deposit-example.solc" caseFolder,
       runTestForFile "yul-asm-for-body.solc" caseFolder,
+      runTestForFile "yul-asm-break-continue-leave.solc" caseFolder,
       runTestForFile
         "yul-asm-switch-body.solc"
         caseFolder,

--- a/test/examples/cases/yul-asm-break-continue-leave.solc
+++ b/test/examples/cases/yul-asm-break-continue-leave.solc
@@ -1,0 +1,29 @@
+import std.{*};
+
+function yul_asm_break_continue_leave() -> () {
+    let result : word = 0;
+    assembly {
+        function clamp(x) -> y {
+            y := x
+            if gt(x, 3) {
+                y := 3
+                leave
+            }
+        }
+        for { let i := 0 } lt(i, 10) { i := add(i, 1) } {
+            if lt(i, 2) {
+                continue
+            }
+            if gt(i, 5) {
+                break
+            }
+            result := add(result, clamp(i))
+        }
+    }
+}
+
+contract Foo {
+    public function main() -> () {
+        yul_asm_break_continue_leave()
+    }
+}

--- a/test/examples/dispatch/asm_break_continue_leave.json
+++ b/test/examples/dispatch/asm_break_continue_leave.json
@@ -1,0 +1,40 @@
+{
+  "asm_break_continue_leave": {
+    "bytecode": "_CODE",
+    "contract": "C",
+    "tests": [
+      {
+        "input": {
+          "comment": "constructor()",
+          "calldata": "",
+          "value": "0"
+        },
+        "kind": "constructor"
+      },
+      {
+        "input": {
+          "comment": "loopSum()(uint256) -> 14 (continue skips 0,1; break stops at 6; 2+3+4+5)",
+          "calldata": "7ae9260b",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "000000000000000000000000000000000000000000000000000000000000000e",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "clampSum()(uint256) -> 105 (leave early-returns clamp(9)=3; 102+3)",
+          "calldata": "fd339a24",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000069",
+          "status": "success"
+        }
+      }
+    ]
+  }
+}

--- a/test/examples/dispatch/asm_break_continue_leave.solc
+++ b/test/examples/dispatch/asm_break_continue_leave.solc
@@ -1,0 +1,52 @@
+import std.{*};
+import std.dispatch.{*};
+
+// End-to-end (runs on evmone via the testrunner) check that Yul `break`,
+// `continue` and `leave` in inline assembly don't just parse, but actually
+// execute with the right control-flow semantics.
+contract C {
+    constructor() {}
+
+    // `continue` + `break`: sum i over [0, 10), skipping i < 2 (continue) and
+    // stopping once i > 5 (break). So only i in {2,3,4,5} contribute:
+    //   2 + 3 + 4 + 5 = 14
+    // A miscompiled `continue` would also add 0 and 1 (=> 15); a broken `break`
+    // would keep going and add 6..9 as well.
+    public function loopSum() -> uint256 {
+        let result : word;
+        assembly {
+            result := 0
+            for { let i := 0 } lt(i, 10) { i := add(i, 1) } {
+                if lt(i, 2) {
+                    continue
+                }
+                if gt(i, 5) {
+                    break
+                }
+                result := add(result, i)
+            }
+        }
+        return uint256(result);
+    }
+
+    // `leave`: clamp(x) returns 3 early (via `leave`) when x > 3, skipping the
+    // `+ 100`; otherwise it returns x + 100.
+    //   clamp(2) = 102, clamp(9) = 3  =>  102 + 3 = 105
+    // A broken `leave` would fall through and add 100 to the x > 3 branch too
+    // (clamp(9) => 103 => total 205).
+    public function clampSum() -> uint256 {
+        let result : word;
+        assembly {
+            function clamp(x) -> y {
+                y := x
+                if gt(x, 3) {
+                    y := 3
+                    leave
+                }
+                y := add(y, 100)
+            }
+            result := add(clamp(2), clamp(9))
+        }
+        return uint256(result);
+    }
+}


### PR DESCRIPTION
yulStmt's choice had no clause for break/continue/leave, so these Yul
statements were unparseable: `break` inside an asm `for` fell through to
YExp (YIdent "break") and later died with an "undefined name" error.
Every other stage already supported them (tcYulStmt, checkAsmStmt,
renameYulStmts, substYulStmt) and the AST/pretty-printer already had the
YBreak/YContinue/YLeave constructors — only the parser was missing.

Add the three keyword clauses to yulStmt (before the YExp fallback so the
keywords aren't swallowed as identifiers) and a regression test exercising
all three inside an inline-assembly block.