### PR TITLE
Clear ecrecover return-data scratch before the precompile call

### DIFF
--- a/std/std.solc
+++ b/std/std.solc
@@ -2565,6 +2565,12 @@ function ecrecover(hash: bytes32, v: uint256, r: bytes32, s: bytes32) -> address
     mstore(ptr + 32, v_);
     mstore(ptr + 64, r_);
     mstore(ptr + 96, s_);
+    // Clear the [0, 32] scratch space that receives the return data. On a
+    // failed recovery (e.g. v not in {27, 28}, or the generic could-not-recover
+    // case) the precompile still reports success but returns no data, leaving
+    // the output area untouched. Without this, a stale non-zero value would
+    // slip past the `res != 0` check below and yield a bogus address.
+    mstore(0, 0);
     let ret = staticcall(gas(), 1, ptr, 128, 0, 32);
     require(ret != 0, Error(0x578763f7)); // ECRecoverCallFailed()
     let res = mload(0);

--- a/test/examples/dispatch/ecrecover.json
+++ b/test/examples/dispatch/ecrecover.json
@@ -34,6 +34,18 @@
           "returndata": "4fbfae63",
           "status": "failure"
         }
+      },
+      {
+        "input": {
+          "comment": "recoverFailBadV()(address)",
+          "calldata": "5dc458b7",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "returndata": "4fbfae63",
+          "status": "failure"
+        }
       }
     ]
   }

--- a/test/examples/dispatch/ecrecover.solc
+++ b/test/examples/dispatch/ecrecover.solc
@@ -21,4 +21,19 @@ contract EcrecoverTest {
         let s: bytes32 = bytes32(0x3523e7d34da277c59af090e44cebddb10b73be11780f028d02cf5ae5f24109fc);
         return ecrecover(h, v, r, s);
     }
+
+    // v = 1 is not a valid recovery id (only 27 and 28 are accepted). The
+    // precompile still succeeds (ret != 0) but returns empty output, leaving the
+    // [0, 32] return-data area untouched. Only because `ecrecover` now clears
+    // that area with `mstore(0, 0)` before the call does `res` reliably read as
+    // 0 and hit the `ECRecoverFailed()` (0x4fbfae63) revert path — without the
+    // clear a stale non-zero word would be returned as a bogus address. `r` and
+    // `s` are the well-formed values from `recover()` so only `v` is at fault.
+    public function recoverFailBadV() -> address {
+        let h: bytes32 = bytes32(0xaabbccddeeff00112233445566778899aabbccddeeff00112233445566778899);
+        let v: uint256 = uint256(1);
+        let r: bytes32 = bytes32(0xb3ba6dd3757d18f28736e84b1296af85362b7bdf4548710733c6325abf95311d);
+        let s: bytes32 = bytes32(0x3523e7d34da277c59af090e44cebddb10b73be11780f028d02cf5ae5f24109fc);
+        return ecrecover(h, v, r, s);
+    }
 }

--- a/test/testrunner/EVMHost.cpp
+++ b/test/testrunner/EVMHost.cpp
@@ -555,6 +555,22 @@ evmc::Result EVMHost::precompileECRecover(evmc_message const& _message) noexcept
 			}
 		},
 		{
+			// Same hash/r/s as the recover() success case but with v = 1, which
+			// is not a valid recovery id (only 27 and 28 are). The precompile
+			// succeeds with empty output (test/examples/dispatch/ecrecover
+			// recoverFailBadV()).
+			fromHex(
+				"aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+				"0000000000000000000000000000000000000000000000000000000000000001"
+				"b3ba6dd3757d18f28736e84b1296af85362b7bdf4548710733c6325abf95311d"
+				"3523e7d34da277c59af090e44cebddb10b73be11780f028d02cf5ae5f24109fc"
+			),
+			{
+				fromHex(""),
+				gas_cost
+			}
+		},
+		{
 			// EIP-712 canonical "Mail" example digest (test/examples/dispatch/eip712).
 			fromHex(
 				"be609aee343fb3c4b28e1df9e632fca64fcfaede20f02e86244efddf30957bd2"


### PR DESCRIPTION
The ecrecover precompile reports success (ret != 0) even when it recovers nothing — e.g. when v is not 27 or 28, or in the generic could-not-recover case — but in that case it returns empty output, so the [0, 32] output area passed to staticcall is left untouched. `res = mload(0)` then reads whatever stale word was already there; a non-zero value slips past the `res != 0` guard and ecrecover returns a bogus address instead of reverting.

Add `mstore(0, 0)` before the call so the scratch area reads back as 0 on an empty return, making the `ECRecoverFailed()` guard fire reliably.

Add a `recoverFailBadV()` test (v = 1, well-formed r/s) covering the v not in {27, 28} path; the existing `recoverFail()` (r = 0) test covers the generic could-not-recover path.

Fixes #543.