### PR TITLE
Exclude memory-op asm from the comptime purity notion

### DIFF
--- a/doc/comptime-asm.md
+++ b/doc/comptime-asm.md
@@ -25,15 +25,44 @@ type YulState = Map.Map Name Integer  -- variable bindings only (no memory yet)
 
 ### Purity classification
 
-`asmIsInterpretable :: [YulStmt] -> Bool` is used by `stmtIsPure` to decide whether
-a function whose body contains an asm block belongs in `pureFuns`.  This is load-bearing
-for comptime-check soundness: a function containing `sload` must **not** enter `pureFuns`,
-or `isComptime` in `Backend/ComptimeCheck.hs` would wrongly classify its result as comptime.
+`asmIsInterpretableWith :: Bool -> [YulStmt] -> Bool` is used by `stmtIsPure` to decide
+whether a function whose body contains an asm block belongs in a purity set.  This is
+load-bearing for comptime-check soundness: a function containing `sload` must **not**
+enter any purity set, or `isComptime` in `Backend/ComptimeCheck.hs` would wrongly
+classify its result as comptime.
 
-The rule: `stmtIsPure _ (MastAsm stmts) = asmIsInterpretable stmts`.
+The rule: `stmtIsPure memOk _ (MastAsm stmts) = asmIsInterpretableWith memOk stmts`.
 
 Optimistic treatment (`True` for all asm) breaks negative tests because it lets
-`sloadWord` into `pureFuns`.
+`sloadWord` into the purity set.
+
+### Two purity notions (`memOk`)
+
+There are **two** purity sets, differing only in whether memory ops
+(`mload`/`mstore`/`mstore8`) count as interpretable — the `memOk` flag:
+
+- **`computePureFuns` (`memOk = True`)** — drives partial-evaluation inlining.
+  Memory ops are interpretable here because the Yul interpreter only *executes*
+  them under `envComptimeMode`, and `mload` succeeds only for bytes written
+  earlier in the **same** evaluation context (`mloadWord` returns `Nothing`
+  otherwise). Folding a memory-touching function is therefore gated *dynamically*
+  and stays sound.
+
+- **`computeComptimePureFuns` (`memOk = False`)** — drives the MAST comptime check.
+  `isComptime` classifies expressions *structurally*, with none of that runtime
+  gating. A call to an `mload`-reading function that PE could **not** fold survives
+  to the comptime check; if it were treated as pure, `isComptime` would wrongly
+  label its result comptime even though it depends on runtime memory. So memory-op
+  functions are excluded from this stricter set.
+
+  This is exactly right: a legitimately foldable memory chain (e.g. `mstore` then
+  `mload` of the same address, as in `ct_asm_mem.solc`) is already collapsed to a
+  literal by PE *before* the comptime check runs — so `isComptime` sees a literal,
+  not a call, and the strictness never rejects it. An **unfoldable** memory read
+  (e.g. `mload` of an address never written in context, as in
+  `ct_asm_mload_runtime.solc`) survives as a call and is correctly rejected.
+
+  Storage ops (`sload`, …) are never interpretable, regardless of `memOk`.
 
 ### TypeReg
 
@@ -352,9 +381,11 @@ Note: `mload` is an interpretable *expression* (returns a value), while
 
 ### Memory ops are gated on `envComptimeMode`
 
-`asmIsInterpretable` classifies `mstore`/`mstore8`/`mload` as interpretable (so
-functions using them remain in `pureFuns`), but the evaluator only *executes* them
-when `envComptimeMode = True`:
+`asmIsInterpretable` (i.e. `asmIsInterpretableWith True`) classifies
+`mstore`/`mstore8`/`mload` as interpretable (so functions using them remain in the
+PE `pureFuns`; the stricter comptime set — `asmIsInterpretableWith False` — excludes
+them, see "Two purity notions" above), but the evaluator only *executes* them when
+`envComptimeMode = True`:
 
 - **`mload`** in `evalYulExp`: returns `Nothing` if `envComptimeMode = False`.
 - **`mstore`/`mstore8`** in `evalYulStmt`: return `Nothing` (abort the block) if

