### PR TITLE
Make stop/invalid/selfdestruct terminators polymorphic

### DIFF
--- a/src/Solcore/Primitives/Primitives.hs
+++ b/src/Solcore/Primitives/Primitives.hs
@@ -294,7 +294,10 @@ tupleTyFromList (t1 : ts) = pair t1 (tupleTyFromList ts)
 -- Builtins as of Osaka
 yulPrimOps :: [(Name, Scheme)]
 yulPrimOps =
-  [ (Name "stop", monotype unit),
+  [ -- Terminators never return control to their caller, so their result type
+    -- is polymorphic: an 'assembly' block ending in one can stand as the last
+    -- statement of a value-returning function (see 'return'/'revert' below).
+    (Name "stop", Forall [aVar] ([] :=> (TyVar aVar))),
     (Name "add", monotype (word :-> word :-> word)),
     (Name "mul", monotype (word :-> word :-> word)),
     (Name "sub", monotype (word :-> word :-> word)),
@@ -373,8 +376,8 @@ yulPrimOps =
     (Name "create2", monotype (word :-> word :-> word :-> word :-> word)),
     (Name "staticcall", monotype (funtype (words 6) word)),
     (Name "revert", Forall [aVar] ([] :=> (word :-> word :-> (TyVar aVar)))),
-    (Name "invalid", monotype unit),
-    (Name "selfdestruct", monotype (word :-> unit)),
+    (Name "invalid", Forall [aVar] ([] :=> (TyVar aVar))),
+    (Name "selfdestruct", Forall [aVar] ([] :=> (word :-> (TyVar aVar)))),
     -- Yul-specific
     (Name "datasize", monotype (string :-> word)),
     (Name "dataoffset", monotype (string :-> word)),

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -289,7 +289,8 @@ opcodes :: TestTree
 opcodes =
   testGroup
     "Files for opcodes wrappers"
-    [ runTestForFile "all-shapes.solc" opcodesFolder
+    [ runTestForFile "all-shapes.solc" opcodesFolder,
+      runTestForFile "terminators.solc" opcodesFolder
     ]
   where
     opcodesFolder = "./test/examples/opcodes"

--- a/test/examples/opcodes/terminators.solc
+++ b/test/examples/opcodes/terminators.solc
@@ -1,0 +1,40 @@
+// Terminators (stop, invalid, selfdestruct, revert) never return control, so
+// a bare 'assembly' block ending in one is allowed as the last statement of a
+// value-returning function — its polymorphic result unifies with any return
+// type. Regression test for stop/invalid/selfdestruct being made polymorphic
+// like revert/return (see Primitives.hs 'yulPrimOps').
+
+forall a.function viaStop() -> a {
+  assembly {
+    stop()
+  }
+}
+
+forall a.function viaInvalid() -> a {
+  assembly {
+    invalid()
+  }
+}
+
+forall a.function viaSelfdestruct(beneficiary: word) -> a {
+  assembly {
+    selfdestruct(beneficiary)
+  }
+}
+
+forall a.function viaRevert() -> a {
+  assembly {
+    revert(0, 0)
+  }
+}
+
+function useWord(w: word) -> () {}
+
+contract Terminators {
+  public function main() -> () {
+    useWord(viaStop());
+    useWord(viaInvalid());
+    useWord(viaSelfdestruct(0));
+    useWord(viaRevert());
+  }
+}


### PR DESCRIPTION
The Yul builtins `stop`, `invalid`, and `selfdestruct` were typed as `monotype unit`, while the other terminators `return` and `revert` are polymorphic in their result (`forall a. ... -> a`). All five never return control to the caller, but only the polymorphic ones could stand as the last statement of a value-returning function: `assembly { revert(0,0) }` worked as a tail terminator whereas `assembly { stop() }` did not.

Give the three unit-typed terminators the same polymorphic result type so their result unifies with any enclosing return type, mirroring `return`/`revert`. The Hull backend keeps them at `TUnit` (as it already does for `return`/`revert`), so only the frontend inference scheme changes.

Add test/examples/opcodes/terminators.solc exercising all four bare terminators as the tail of value-returning functions.