### PR TITLE
Desugar field accesses nested inside constructor arguments

### DIFF
--- a/src/Solcore/Desugarer/FieldAccess.hs
+++ b/src/Solcore/Desugarer/FieldAccess.hs
@@ -248,7 +248,12 @@ transRhs expr cenv = go expr cenv
     go (Cond e1 e2 e3) = Cond <$> transRhs e1 <*> transRhs e2 <*> transRhs e3
     go (ArrayLit es) = ArrayLit <$> mapM transRhs es
     go e@Var {} = pure e
-    go e@Con {} = pure e
+    -- Recurse into constructor arguments: a field access can sit inside a
+    -- constructor application in r-value position, e.g. a tuple literal
+    -- `(this.branch[i], node)` (which parses to `pair(this.branch[i], node)`).
+    -- Without this, such nested field accesses reach the type checker
+    -- undesugared and fail with "tcExp not implemented for: this.<field>".
+    go (Con n es) = Con n <$> mapM transRhs es
     go e@Lit {} = pure e
     go FieldAccess {} = error "Impossible"
 

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -165,7 +165,8 @@ dispatches =
       runDispatchTest "arraylit.solc",
       runDispatchTest "derive_ord.solc",
       runDispatchTest "derive_contract_local.solc",
-      runDispatchTest "deposit.solc"
+      runDispatchTest "deposit.solc",
+      runDispatchTest "field-access-in-tuple.solc"
     ]
   where
     runDispatchTest file = runTestForFileWith (emptyOption mempty) file "./test/examples/dispatch"

--- a/test/examples/dispatch/field-access-in-tuple.solc
+++ b/test/examples/dispatch/field-access-in-tuple.solc
@@ -1,0 +1,43 @@
+import std.{*};
+import std.dispatch.{*};
+pragma no-patterson-condition ;
+pragma no-coverage-condition ;
+pragma no-bounded-variable-condition ;
+
+// Regression test for the field-access desugarer (transRhs in
+// src/Solcore/Desugarer/FieldAccess.hs).
+//
+// A tuple literal `(x, y)` parses to a `pair(x, y)` constructor application.
+// transRhs used to leave constructor applications untouched (`go Con{} = pure e`),
+// so a contract field access nested inside a tuple in r-value position was never
+// lowered to its storage-access form. The undesugared `this.<field>` then reached
+// the type checker and failed with "tcExp not implemented for: this.<field>".
+//
+// This is the minimal shape of the original deposit.solc failure
+// `concat((branch[height], node))`: a plain field access and an indexed
+// storage-array field access, each nested inside a tuple literal passed as a
+// single argument. `abi_encode` accepts a tuple argument this way (and, unlike
+// `concat`, is available in this PR).
+contract C {
+    a : uint256;
+    b : uint256;
+    xs : array(uint256);
+
+    constructor() {
+        a = 1;
+        b = 2;
+        Array.setLength(xs, 4);
+    }
+
+    // Plain contract field accesses nested inside a tuple literal, passed as a
+    // single argument to abi_encode.
+    public function encFields() -> memory(bytes) {
+        return abi_encode((a, b));
+    }
+
+    // Indexed storage-array field access nested inside a tuple literal -- the
+    // exact shape from the deposit bug.
+    public function encIndexed(i: uint256) -> memory(bytes) {
+        return abi_encode((xs[i], b));
+    }
+}


### PR DESCRIPTION
The field-access desugarer's transRhs left constructor applications
untouched (`go Con{} = pure e`), so a contract field access sitting inside
a constructor's arguments in r-value position was never lowered to its
storage-access form. Tuple literals parse to `pair(..)` constructors, so
`concat((this.branch[i], node))` carried an undesugared `this.branch[i]`
through to type checking, which failed with
"tcExp not implemented for: this.branch".

Recurse into constructor arguments like Call/ArrayLit already do. Nullary
constructors are unaffected (mapM over []), and constructor args in r-value
position should be desugared regardless, so this only fixes previously
broken cases.