--- a/src/Solcore/Backend/ComptimeCheck.hs
+++ b/src/Solcore/Backend/ComptimeCheck.hs
@@ -7,7 +7,10 @@ module Solcore.Backend.ComptimeCheck (checkComptime) where
      1. Classification: is an expression statically comptime?
         A value is comptime if it is a literal, a comptime-bound variable,
         or a call to a pure function whose arguments are all comptime.
-        Purity is determined by computePureFuns (MastEval).
+        Purity is determined by computeComptimePureFuns (MastEval), the
+        stricter notion that excludes memory-op (mload/mstore) functions: this
+        classifier is structural, without the runtime gating that makes memory
+        folding sound in the partial evaluator.
 
      2. Constraint checking: annotations must be consistent with reality.
         - A parameter annotated 'comptime' must receive a comptime argument
@@ -22,7 +25,7 @@ module Solcore.Backend.ComptimeCheck (checkComptime) where
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Solcore.Backend.Mast
-import Solcore.Backend.MastEval (FunTable, buildFunTable, computePureFuns)
+import Solcore.Backend.MastEval (FunTable, buildFunTable, computeComptimePureFuns)
 import Solcore.Frontend.Syntax.Name (Name)
 
 -- | Set of variable names known to be comptime in the current scope.
@@ -33,7 +36,7 @@ checkComptime :: MastCompUnit -> Either String ()
 checkComptime cu = mapM_ checkTopDecl (mastTopDecls cu)
   where
     ft = buildFunTable cu
-    pure_ = computePureFuns ft
+    pure_ = computeComptimePureFuns ft
 
     checkTopDecl (MastTContr c) = mapM_ (checkContractDecl ft pure_) (mastContrDecls c)
     checkTopDecl (MastTDataDef _) = Right ()

--- a/src/Solcore/Backend/MastEval.hs
+++ b/src/Solcore/Backend/MastEval.hs
@@ -5,6 +5,7 @@ module Solcore.Backend.MastEval
     FunTable,
     buildFunTable,
     computePureFuns,
+    computeComptimePureFuns,
     -- Evaluation monad (exported for testing)
     EvalEnv (..),
     EvalState (..),
@@ -17,6 +18,7 @@ module Solcore.Backend.MastEval
     evalYulStmt,
     evalYulBlock,
     asmIsInterpretable,
+    asmIsInterpretableWith,
     maskWord,
     mstoreBytes,
     mloadWord,
@@ -1032,8 +1034,36 @@ builtinImpureFuns = Set.fromList [Name "revertLit", memStringFromLitName]
 -- contain no asm and whose every call target is already known-pure.
 -- Self-recursive calls are handled by including the candidate function in
 -- the assumed-pure set when checking its own body.
+--
+-- This is the PE notion of purity: memory ops (mload/mstore/mstore8) count as
+-- interpretable, because the Yul interpreter only *executes* them under
+-- 'envComptimeMode' and 'mload' succeeds only for bytes written earlier in the
+-- SAME evaluation context (mloadWord returns Nothing otherwise). Folding a
+-- memory-touching function is therefore gated dynamically and stays sound.
 computePureFuns :: FunTable -> Set.Set Name
