### PR TITLE
Add `bool:ABIDecode` instance

### DIFF
--- a/std/dispatch.solc
+++ b/std/dispatch.solc
@@ -52,6 +52,7 @@ instance uint256 : SigString { function sigStr(x:Proxy(uint256)) -> string { "ui
 instance bytes32 : SigString { function sigStr(x:Proxy(bytes32)) -> string { "bytes32" }}
 instance bytes4 : SigString { function sigStr(x:Proxy(bytes4)) -> string { "bytes4" }}
 instance address : SigString { function sigStr(x:Proxy(address)) -> string { "address" }}
+instance bool : SigString { function sigStr(x:Proxy(bool)) -> string { "bool" }}
 instance memory(string) : SigString { function sigStr(x:Proxy(memory(string))) -> string { "string" }}
 instance memory(bytes) : SigString { function sigStr(x:Proxy(memory(bytes))) -> string { "bytes" }}
 instance ():SigString { function sigStr(x:Proxy(())) -> string { "" } }

--- a/std/std.solc
+++ b/std/std.solc
@@ -1553,6 +1553,15 @@ forall reader . reader:WordReader => instance ABIDecoder(bytes4, reader):ABIDeco
     }
 }
 
+// ABI Decoding for bool
+// bool is a builtin (not a Typedef(word)), so it round-trips through word via
+// tobool, mirroring the bool:ABIEncode instance which uses frombool.
+forall reader . reader:WordReader => instance ABIDecoder(bool, reader):ABIDecode(bool) {
+    function decode(ptr:ABIDecoder(bool, reader), currentHeadOffset:word) -> bool {
+        return tobool(WordReader.read(WordReader.advance(ptr, currentHeadOffset)));
+    }
+}
+
 // ABI Decoding for address
 forall reader . reader:WordReader => instance ABIDecoder(address, reader):ABIDecode(address) {
     function decode(ptr:ABIDecoder(address, reader), currentHeadOffset:word) -> address {

--- a/std/std.solc
+++ b/std/std.solc
@@ -1558,7 +1558,9 @@ forall reader . reader:WordReader => instance ABIDecoder(bytes4, reader):ABIDeco
 // tobool, mirroring the bool:ABIEncode instance which uses frombool.
 forall reader . reader:WordReader => instance ABIDecoder(bool, reader):ABIDecode(bool) {
     function decode(ptr:ABIDecoder(bool, reader), currentHeadOffset:word) -> bool {
-        return tobool(WordReader.read(WordReader.advance(ptr, currentHeadOffset)));
+        let v = WordReader.read(WordReader.advance(ptr, currentHeadOffset));
+        require(v <= 1, Error(0x0557dbbf)); // DirtyHigherBitsForBool()
+        return tobool(v);
     }
 }
 

--- a/test/examples/dispatch/basic.json
+++ b/test/examples/dispatch/basic.json
@@ -397,14 +397,14 @@
       },
       {
         "input": {
-          "comment": "id_bool(bool)(bool) non-0/1 input 2 -> tobool clamps any nonzero to true -> 1",
+          "comment": "id_bool(bool)(bool) non-0/1 input 2 -> DirtyHigherBitsForBool()",
           "calldata": "0x664a0de40000000000000000000000000000000000000000000000000000000000000002",
           "value": "0"
         },
         "kind": "call",
         "output": {
-          "returndata": "0000000000000000000000000000000000000000000000000000000000000001",
-          "status": "success"
+          "returndata": "0557dbbf",
+          "status": "failure"
         }
       },
       {

--- a/test/examples/dispatch/basic.json
+++ b/test/examples/dispatch/basic.json
@@ -373,6 +373,42 @@
       },
       {
         "input": {
+          "comment": "id_bool(bool)(bool) true -> true",
+          "calldata": "0x664a0de40000000000000000000000000000000000000000000000000000000000000001",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000001",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "id_bool(bool)(bool) false -> false",
+          "calldata": "0x664a0de40000000000000000000000000000000000000000000000000000000000000000",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000000",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
+          "comment": "id_bool(bool)(bool) non-0/1 input 2 -> tobool clamps any nonzero to true -> 1",
+          "calldata": "0x664a0de40000000000000000000000000000000000000000000000000000000000000002",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000001",
+          "status": "success"
+        }
+      },
+      {
+        "input": {
           "comment": "id_pair()(uint256,uint256)",
           "calldata": "5880a1a0",
           "value": "0"

--- a/test/examples/dispatch/basic.solc
+++ b/test/examples/dispatch/basic.solc
@@ -165,6 +165,11 @@ contract C {
         return a;
     }
 
+    // Exercises bool:ABIDecode (argument) and bool:ABIEncode (return).
+    public function id_bool(b: bool) -> bool {
+        return b;
+    }
+
     public function id_pair() -> (uint256, uint256) {
         return (uint256(7), uint256(11));
     }


### PR DESCRIPTION
Add an ABIDecoder(bool, reader):ABIDecode(bool) instance so public functions can take bool arguments. bool is a builtin (not a Typedef(word)), so decode round-trips through word via tobool, mirroring the existing bool:ABIEncode instance that uses frombool.

Cover the new instance end-to-end with an id_bool(bool) entry point in the basic dispatch contract and true/false round-trip cases in basic.json.

Fixes #542.