-computePureFuns ft = go builtinPureFuns
+computePureFuns = computePureFunsWith True
+
+-- | Stricter purity used by the MAST comptime check ('ComptimeCheck').
+-- Unlike 'computePureFuns', memory ops (mload/mstore/mstore8) do NOT count as
+-- interpretable, so any function whose asm reads or writes memory is excluded.
+--
+-- Why the two notions must differ: 'isComptime' classifies expressions
+-- *structurally*, with none of the dynamic 'envComptimeMode' / in-context-write
+-- gating that makes memory folding sound during PE. A call to an mload-reading
+-- function that PE could not fold survives to the comptime check; if it were in
+-- pureFuns, 'isComptime' would wrongly label its result comptime even though it
+-- depends on runtime memory. Excluding memory-op functions keeps the classifier
+-- sound: a legitimately foldable memory chain (e.g. mstore then mload of the
+-- same address) is already collapsed to a literal by PE before this check runs,
+-- while an unfoldable memory read survives as a call and is correctly rejected.
+computeComptimePureFuns :: FunTable -> Set.Set Name
+computeComptimePureFuns = computePureFunsWith False
+
+-- | Fixed-point purity computation. @memOk@ selects whether memory ops
+-- (mload/mstore/mstore8) count as interpretable: True for PE
+-- ('computePureFuns'), False for the comptime check ('computeComptimePureFuns').
+computePureFunsWith :: Bool -> FunTable -> Set.Set Name
+computePureFunsWith memOk ft = go builtinPureFuns
   where
     go pureFuns =
       let pureFuns' =
@@ -1043,7 +1073,7 @@ computePureFuns ft = go builtinPureFuns
                     || fname `Set.member` builtinImpureFuns
                     then acc
                     else
-                      if bodyIsPure (Set.insert fname acc) (mastFunBody fd)
+                      if bodyIsPure memOk (Set.insert fname acc) (mastFunBody fd)
                         then Set.insert fname acc
                         else acc
               )
@@ -1053,28 +1083,29 @@ computePureFuns ft = go builtinPureFuns
             then pureFuns
             else go pureFuns'
 
-bodyIsPure :: Set.Set Name -> [MastStmt] -> Bool
-bodyIsPure pureFuns = all (stmtIsPure pureFuns)
+bodyIsPure :: Bool -> Set.Set Name -> [MastStmt] -> Bool
+bodyIsPure memOk pureFuns = all (stmtIsPure memOk pureFuns)
 
-stmtIsPure :: Set.Set Name -> MastStmt -> Bool
+stmtIsPure :: Bool -> Set.Set Name -> MastStmt -> Bool
 -- Asm blocks are pure only if every statement uses a statically interpretable
--- operation. This keeps storage/memory reads (sload, mload, …) out of pureFuns,
--- which is load-bearing for the MAST-level comptime check.
-stmtIsPure _ (MastAsm stmts) = asmIsInterpretable stmts
-stmtIsPure pureFuns (MastLet _ _ _ mInit) = maybe True (expIsPure pureFuns) mInit
-stmtIsPure pureFuns (MastAssign _ e) = expIsPure pureFuns e
-stmtIsPure pureFuns (MastStmtExp e) = expIsPure pureFuns e
-stmtIsPure pureFuns (MastReturn e) = expIsPure pureFuns e
-stmtIsPure pureFuns (MastMatch e alts) =
-  expIsPure pureFuns e && all (bodyIsPure pureFuns . snd) alts
-stmtIsPure pureFuns (MastFor initStmt cond post body) =
-  stmtIsPure pureFuns initStmt
+-- operation. This keeps storage reads (sload, …) out of pureFuns entirely;
+-- memory reads/writes (mload/mstore/mstore8) count only when @memOk@ is True
+-- (PE), never for the comptime check — which is load-bearing for its soundness.
+stmtIsPure memOk _ (MastAsm stmts) = asmIsInterpretableWith memOk stmts
+stmtIsPure _ pureFuns (MastLet _ _ _ mInit) = maybe True (expIsPure pureFuns) mInit
+stmtIsPure _ pureFuns (MastAssign _ e) = expIsPure pureFuns e
+stmtIsPure _ pureFuns (MastStmtExp e) = expIsPure pureFuns e
+stmtIsPure _ pureFuns (MastReturn e) = expIsPure pureFuns e
+stmtIsPure memOk pureFuns (MastMatch e alts) =
+  expIsPure pureFuns e && all (bodyIsPure memOk pureFuns . snd) alts
+stmtIsPure memOk pureFuns (MastFor initStmt cond post body) =
+  stmtIsPure memOk pureFuns initStmt
     && expIsPure pureFuns cond
-    && stmtIsPure pureFuns post
-    && bodyIsPure pureFuns body
-stmtIsPure _ MastBreak = True
-stmtIsPure _ MastContinue = True
-stmtIsPure pureFuns (MastSeq stmts) = bodyIsPure pureFuns stmts
+    && stmtIsPure memOk pureFuns post
+    && bodyIsPure memOk pureFuns body
+stmtIsPure _ _ MastBreak = True
+stmtIsPure _ _ MastContinue = True
+stmtIsPure memOk pureFuns (MastSeq stmts) = bodyIsPure memOk pureFuns stmts
 
 expIsPure :: Set.Set Name -> MastExp -> Bool
 expIsPure _ (MastLit _) = True
@@ -1088,14 +1119,25 @@ expIsPure pureFuns (MastCond e1 e2 e3) =
 -- | True if an asm block contains only statically interpretable statements.
 -- Such blocks can be evaluated at compile time by the Yul interpreter,
 -- and functions containing only such blocks are eligible for PE inlining.
--- Operations NOT listed here (sload, …) make the block non-interpretable,
--- which keeps the enclosing function out of pureFuns and preserves comptime-check soundness.
+-- Memory ops (mload/mstore/mstore8) are interpretable here; see
+-- 'asmIsInterpretableWith' for the stricter variant used by the comptime check.
 asmIsInterpretable :: [YulStmt] -> Bool
-asmIsInterpretable = all interpretableStmt
+asmIsInterpretable = asmIsInterpretableWith True
+
+-- | Generalisation of 'asmIsInterpretable'. @memOk@ selects whether memory ops
+-- (mload/mstore/mstore8) are treated as interpretable:
+--
+--   * PE ('computePureFuns') passes True — the interpreter gates memory ops on
+--     'envComptimeMode' and only folds in-context writes, so this stays sound.
+--   * The comptime check ('computeComptimePureFuns') passes False, so
+--     memory-touching asm never counts as pure there. Storage ops (sload, …)
+--     are never interpretable, regardless of @memOk@.
+asmIsInterpretableWith :: Bool -> [YulStmt] -> Bool
+asmIsInterpretableWith memOk = all interpretableStmt
   where
     interpretableStmt (YAssign [_] e) = interpretableExp e
-    interpretableStmt (YExp (YCall (Name "mstore") [p, v])) = interpretableExp p && interpretableExp v
-    interpretableStmt (YExp (YCall (Name "mstore8") [p, v])) = interpretableExp p && interpretableExp v
+    interpretableStmt (YExp (YCall (Name "mstore") [p, v])) = memOk && interpretableExp p && interpretableExp v
+    interpretableStmt (YExp (YCall (Name "mstore8") [p, v])) = memOk && interpretableExp p && interpretableExp v
     interpretableStmt _ = False
 
     -- mload has its own clause (reads memory); general YCall delegates to interpretableOp
@@ -1103,7 +1145,7 @@ asmIsInterpretable = all interpretableStmt
     interpretableExp (YLit (YulNumber _)) = True
     interpretableExp (YLit YulTrue) = True
     interpretableExp (YLit YulFalse) = True
-    interpretableExp (YCall (Name "mload") [p]) = interpretableExp p
+    interpretableExp (YCall (Name "mload") [p]) = memOk && interpretableExp p
     interpretableExp (YCall op args) =
       interpretableOp op (length args) && all interpretableExp args
     interpretableExp _ = False

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -69,6 +69,7 @@ comptime =
       runTestExpectingFailure "ct_param_poly_runtime.solc" comptimeFolder,
       runTestExpectingFailure "ct_runtime_arg.solc" comptimeFolder,
       runTestExpectingFailure "ct_let_runtime.solc" comptimeFolder,
+      runTestExpectingFailure "ct_asm_mload_runtime.solc" comptimeFolder,
       runTestExpectingFailure "ct_asm_ret.solc" comptimeFolder,
       runTestExpectingFailure "ct_overloaded_bad.solc" comptimeFolder,
       runTestExpectingFailure "string-mem-runtime-fail.solc" comptimeFolder

--- a/test/YulEvalTests.hs
+++ b/test/YulEvalTests.hs
@@ -454,5 +454,22 @@ asmIsInterpretableTests =
           [ yAssign "a" (yCall "add" [yIdent "x", yIdent "y"]),
             yAssign "b" (yCall "sload" [yNum 0])
           ]
+          @?= False,
+      -- Strict variant (memOk = False), used by the comptime check: memory ops
+      -- are NOT interpretable, but pure arithmetic still is.
+      testCase "strict: mload in assignment → False" $
+        asmIsInterpretableWith False [yAssign "r" (yCall "mload" [yNum 0])]
+          @?= False,
+      testCase "strict: mstore expression stmt → False" $
+        asmIsInterpretableWith False [yExp "mstore" [yNum 0, yIdent "v"]]
+          @?= False,
+      testCase "strict: mstore8 expression stmt → False" $
+        asmIsInterpretableWith False [yExp "mstore8" [yNum 31, yNum 0xff]]
+          @?= False,
+      testCase "strict: add-assign still → True" $
+        asmIsInterpretableWith False [yAssign "rw" (yCall "add" [yIdent "x", yIdent "y"])]
+          @?= True,
+      testCase "strict: nested mload inside arithmetic → False" $
+        asmIsInterpretableWith False [yAssign "r" (yCall "add" [yCall "mload" [yNum 0], yNum 1])]
           @?= False
     ]

--- a/test/examples/comptime/ct_asm_mload_runtime.solc
+++ b/test/examples/comptime/ct_asm_mload_runtime.solc
@@ -1,0 +1,24 @@
+/* Negative: comptime let bound to a runtime memory read — must fail.
+   readMem reads address 0 without any in-context mstore, so partial
+   evaluation cannot fold it to a literal (mload in comptime mode returns
+   Nothing for unwritten bytes) and the call survives to the comptime check.
+   Memory reads are excluded from the comptime purity notion — they are not
+   statically comptime, since the classifier has none of the runtime gating
+   that makes memory folding sound during partial evaluation — so binding the
+   result with 'let y : comptime word' must be rejected by the verifier.
+*/
+
+function readMem() -> word {
+  let v : word;
+  assembly {
+    v := mload(0)
+  }
+  return v;
+}
+
+contract ComptimeMloadRuntime {
+  function main() -> word {
+    let y : comptime word = readMem();
+    return y;
+  }
+}


### PR DESCRIPTION
`asmIsInterpretable` treats `mload`/`mstore`/`mstore8` as interpretable so that memory-touching functions enter `pureFuns`. That set feeds two very different consumers:

  1. Partial evaluation inlining, where memory folding is sound because the Yul interpreter only executes memory ops under `envComptimeMode` and `mload` succeeds only for bytes written earlier in the same evaluation context (dynamic gating).

  2. `ComptimeCheck.isComptime`, which classifies expressions *structurally* with no such gating. A call to an `mload`-reading function that partial evaluation could not fold survives to the comptime check and, because it was in `pureFuns`, was wrongly classified comptime — even though its result depends on runtime memory. That let a `let x : comptime word` binding accept a genuinely runtime memory read.

Split purity into two notions selected by a `memOk` flag:

  * `computePureFuns` (memOk = True)  — unchanged, drives PE.
  * `computeComptimePureFuns` (memOk = False) — excludes memory-op functions; now used by `ComptimeCheck`.

A legitimately foldable memory chain (mstore then mload of the same address, `ct_asm_mem.solc`) is already collapsed to a literal by PE before the comptime check runs, so it is unaffected. An unfoldable memory read survives as a call and is now correctly rejected (new negative test `ct_asm_mload_runtime.solc`).

Also generalise `asmIsInterpretable` to `asmIsInterpretableWith memOk`, add strict-variant unit tests, and update `doc/comptime-asm.md`.