### PR TITLE
 Make comptime failures loud

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -240,14 +240,16 @@ single-constructor ADT is a product/struct with no discriminant and carries no t
 module validation, and type checking:
 - `Diagnostic`s carry a `Severity`, an optional `DiagnosticCode` (e.g. `SC0101` unknown name,
   `SC0201` type mismatch, `SC0225`/`SC0227`/`SC0228` duplicate definitions, `SC0301`/`SC0302`
-  match-compiler warnings), labeled `SourceSpan`s (primary/secondary), notes, and help text.
+  match-compiler warnings, `SC0401` partial evaluation out of fuel), labeled `SourceSpan`s
+  (primary/secondary), notes, and help text.
 - `SolcorePipeline` enriches diagnostics after the fact by searching source text/tokens for terms
   implicated by the error message, to attach precise labels even when the originating pass didn't
   compute a span directly.
 - Rendering (`renderDiagnostics`) supports plain-text or JSON output, configurable color and
   unicode usage, and terminal width, controlled via CLI flags in `Solcore.Pipeline.Options`.
-- Warning policy (`--warnings=default|always|never|deny`) controls whether match-compiler
-  exhaustiveness/redundancy warnings are shown or promoted to errors.
+- Warning policy (`--warnings=default|always|never|deny`) controls whether warnings —
+  match-compiler exhaustiveness/redundancy and partial-evaluation fuel exhaustion — are shown or
+  promoted to errors.
 
 ## Module System
 

--- a/doc/comptime-asm.md
+++ b/doc/comptime-asm.md
@@ -25,44 +25,36 @@ type YulState = Map.Map Name Integer  -- variable bindings only (no memory yet)
 
 ### Purity classification
 
-`asmIsInterpretableWith :: Bool -> [YulStmt] -> Bool` is used by `stmtIsPure` to decide
-whether a function whose body contains an asm block belongs in a purity set.  This is
-load-bearing for comptime-check soundness: a function containing `sload` must **not**
-enter any purity set, or `isComptime` in `Backend/ComptimeCheck.hs` would wrongly
-classify its result as comptime.
+`asmIsInterpretable :: [YulStmt] -> Bool` is used by `stmtIsPure` to decide whether a
+function whose body contains an asm block belongs in the purity set that drives
+partial-evaluation inlining.  A function containing `sload` must **not** enter it, or
+PE would fold a storage read into a compile-time constant.
 
-The rule: `stmtIsPure memOk _ (MastAsm stmts) = asmIsInterpretableWith memOk stmts`.
+The rule: `stmtIsPure _ (MastAsm stmts) = asmIsInterpretable stmts`.
 
 Optimistic treatment (`True` for all asm) breaks negative tests because it lets
 `sloadWord` into the purity set.
 
-### Two purity notions (`memOk`)
+### Memory ops are interpretable; storage ops are not
 
-There are **two** purity sets, differing only in whether memory ops
-(`mload`/`mstore`/`mstore8`) count as interpretable — the `memOk` flag:
+`computePureFuns` counts memory ops (`mload`/`mstore`/`mstore8`) as interpretable
+because the Yul interpreter only *executes* them under `envComptimeMode`, and `mload`
+succeeds only for bytes written earlier in the **same** evaluation context
+(`mloadWord` returns `Nothing` otherwise).  Folding a memory-touching function is
+therefore gated *dynamically* and stays sound.  Storage ops are never interpretable.
 
-- **`computePureFuns` (`memOk = True`)** — drives partial-evaluation inlining.
-  Memory ops are interpretable here because the Yul interpreter only *executes*
-  them under `envComptimeMode`, and `mload` succeeds only for bytes written
-  earlier in the **same** evaluation context (`mloadWord` returns `Nothing`
-  otherwise). Folding a memory-touching function is therefore gated *dynamically*
-  and stays sound.
+There is one purity notion, and the MAST comptime check does not use it: purity guides
+*folding*, while `Backend/ComptimeCheck.hs` only inspects the *outcome* of folding,
+asking whether a discharged comptime obligation is a value (`isValue` — a literal, or a
+constructor applied to values).  The two memory cases land correctly without a stricter
+purity set:
 
-- **`computeComptimePureFuns` (`memOk = False`)** — drives the MAST comptime check.
-  `isComptime` classifies expressions *structurally*, with none of that runtime
-  gating. A call to an `mload`-reading function that PE could **not** fold survives
-  to the comptime check; if it were treated as pure, `isComptime` would wrongly
-  label its result comptime even though it depends on runtime memory. So memory-op
-  functions are excluded from this stricter set.
-
-  This is exactly right: a legitimately foldable memory chain (e.g. `mstore` then
-  `mload` of the same address, as in `ct_asm_mem.solc`) is already collapsed to a
-  literal by PE *before* the comptime check runs — so `isComptime` sees a literal,
-  not a call, and the strictness never rejects it. An **unfoldable** memory read
-  (e.g. `mload` of an address never written in context, as in
-  `ct_asm_mload_runtime.solc`) survives as a call and is correctly rejected.
-
-  Storage ops (`sload`, …) are never interpretable, regardless of `memOk`.
+- A foldable memory chain (`mstore` then `mload` of the same address, `ct_asm_mem.solc`)
+  is collapsed to a literal by PE *before* the check runs, so the check sees a value and
+  accepts.
+- An unfoldable memory read (`mload` of an address never written in context,
+  `ct_asm_mload_runtime.solc`) survives as a call.  A call is not a value, so it is
+  rejected — whether or not its function was classified pure.
 
 ### TypeReg
 
@@ -381,11 +373,9 @@ Note: `mload` is an interpretable *expression* (returns a value), while
 
 ### Memory ops are gated on `envComptimeMode`
 
-`asmIsInterpretable` (i.e. `asmIsInterpretableWith True`) classifies
-`mstore`/`mstore8`/`mload` as interpretable (so functions using them remain in the
-PE `pureFuns`; the stricter comptime set — `asmIsInterpretableWith False` — excludes
-them, see "Two purity notions" above), but the evaluator only *executes* them when
-`envComptimeMode = True`:
+`asmIsInterpretable` classifies `mstore`/`mstore8`/`mload` as interpretable, so
+functions using them remain in the PE `pureFuns` (see "Memory ops are interpretable"
+above), but the evaluator only *executes* them when `envComptimeMode = True`:
 
 - **`mload`** in `evalYulExp`: returns `Nothing` if `envComptimeMode = False`.
 - **`mstore`/`mstore8`** in `evalYulStmt`: return `Nothing` (abort the block) if

--- a/doc/comptime-design.md
+++ b/doc/comptime-design.md
@@ -1,5 +1,17 @@
 # Comptime Analysis: Design Options
 
+> **Status: implemented, via Option C (hybrid).**  Both stages are in the tree:
+> the late verifier is `Solcore.Backend.ComptimeCheck` and the early classifier is
+> `Solcore.Frontend.ComptimeCheck`.  Comptime expression match labels, comptime
+> results, comptime `let` bindings, and comptime annotations on class methods all
+> work.  Sections 1–2 describe the shipped design; sections 3–6 are kept as the
+> record of the options weighed, and section 7 records how the open questions were
+> answered.  For the surrounding pipeline see
+> [`architecture.md`](architecture.md); for the comptime-only types and the Yul
+> interpreter see [`comptime-integer.md`](comptime-integer.md),
+> [`comptime-string.md`](comptime-string.md), and
+> [`comptime-asm.md`](comptime-asm.md).
+
 ## 1. Background
 
 ### What comptime means
@@ -11,30 +23,34 @@ also evaluate the expression at compile time.
 ### Current state
 
 The `comptime` keyword is parsed and stored as a `Bool` flag in `Param` constructors
-throughout the typed AST. It is currently ignored by all later phases and lost during
-specialization (the `toMastParam` conversion discards it).
+throughout the typed AST, and preserved through specialization: `toMastParam`
+(`Specialise.hs:1170`) carries it into `MastParam.mastParamComptime`, so both the
+frontend and the backend checkers can see it.
 
 ### Relevant pipeline ordering
 
 ```
- Step  Pass                          AST type         Phase
- ───── ───────────────────────────── ──────────────── ─────────
-  2    Name resolution               CompUnit Name    Untyped
-       (numeric ops → Call Add.add)
-  ...
-  9    Type checking                  CompUnit Id      Typed
- 10    If/Bool desugaring             CompUnit Id      Typed
- 11    Match compilation              CompUnit Id      Typed
- 12    Specialization                 MastCompUnit     Monomorphic
- 13    Partial evaluation (MastEval)  MastCompUnit     Monomorphic
- 14    Dead code elimination          MastCompUnit     Monomorphic
- 15    Hull emission                  HullCompUnit     Lowered
+ Pass                              AST type         Phase
+ ───────────────────────────────── ──────────────── ────────────
+ Name resolution                   CompUnit Name    Untyped
+   (numeric ops → Call Add.add)
+ ...
+ Type checking                     CompUnit Id      Typed
+ Early comptime check              CompUnit Id      Typed
+ Array literal desugaring          CompUnit Id      Typed
+ If/Bool desugaring                CompUnit Id      Typed
+ Match compilation                 CompUnit Id      Typed
+ Specialization                    MastCompUnit     Monomorphic
+ Partial evaluation (MastEval)     MastCompUnit     Monomorphic
+ Dead code elimination             MastCompUnit     Monomorphic
+ Late comptime check               MastCompUnit     Monomorphic
+ Hull emission                     [Hull.Object]    Lowered
 ```
 
-Key fact: **match compilation (step 11) runs before specialization (step 12)**.
+Key fact: **match compilation runs before specialization**.
 
 Numeric operators (`+`, `-`, `*`) are desugared to overloaded function calls
-(`Add.add`, `Sub.sub`, `Mul.mul`) at name resolution (step 2). By the time
+(`Add.add`, `Sub.sub`, `Mul.mul`) at name resolution. By the time
 type checking runs, `2 + 2` is `Call Add.add [Lit 2, Lit 2]` — a call to a
 type-class method.
 
@@ -62,9 +78,18 @@ rather than semantically. The consequences of syntactic-only comparison:
 
 ### Representation
 
-Expression labels need a new pattern variant (e.g., `PExp (Exp Id)`) or an
-extension to `Literal`, since they are fundamentally different from structural
-patterns — they don't bind variables, they compute values.
+Expression labels need a new pattern variant, since they are fundamentally
+different from structural patterns — they don't bind variables, they compute
+values. Implemented as `PExp` in the frontend (`Frontend/Syntax/Stmt.hs`) and
+`MastPExp` in Mast (`Backend/Mast.hs:156`), written with a `comptime` keyword in
+front of the label:
+
+```solc
+match selector {
+  | comptime keccakLit("transfer(address,uint256)") => return 1;
+  | _                                               => return 0;
+}
+```
 
 An important constraint: **expression labels may reference variables from outer
 scope** (e.g., `match x { | y + 1 => ... }` where `y` is a local). Patterns
@@ -74,16 +99,20 @@ be clear in the AST.
 ### When to evaluate
 
 Expression labels pass through match compilation unevaluated, survive through
-specialization into Mast, and are evaluated post-specialization (by MastEval
-or a dedicated comptime evaluator). The Yul backend emits if-else chains
-for expression labels rather than Yul `switch` statements (which require
-literal case values).
+specialization into Mast, and are evaluated post-specialization by MastEval:
+`evalPat` (`MastEval.hs:442`) reduces a `MastPExp` to a `MastPLit`. A label that
+does not reduce to a literal is a hard failure there, and reaching Hull emission
+still wrapped in `MastPExp` is a panic (`EmitHull.hs:503`). Because the reduction
+happens before emission, the backend only ever sees ordinary literal patterns and
+needs no special handling — no if-else chain is required.
 
 ### Scope restriction
 
 Expression labels are restricted to **monomorphic numeric types** (primarily
 `word`, potentially `uint8` etc.). This avoids overloading complications —
-after specialization, all operations are concrete and evaluable.
+after specialization, all operations are concrete and evaluable. The restriction is
+enforced by `tcPat'` (`TcStmt.hs:317`), which unifies the label's type with the
+scrutinee's and then rejects a non-numeric result.
 
 ---
 
@@ -286,7 +315,9 @@ understands instance resolution.
 2. Add expression patterns for switch labels (AST, parser, match compiler)
 3. Comptime classification pass after specialization
 4. MastEval evaluates expression labels and comptime expressions
-5. Yul backend handles expression labels via if-else chains
+5. Yul backend handles expression labels via if-else chains — *not needed in the
+   end: MastEval reduces every label to a literal, so the backend sees ordinary
+   literal patterns (see Section 2)*
 
 **Stage 2 (early classification, added later):**
 6. Add comptime annotations to function result types and class methods
@@ -297,7 +328,9 @@ understands instance resolution.
 
 ## 4. Common implementation elements (all options)
 
-These changes are needed regardless of which option is chosen:
+These changes are needed regardless of which option is chosen. **All seven have
+landed** — items 5–7, listed below as Option A / C-Phase-2 work, came in with the
+early classifier:
 
 1. **Preserve comptime flag into Mast**: `MastParam` gains a `mastParamComptime`
    field; `toMastParam` preserves it from `Param Id`.
@@ -341,7 +374,12 @@ Changes needed for Options A and C (Phase 2) but not Option B alone:
 
 ## 6. Recommended approach
 
-**Option C (Hybrid), starting with the Option B foundation.**
+**Option C (Hybrid), starting with the Option B foundation.** Both stages are now
+implemented: `Solcore.Backend.ComptimeCheck` verifies the monomorphic program after
+partial evaluation, and `Solcore.Frontend.ComptimeCheck` classifies the typed AST
+beforehand (`CTComptime` / `CTRuntime` / `CTDeferred`, deferring to the late check
+whenever it cannot decide) and enforces that a declared-comptime binding is
+immutable — including against assignment from inside an `assembly` block.
 
 Rationale:
 - Start with late analysis: simplest implementation, handles all use cases
@@ -355,24 +393,47 @@ Rationale:
 
 ---
 
-## 7. Open questions
+## 7. Questions, as answered
 
-1. **Syntax for comptime results**: `-> comptime word` or a different notation?
-2. **Syntax for numeric switch**: Reuse `match` with expression labels, or
-   introduce a separate `switch` keyword?
-3. **Comptime let bindings**: `let x = comptime e` or `comptime let x = e` or
-   `let comptime x = e`?
-4. **Should comptime be inferred for function results?** If all inputs are
-   comptime and the function is pure, the result could be automatically comptime.
-   Explicit annotation gives stronger contracts; inference reduces annotation
-   burden.
-5. **Interaction with assembly blocks**: Any expression containing inline
-   assembly is definitionally not comptime. Should this be explicit?
-6. **Recursive comptime functions**: Can a recursive function be comptime?
-   Requires bounded recursion or a fuel limit to guarantee termination.
-   MastEval already uses fuel — same mechanism could apply.
-7. **Expression label collision**: Two expression labels evaluating to the same
-   value at runtime. Options: (a) silently pick first matching branch,
-   (b) emit a compiler warning if detected during evaluation, (c) treat as
-   error. Since labels are comptime, collision can be detected at compile time
-   after evaluation.
+1. **Syntax for comptime results**: `-> comptime word`, as proposed. Class methods
+   take the same annotations on parameters and results
+   (`function fromInteger(comptime x : integer) -> comptime a;`, `std/std.solc:517`).
+2. **Syntax for numeric switch**: `match` is reused. An expression label is written
+   with a leading `comptime` keyword, which keeps it visibly distinct from a
+   variable-binding pattern.
+3. **Comptime let bindings**: the annotation goes on the type —
+   `let x : comptime word = e`.
+4. **Is comptime inferred for function results?** No. A result is comptime only when
+   annotated. The *classifier* infers comptime-ness of expressions, and the frontend
+   yields `CTDeferred` rather than guessing whenever it cannot decide, but a function's
+   contract is always explicit.
+5. **Interaction with assembly blocks**: an assembly block is *not* definitionally
+   runtime. MastEval carries a Yul interpreter (see
+   [`comptime-asm.md`](comptime-asm.md)), so a block it can interpret folds like any
+   other expression; one it cannot — anything touching storage, calldata, or the
+   outside world — makes the enclosing expression runtime. `ct_asm_ret.solc` pins the
+   rejection of `-> comptime word` on a body that does `sload`, and `ct_asm_mem.solc`
+   pins the folding case. Assembly does have one special rule, in the opposite
+   direction: because a Yul block assigns to enclosing variables by name, the frontend
+   check rejects assignments to comptime bindings from inside a block, exactly as it
+   does for SAIL assignments.
+6. **Recursive comptime functions**: yes, bounded by MastEval's fuel (`--pe-fuel N`,
+   `fib3.solc` and `integer-fib.solc`). Exhausting the budget is reported as
+   `warning[SC0401]`, which obeys `--warnings` and escalates under `--warnings deny`;
+   the annotation that consequently failed to discharge is then rejected by the late
+   check.
+7. **Expression label collision**: (a) — the first matching branch wins, silently.
+   Labels reduce to literals during partial evaluation, so a collision *could* be
+   detected there by comparing the reduced literals, but nothing does so today. The
+   worst outcome is a dead branch, not a wrong one.
+
+### Still open
+
+- **MAST-level rejections carry no source span.** Mast has no source locations, so a
+  violation the frontend classifier deferred is reported against an arbitrary position
+  in `std/opcodes.solc` rather than the user's code. The frontend check exists partly to
+  keep the common cases away from this path, but it does not cover all of them.
+- **Comptime-only types are not covered by the immutability rule.** `ctDeclared` is
+  false for an `isComptimeOnlyTy` parameter by design, so `function f(s : string) { s =
+  "x"; }` is caught only much later, by EmitHull's "comptime value not eliminated"
+  guard. Whether the frontend rule should extend to them is undecided.

--- a/doc/comptime-design.md
+++ b/doc/comptime-design.md
@@ -433,7 +433,19 @@ Rationale:
   violation the frontend classifier deferred is reported against an arbitrary position
   in `std/opcodes.solc` rather than the user's code. The frontend check exists partly to
   keep the common cases away from this path, but it does not cover all of them.
-- **Comptime-only types are not covered by the immutability rule.** `ctDeclared` is
-  false for an `isComptimeOnlyTy` parameter by design, so `function f(s : string) { s =
-  "x"; }` is caught only much later, by EmitHull's "comptime value not eliminated"
-  guard. Whether the frontend rule should extend to them is undecided.
+- **Comptime-only types are not covered by the immutability rule.** `ctDeclared` is set
+  from the `comptime` keyword alone, while a parameter's *classification* also becomes
+  `CTComptime` for an `isComptimeOnlyTy` type. So a `string` parameter is treated as
+  comptime everywhere except by the assignment rule, and `function f(s : string) { s =
+  "x"; }` reaches the backend. What happens next depends on the assignment, and only the
+  first of the three is a decent outcome:
+
+  | Program | Result |
+  |---|---|
+  | `s = "x"`, one literal, foldable | compiles, correct code |
+  | assigned in both arms of a runtime `match`, then passed to `strlenLit` or bound to a `string` let | rejected by the late check — `runtime value passed to comptime parameter 'a' of 'strlenLit'` / `comptime let 'r' is bound to a runtime expression`, at the bogus span above |
+  | same, but the result never reaches a comptime obligation | `EmitHull.translateParam` (`EmitHull.hs:251`) aborts with `string-typed parameter 's': comptime value not eliminated before hull emission` — a panic with a GHC call stack, not a diagnostic |
+
+  Extending the frontend rule to comptime-only types would replace all three with one
+  message at the assignment, but would also reject the first program, which works today.
+  Undecided.

--- a/doc/comptime-integer.md
+++ b/doc/comptime-integer.md
@@ -305,7 +305,7 @@ here to make the assumption explicit.
 
 ### MAST-level checker
 
-`isComptime` already returns `True` for `MastLit _` — no change needed.
+`isValue` already returns `True` for `MastLit _` — no change needed.
 
 `integer`-typed parameters and `let`-bindings must carry the `comptime` flag at
 the source level; the existing flag propagation handles them.

--- a/sol-core.cabal
+++ b/sol-core.cabal
@@ -190,6 +190,7 @@ test-suite sol-core-tests
   -- cabal-fmt: expand test -Main
   other-modules:
     Cases
+    ComptimeCheckTests
     ContractAbiTests
     DiagnosticCliTests
     DiagnosticTests

--- a/src/Solcore/Backend/ComptimeCheck.hs
+++ b/src/Solcore/Backend/ComptimeCheck.hs
@@ -139,9 +139,11 @@ checkStmt fc env stmt = case stmt of
         when_ (ct && not ct') $
           "comptime let '" ++ show (mastIdName i) ++ "' is bound to a runtime expression"
         return $ if ct || ct' then Set.insert (mastIdName i) env else env
-  MastAssign _ e -> do
+  MastAssign i e -> do
     checkExp fc env e
-    return env
+    -- Whatever the variable held before, it now holds the result of this
+    -- assignment, so it is no longer a known comptime value.
+    return $ Set.delete (mastIdName i) env
   MastStmtExp e -> do
     checkExp fc env e
     return env

--- a/src/Solcore/Backend/ComptimeCheck.hs
+++ b/src/Solcore/Backend/ComptimeCheck.hs
@@ -3,54 +3,35 @@ module Solcore.Backend.ComptimeCheck (checkComptime) where
 {- MAST-level comptime verification pass.
    Runs on MastCompUnit after specialization and partial evaluation.
 
-   Two independent concerns:
-     1. Classification: is an expression comptime?
-        This pass runs after partial evaluation, so the question it asks
-        depends on what evaluation still had left to do.
+   Partial evaluation has already had its chance at every function here, so a
+   comptime obligation counts as discharged only when nothing is left to
+   compute: a literal, or a constructor applied to values.  A residual call is
+   a runtime computation whatever its shape, which is what makes exhausted
+   fuel a rejection rather than silently worse code.
 
-        In a closed context — a function with no comptime parameters and no
-        comptime return — every comptime argument the body could receive has
-        already been substituted, so partial evaluation has had its chance:
-        only a value (a literal, or a constructor applied to values) counts.
-        A residual call is a runtime computation whatever its shape, which is
-        what makes exhausted fuel a rejection rather than silently worse code.
-
-        In an open context the comptime parameters are still parameters, so
-        the most that can be asked is the structural classification: a
-        literal, a comptime-bound variable, or a call to a pure function whose
-        arguments are all comptime.  Purity is determined by
-        computeComptimePureFuns (MastEval), the stricter notion that excludes
-        memory-op (mload/mstore) functions: this classifier has none of the
-        runtime gating that makes memory folding sound in the evaluator.
-
-     2. Constraint checking: annotations must be consistent with reality.
-        - A parameter annotated 'comptime' must receive a comptime argument
-          at every call site.
-        - A 'let x : comptime T = e' binding requires e to be comptime.
-        - A function annotated '-> comptime T' requires every returned
-          expression to be comptime.
+   What the pass enforces:
+     - A parameter annotated 'comptime' receives a value at every call site.
+     - A 'let x : comptime T = e' binding has a value for e.
+     - A function annotated '-> comptime T' returns a value.
+     - No comptime annotation survives at all: every function reaching this
+       pass is about to be emitted, so a comptime parameter means the argument
+       was never substituted and a comptime return means a call to it was
+       never folded.  Either way the promise the annotation makes is now
+       unkeepable.
 
    The verifier reports the first violation found as a String error.
 -}
 
 import Data.Map qualified as Map
-import Data.Set qualified as Set
 import Solcore.Backend.Mast
-import Solcore.Backend.MastEval (FunTable, buildFunTable, computeComptimePureFuns)
+import Solcore.Backend.MastEval (FunTable, buildFunTable)
 import Solcore.Frontend.Syntax.Name (Name)
-
--- | Set of variable names known to be comptime in the current scope.
-type ComptimeEnv = Set.Set Name
 
 -- | What the checker needs to know about the function it is walking.
 data FunCtx = FunCtx
   { fcFunTable :: FunTable,
-    fcPure :: Set.Set Name,
     fcRetComptime :: Bool,
-    fcName :: Name,
-    -- | True when comptime values reach this body as parameters rather than
-    -- as substituted values, so a comptime expression need not be a value yet.
-    fcOpen :: Bool
+    fcName :: Name
   }
 
 -- | Entry point: check all functions in the compilation unit.
@@ -60,11 +41,10 @@ data FunCtx = FunCtx
 -- binding — are reported in preference to it.
 checkComptime :: MastCompUnit -> Either String ()
 checkComptime cu = do
-  onEveryFunDef (checkFunDef ft pure_) cu
+  onEveryFunDef (checkFunDef ft) cu
   onEveryFunDef checkNothingLeftToSubstitute cu
   where
     ft = buildFunTable cu
-    pure_ = computeComptimePureFuns ft
 
 -- | Apply a check to every function definition in the unit.
 onEveryFunDef :: (MastFunDef -> Either String ()) -> MastCompUnit -> Either String ()
@@ -77,28 +57,15 @@ onEveryFunDef f cu = mapM_ inTopDecl (mastTopDecls cu)
     inDecl (MastCDataDecl _) = Right ()
 
 -- | Check a single function definition.
-checkFunDef :: FunTable -> Set.Set Name -> MastFunDef -> Either String ()
-checkFunDef ft pure_ fd = checkStmts fc initEnv (mastFunBody fd)
+checkFunDef :: FunTable -> MastFunDef -> Either String ()
+checkFunDef ft fd = checkStmts fc (mastFunBody fd)
   where
     fc =
       FunCtx
         { fcFunTable = ft,
-          fcPure = pure_,
           fcRetComptime = mastFunRetComptime fd,
-          fcName = mastFunName fd,
-          fcOpen =
-            any mastParamComptime (mastFunParams fd)
-              || mastFunRetComptime fd
+          fcName = mastFunName fd
         }
-    -- For '-> comptime' functions, assume ALL params are comptime when checking
-    -- the body: this verifies "if all args happen to be comptime, is the result?"
-    -- For other functions, only explicitly-annotated comptime params are trusted.
-    initEnv =
-      Set.fromList
-        [ mastParamName p
-        | p <- mastFunParams fd,
-          mastParamComptime p || mastFunRetComptime fd
-        ]
 
 -- | Every function reaching this pass is about to be emitted, so no comptime
 -- annotation on it can still be honoured: a comptime parameter means the
@@ -120,94 +87,75 @@ checkNothingLeftToSubstitute fd = do
       ++ show (mastFunName fd)
       ++ "' annotated '-> comptime' survived partial evaluation"
 
--- | Check a sequence of statements, threading the comptime environment.
-checkStmts :: FunCtx -> ComptimeEnv -> [MastStmt] -> Either String ()
-checkStmts _ _ [] = Right ()
-checkStmts fc env (s : ss) = do
-  env' <- checkStmt fc env s
-  checkStmts fc env' ss
+-- | Check a sequence of statements.
+checkStmts :: FunCtx -> [MastStmt] -> Either String ()
+checkStmts fc = mapM_ (checkStmt fc)
 
--- | Check one statement; returns the updated comptime environment.
-checkStmt :: FunCtx -> ComptimeEnv -> MastStmt -> Either String ComptimeEnv
-checkStmt fc env stmt = case stmt of
-  MastLet ct i _ mInit -> do
+-- | Check one statement.
+checkStmt :: FunCtx -> MastStmt -> Either String ()
+checkStmt fc stmt = case stmt of
+  MastLet ct i _ mInit ->
     case mInit of
-      Nothing -> return env
+      Nothing -> Right ()
       Just e -> do
-        checkExp fc env e
-        let ct' = discharged fc env e
-        when_ (ct && not ct') $
+        checkExp fc e
+        when_ (ct && not (isValue e)) $
           "comptime let '" ++ show (mastIdName i) ++ "' is bound to a runtime expression"
-        return $ if ct || ct' then Set.insert (mastIdName i) env else env
-  MastAssign i e -> do
-    checkExp fc env e
-    -- Whatever the variable held before, it now holds the result of this
-    -- assignment, so it is no longer a known comptime value.
-    return $ Set.delete (mastIdName i) env
-  MastStmtExp e -> do
-    checkExp fc env e
-    return env
+  MastAssign _ e ->
+    checkExp fc e
+  MastStmtExp e ->
+    checkExp fc e
   MastReturn e -> do
-    checkExp fc env e
-    when_ (fcRetComptime fc && not (discharged fc env e)) $
+    checkExp fc e
+    when_ (fcRetComptime fc && not (isValue e)) $
       "function '" ++ show (fcName fc) ++ "' annotated '-> comptime' returns a runtime expression"
-    return env
   MastMatch scrut alts -> do
-    checkExp fc env scrut
-    mapM_ (checkAlt fc env) alts
-    return env
+    checkExp fc scrut
+    mapM_ (checkAlt fc) alts
   MastFor initStmt cond postStmt body -> do
-    _ <- checkStmt fc env initStmt
-    checkExp fc env cond
-    _ <- checkStmt fc env postStmt
-    mapM_ (checkStmt fc env) body
-    return env
+    checkStmt fc initStmt
+    checkExp fc cond
+    checkStmt fc postStmt
+    checkStmts fc body
   MastAsm _ ->
-    return env
+    Right ()
   MastBreak ->
-    return env
+    Right ()
   MastContinue ->
-    return env
-  MastSeq stmts -> do
-    checkStmts fc env stmts
-    return env
+    Right ()
+  MastSeq stmts ->
+    checkStmts fc stmts
 
 -- | Check an alternative in a match expression.
-checkAlt :: FunCtx -> ComptimeEnv -> MastAlt -> Either String ()
-checkAlt fc env (_, body) = checkStmts fc env body
+checkAlt :: FunCtx -> MastAlt -> Either String ()
+checkAlt fc (_, body) = checkStmts fc body
 
 -- | Check comptime-param constraints inside an expression (recursive).
-checkExp :: FunCtx -> ComptimeEnv -> MastExp -> Either String ()
-checkExp fc env (MastCall f args) = do
-  checkCallSite fc env f args
-  mapM_ (checkExp fc env) args
-checkExp fc env (MastCon _ args) =
-  mapM_ (checkExp fc env) args
-checkExp fc env (MastCond c t e) =
-  mapM_ (checkExp fc env) [c, t, e]
-checkExp _ _ _ = Right ()
+checkExp :: FunCtx -> MastExp -> Either String ()
+checkExp fc (MastCall f args) = do
+  checkCallSite fc f args
+  mapM_ (checkExp fc) args
+checkExp fc (MastCon _ args) =
+  mapM_ (checkExp fc) args
+checkExp fc (MastCond c t e) =
+  mapM_ (checkExp fc) [c, t, e]
+checkExp _ _ = Right ()
 
 -- | Verify that comptime-annotated parameters receive comptime arguments.
-checkCallSite :: FunCtx -> ComptimeEnv -> MastId -> [MastExp] -> Either String ()
-checkCallSite fc env f args =
+checkCallSite :: FunCtx -> MastId -> [MastExp] -> Either String ()
+checkCallSite fc f args =
   case Map.lookup (mastIdName f) (fcFunTable fc) of
     Nothing -> Right () -- builtin or unknown; no annotation to check
     Just fd ->
       mapM_ checkArg (zip (mastFunParams fd) args)
   where
     checkArg (param, arg) =
-      when_ (mastParamComptime param && not (discharged fc env arg)) $
+      when_ (mastParamComptime param && not (isValue arg)) $
         "runtime value passed to comptime parameter '"
           ++ show (mastParamName param)
           ++ "' of '"
           ++ show (mastIdName f)
           ++ "'"
-
--- | Has this expression's comptime obligation actually been met?
-discharged :: FunCtx -> ComptimeEnv -> MastExp -> Bool
-discharged fc env e
-  | fcOpen fc = isComptime (fcFunTable fc) (fcPure fc) env e
-  | otherwise = isValue e
 
 -- | A value: what a discharged comptime expression looks like once partial
 -- evaluation has finished with it.  No computation left to perform.
@@ -215,26 +163,6 @@ isValue :: MastExp -> Bool
 isValue (MastLit _) = True
 isValue (MastCon _ args) = all isValue args
 isValue _ = False
-
--- | Classify an expression as comptime (True) or runtime (False).
---
--- A value is comptime if it is:
---   - a literal
---   - a variable bound in the comptime environment
---   - a call to a pure function with all comptime arguments
---   - a constructor applied to all comptime arguments
---   - a conditional whose scrutinee and both branches are comptime
-isComptime :: FunTable -> Set.Set Name -> ComptimeEnv -> MastExp -> Bool
-isComptime _ _ _ (MastLit _) = True
-isComptime _ _ env (MastVar i) = mastIdName i `Set.member` env
-isComptime ft pure_ env (MastCall f args) =
-  mastIdName f `Set.member` pure_ && all (isComptime ft pure_ env) args
-isComptime ft pure_ env (MastCon _ args) =
-  all (isComptime ft pure_ env) args
-isComptime ft pure_ env (MastCond c t e) =
-  isComptime ft pure_ env c
-    && isComptime ft pure_ env t
-    && isComptime ft pure_ env e
 
 -- | Like 'when' but for Either.
 when_ :: Bool -> String -> Either String ()

--- a/src/Solcore/Backend/ComptimeCheck.hs
+++ b/src/Solcore/Backend/ComptimeCheck.hs
@@ -4,13 +4,24 @@ module Solcore.Backend.ComptimeCheck (checkComptime) where
    Runs on MastCompUnit after specialization and partial evaluation.
 
    Two independent concerns:
-     1. Classification: is an expression statically comptime?
-        A value is comptime if it is a literal, a comptime-bound variable,
-        or a call to a pure function whose arguments are all comptime.
-        Purity is determined by computeComptimePureFuns (MastEval), the
-        stricter notion that excludes memory-op (mload/mstore) functions: this
-        classifier is structural, without the runtime gating that makes memory
-        folding sound in the partial evaluator.
+     1. Classification: is an expression comptime?
+        This pass runs after partial evaluation, so the question it asks
+        depends on what evaluation still had left to do.
+
+        In a closed context — a function with no comptime parameters and no
+        comptime return — every comptime argument the body could receive has
+        already been substituted, so partial evaluation has had its chance:
+        only a value (a literal, or a constructor applied to values) counts.
+        A residual call is a runtime computation whatever its shape, which is
+        what makes exhausted fuel a rejection rather than silently worse code.
+
+        In an open context the comptime parameters are still parameters, so
+        the most that can be asked is the structural classification: a
+        literal, a comptime-bound variable, or a call to a pure function whose
+        arguments are all comptime.  Purity is determined by
+        computeComptimePureFuns (MastEval), the stricter notion that excludes
+        memory-op (mload/mstore) functions: this classifier has none of the
+        runtime gating that makes memory folding sound in the evaluator.
 
      2. Constraint checking: annotations must be consistent with reality.
         - A parameter annotated 'comptime' must receive a comptime argument
@@ -31,6 +42,17 @@ import Solcore.Frontend.Syntax.Name (Name)
 -- | Set of variable names known to be comptime in the current scope.
 type ComptimeEnv = Set.Set Name
 
+-- | What the checker needs to know about the function it is walking.
+data FunCtx = FunCtx
+  { fcFunTable :: FunTable,
+    fcPure :: Set.Set Name,
+    fcRetComptime :: Bool,
+    fcName :: Name,
+    -- | True when comptime values reach this body as parameters rather than
+    -- as substituted values, so a comptime expression need not be a value yet.
+    fcOpen :: Bool
+  }
+
 -- | Entry point: check all functions in the compilation unit.
 checkComptime :: MastCompUnit -> Either String ()
 checkComptime cu = mapM_ checkTopDecl (mastTopDecls cu)
@@ -48,9 +70,18 @@ checkContractDecl _ _ (MastCDataDecl _) = Right ()
 
 -- | Check a single function definition.
 checkFunDef :: FunTable -> Set.Set Name -> MastFunDef -> Either String ()
-checkFunDef ft pure_ fd =
-  checkStmts ft pure_ (mastFunRetComptime fd) (mastFunName fd) initEnv (mastFunBody fd)
+checkFunDef ft pure_ fd = checkStmts fc initEnv (mastFunBody fd)
   where
+    fc =
+      FunCtx
+        { fcFunTable = ft,
+          fcPure = pure_,
+          fcRetComptime = mastFunRetComptime fd,
+          fcName = mastFunName fd,
+          fcOpen =
+            any mastParamComptime (mastFunParams fd)
+              || mastFunRetComptime fd
+        }
     -- For '-> comptime' functions, assume ALL params are comptime when checking
     -- the body: this verifies "if all args happen to be comptime, is the result?"
     -- For other functions, only explicitly-annotated comptime params are trusted.
@@ -62,45 +93,44 @@ checkFunDef ft pure_ fd =
         ]
 
 -- | Check a sequence of statements, threading the comptime environment.
-checkStmts :: FunTable -> Set.Set Name -> Bool -> Name -> ComptimeEnv -> [MastStmt] -> Either String ()
-checkStmts _ _ _ _ _ [] = Right ()
-checkStmts ft pure_ retCt fname env (s : ss) = do
-  env' <- checkStmt ft pure_ retCt fname env s
-  checkStmts ft pure_ retCt fname env' ss
+checkStmts :: FunCtx -> ComptimeEnv -> [MastStmt] -> Either String ()
+checkStmts _ _ [] = Right ()
+checkStmts fc env (s : ss) = do
+  env' <- checkStmt fc env s
+  checkStmts fc env' ss
 
 -- | Check one statement; returns the updated comptime environment.
-checkStmt :: FunTable -> Set.Set Name -> Bool -> Name -> ComptimeEnv -> MastStmt -> Either String ComptimeEnv
-checkStmt ft pure_ retCt fname env stmt = case stmt of
+checkStmt :: FunCtx -> ComptimeEnv -> MastStmt -> Either String ComptimeEnv
+checkStmt fc env stmt = case stmt of
   MastLet ct i _ mInit -> do
     case mInit of
       Nothing -> return env
       Just e -> do
-        checkExp ft pure_ env e
-        let ct' = isComptime ft pure_ env e
+        checkExp fc env e
+        let ct' = discharged fc env e
         when_ (ct && not ct') $
           "comptime let '" ++ show (mastIdName i) ++ "' is bound to a runtime expression"
         return $ if ct || ct' then Set.insert (mastIdName i) env else env
   MastAssign _ e -> do
-    checkExp ft pure_ env e
+    checkExp fc env e
     return env
   MastStmtExp e -> do
-    checkExp ft pure_ env e
+    checkExp fc env e
     return env
   MastReturn e -> do
-    checkExp ft pure_ env e
-    let ct' = isComptime ft pure_ env e
-    when_ (retCt && not ct') $
-      "function '" ++ show fname ++ "' annotated '-> comptime' returns a runtime expression"
+    checkExp fc env e
+    when_ (fcRetComptime fc && not (discharged fc env e)) $
+      "function '" ++ show (fcName fc) ++ "' annotated '-> comptime' returns a runtime expression"
     return env
   MastMatch scrut alts -> do
-    checkExp ft pure_ env scrut
-    mapM_ (checkAlt ft pure_ retCt fname env) alts
+    checkExp fc env scrut
+    mapM_ (checkAlt fc env) alts
     return env
   MastFor initStmt cond postStmt body -> do
-    _ <- checkStmt ft pure_ retCt fname env initStmt
-    checkExp ft pure_ env cond
-    _ <- checkStmt ft pure_ retCt fname env postStmt
-    mapM_ (checkStmt ft pure_ retCt fname env) body
+    _ <- checkStmt fc env initStmt
+    checkExp fc env cond
+    _ <- checkStmt fc env postStmt
+    mapM_ (checkStmt fc env) body
     return env
   MastAsm _ ->
     return env
@@ -109,40 +139,52 @@ checkStmt ft pure_ retCt fname env stmt = case stmt of
   MastContinue ->
     return env
   MastSeq stmts -> do
-    checkStmts ft pure_ retCt fname env stmts
+    checkStmts fc env stmts
     return env
 
 -- | Check an alternative in a match expression.
-checkAlt :: FunTable -> Set.Set Name -> Bool -> Name -> ComptimeEnv -> MastAlt -> Either String ()
-checkAlt ft pure_ retCt fname env (_, body) =
-  checkStmts ft pure_ retCt fname env body
+checkAlt :: FunCtx -> ComptimeEnv -> MastAlt -> Either String ()
+checkAlt fc env (_, body) = checkStmts fc env body
 
 -- | Check comptime-param constraints inside an expression (recursive).
-checkExp :: FunTable -> Set.Set Name -> ComptimeEnv -> MastExp -> Either String ()
-checkExp ft pure_ env (MastCall f args) = do
-  checkCallSite ft pure_ env f args
-  mapM_ (checkExp ft pure_ env) args
-checkExp ft pure_ env (MastCon _ args) =
-  mapM_ (checkExp ft pure_ env) args
-checkExp ft pure_ env (MastCond c t e) =
-  mapM_ (checkExp ft pure_ env) [c, t, e]
-checkExp _ _ _ _ = Right ()
+checkExp :: FunCtx -> ComptimeEnv -> MastExp -> Either String ()
+checkExp fc env (MastCall f args) = do
+  checkCallSite fc env f args
+  mapM_ (checkExp fc env) args
+checkExp fc env (MastCon _ args) =
+  mapM_ (checkExp fc env) args
+checkExp fc env (MastCond c t e) =
+  mapM_ (checkExp fc env) [c, t, e]
+checkExp _ _ _ = Right ()
 
 -- | Verify that comptime-annotated parameters receive comptime arguments.
-checkCallSite :: FunTable -> Set.Set Name -> ComptimeEnv -> MastId -> [MastExp] -> Either String ()
-checkCallSite ft pure_ env f args =
-  case Map.lookup (mastIdName f) ft of
+checkCallSite :: FunCtx -> ComptimeEnv -> MastId -> [MastExp] -> Either String ()
+checkCallSite fc env f args =
+  case Map.lookup (mastIdName f) (fcFunTable fc) of
     Nothing -> Right () -- builtin or unknown; no annotation to check
     Just fd ->
       mapM_ checkArg (zip (mastFunParams fd) args)
   where
     checkArg (param, arg) =
-      when_ (mastParamComptime param && not (isComptime ft pure_ env arg)) $
+      when_ (mastParamComptime param && not (discharged fc env arg)) $
         "runtime value passed to comptime parameter '"
           ++ show (mastParamName param)
           ++ "' of '"
           ++ show (mastIdName f)
           ++ "'"
+
+-- | Has this expression's comptime obligation actually been met?
+discharged :: FunCtx -> ComptimeEnv -> MastExp -> Bool
+discharged fc env e
+  | fcOpen fc = isComptime (fcFunTable fc) (fcPure fc) env e
+  | otherwise = isValue e
+
+-- | A value: what a discharged comptime expression looks like once partial
+-- evaluation has finished with it.  No computation left to perform.
+isValue :: MastExp -> Bool
+isValue (MastLit _) = True
+isValue (MastCon _ args) = all isValue args
+isValue _ = False
 
 -- | Classify an expression as comptime (True) or runtime (False).
 --

--- a/src/Solcore/Backend/ComptimeCheck.hs
+++ b/src/Solcore/Backend/ComptimeCheck.hs
@@ -54,19 +54,27 @@ data FunCtx = FunCtx
   }
 
 -- | Entry point: check all functions in the compilation unit.
+--
+-- The residual-annotation check is a second pass rather than part of the first
+-- so that the more specific diagnostics — naming the offending call site or
+-- binding — are reported in preference to it.
 checkComptime :: MastCompUnit -> Either String ()
-checkComptime cu = mapM_ checkTopDecl (mastTopDecls cu)
+checkComptime cu = do
+  onEveryFunDef (checkFunDef ft pure_) cu
+  onEveryFunDef checkNothingLeftToSubstitute cu
   where
     ft = buildFunTable cu
     pure_ = computeComptimePureFuns ft
 
-    checkTopDecl (MastTContr c) = mapM_ (checkContractDecl ft pure_) (mastContrDecls c)
-    checkTopDecl (MastTDataDef _) = Right ()
-
-checkContractDecl :: FunTable -> Set.Set Name -> MastContractDecl -> Either String ()
-checkContractDecl ft pure_ (MastCFunDecl fd) = checkFunDef ft pure_ fd
-checkContractDecl ft pure_ (MastCMutualDecl ds) = mapM_ (checkContractDecl ft pure_) ds
-checkContractDecl _ _ (MastCDataDecl _) = Right ()
+-- | Apply a check to every function definition in the unit.
+onEveryFunDef :: (MastFunDef -> Either String ()) -> MastCompUnit -> Either String ()
+onEveryFunDef f cu = mapM_ inTopDecl (mastTopDecls cu)
+  where
+    inTopDecl (MastTContr c) = mapM_ inDecl (mastContrDecls c)
+    inTopDecl (MastTDataDef _) = Right ()
+    inDecl (MastCFunDecl fd) = f fd
+    inDecl (MastCMutualDecl ds) = mapM_ inDecl ds
+    inDecl (MastCDataDecl _) = Right ()
 
 -- | Check a single function definition.
 checkFunDef :: FunTable -> Set.Set Name -> MastFunDef -> Either String ()
@@ -91,6 +99,26 @@ checkFunDef ft pure_ fd = checkStmts fc initEnv (mastFunBody fd)
         | p <- mastFunParams fd,
           mastParamComptime p || mastFunRetComptime fd
         ]
+
+-- | Every function reaching this pass is about to be emitted, so no comptime
+-- annotation on it can still be honoured: a comptime parameter means the
+-- argument was never substituted, and a comptime return means a call to it was
+-- never folded. Either way the promise the annotation makes is now unkeepable.
+checkNothingLeftToSubstitute :: MastFunDef -> Either String ()
+checkNothingLeftToSubstitute fd = do
+  case filter mastParamComptime (mastFunParams fd) of
+    [] -> Right ()
+    (p : _) ->
+      Left $
+        "comptime parameter '"
+          ++ show (mastParamName p)
+          ++ "' of '"
+          ++ show (mastFunName fd)
+          ++ "' survived partial evaluation"
+  when_ (mastFunRetComptime fd) $
+    "function '"
+      ++ show (mastFunName fd)
+      ++ "' annotated '-> comptime' survived partial evaluation"
 
 -- | Check a sequence of statements, threading the comptime environment.
 checkStmts :: FunCtx -> ComptimeEnv -> [MastStmt] -> Either String ()

--- a/src/Solcore/Backend/MastEval.hs
+++ b/src/Solcore/Backend/MastEval.hs
@@ -100,6 +100,9 @@ type CloneKey = (Name, [(Name, Literal)])
 
 data EvalState = EvalState
   { esFuel :: !Fuel,
+    -- set once the budget is found empty; fuel itself is restored after each
+    -- inlining attempt, so the remaining amount does not record this
+    esFuelExhausted :: !Bool,
     esMem :: !(Map.Map Integer Word8),
     -- clones created so far, for reuse across call sites
     esCloneNames :: !(Map.Map CloneKey Name),
@@ -113,18 +116,20 @@ data EvalState = EvalState
 -- Reader for constant environment, State for fuel + memory
 type EvalM = ReaderT EvalEnv (State EvalState)
 
-runEvalM :: EvalEnv -> Fuel -> EvalM a -> (a, Fuel)
+-- Returns the result and whether the fuel budget was found empty at any point.
+runEvalM :: EvalEnv -> Fuel -> EvalM a -> (a, Bool)
 runEvalM env fuel m =
   let initState =
         EvalState
           { esFuel = fuel,
+            esFuelExhausted = False,
             esMem = Map.empty,
             esCloneNames = Map.empty,
             esCloneDefs = Map.empty,
             esPendingClones = []
           }
       (a, finalState) = runState (runReaderT m env) initState
-   in (a, esFuel finalState)
+   in (a, esFuelExhausted finalState)
 
 askFunTable :: EvalM FunTable
 askFunTable = asks envFunTable
@@ -150,7 +155,9 @@ useFuel = do
     then do
       lift $ modify (\s -> s {esFuel = esFuel s - 1})
       pure True
-    else pure False
+    else do
+      lift $ modify (\s -> s {esFuelExhausted = True})
+      pure False
 
 -- Restore one unit of fuel (called after successful inlining)
 restoreFuel :: EvalM ()
@@ -166,14 +173,14 @@ modifyMem f = lift $ modify (\s -> s {esMem = f (esMem s)})
 -- Main entry point
 -----------------------------------------------------------------------
 
--- Returns the evaluated compilation unit and remaining fuel
-evalCompUnit :: Fuel -> MastCompUnit -> (MastCompUnit, Fuel)
-evalCompUnit fuel cu = (cu {mastTopDecls = decls'}, remainingFuel)
+-- Returns the evaluated compilation unit and whether the fuel budget ran out
+evalCompUnit :: Fuel -> MastCompUnit -> (MastCompUnit, Bool)
+evalCompUnit fuel cu = (cu {mastTopDecls = decls'}, fuelExhausted)
   where
     funTable = buildFunTable cu
     pureFuns = computePureFuns funTable
     env = EvalEnv {envFunTable = funTable, envPureFuns = pureFuns, envComptimeMode = False}
-    (decls', remainingFuel) = runEvalM env fuel (mapM evalTopDecl (mastTopDecls cu))
+    (decls', fuelExhausted) = runEvalM env fuel (mapM evalTopDecl (mastTopDecls cu))
 
 -----------------------------------------------------------------------
 -- Build function table from compilation unit

--- a/src/Solcore/Backend/MastEval.hs
+++ b/src/Solcore/Backend/MastEval.hs
@@ -880,9 +880,10 @@ mergeYulStateToVEnv tyReg yulState venv =
 -- does, and EmitHull's per-literal intercept fires as usual.
 
 -- Try to specialise a call by substituting literal arguments for the callee's
--- comptime-only parameters.  Returns a call to the clone, with those arguments
--- dropped.  Gives up (leaving the original call, and hence EmitHull's guard to
--- report it) when any such parameter has a non-literal argument.
+-- erasable parameters.  Returns a call to the clone, with those arguments
+-- dropped.  A parameter given a non-literal argument is simply not erased: for
+-- a `string` that leaves EmitHull's guard to report it, and for a comptime
+-- parameter the comptime verifier.
 tryCloneComptime :: MastId -> [MastExp] -> EvalM (Maybe MastExp)
 tryCloneComptime i args = do
   mfd <- lookupFunDef (mastIdName i)
@@ -890,18 +891,19 @@ tryCloneComptime i args = do
     Nothing -> pure Nothing
     Just fd
       | length (mastFunParams fd) /= length args -> pure Nothing
-      | null comptimeParams -> pure Nothing
-      | otherwise -> case mapM literalOf comptimeParams of
-          Nothing -> pure Nothing
-          Just binds -> cloneWith fd binds args
+      | null binds -> pure Nothing
+      | otherwise -> cloneWith fd binds args
       where
-        comptimeParams =
-          [ (p, a)
-          | (p, a) <- zip (mastFunParams fd) args,
-            mastParamType p == mastStringTy
+        -- A `string` parameter has to go because it has no runtime
+        -- representation; a comptime one because specialising on its value is
+        -- what the annotation asks for.  Inlining handles most of the latter,
+        -- but not for a callee that cannot be inlined at all.
+        erasable p = mastParamComptime p || mastParamType p == mastStringTy
+        binds =
+          [ (p, l)
+          | (p, MastLit l) <- zip (mastFunParams fd) args,
+            erasable p
           ]
-        literalOf (p, MastLit l) = Just (p, l)
-        literalOf _ = Nothing
 
 -- Clone definitions are not in the (immutable) function table, so a clone
 -- calling another cloneable function must be found in the state as well.

--- a/src/Solcore/Backend/MastEval.hs
+++ b/src/Solcore/Backend/MastEval.hs
@@ -6,7 +6,6 @@ module Solcore.Backend.MastEval
     FunTable,
     buildFunTable,
     computePureFuns,
-    computeComptimePureFuns,
     -- Evaluation monad (exported for testing)
     EvalEnv (..),
     EvalState (..),
@@ -20,7 +19,6 @@ module Solcore.Backend.MastEval
     evalYulBlock,
     substYulBlock,
     asmIsInterpretable,
-    asmIsInterpretableWith,
     maskWord,
     mstoreBytes,
     mloadWord,
@@ -1170,29 +1168,7 @@ builtinImpureFuns = Set.fromList [Name "revertLit", memStringFromLitName]
 -- SAME evaluation context (mloadWord returns Nothing otherwise). Folding a
 -- memory-touching function is therefore gated dynamically and stays sound.
 computePureFuns :: FunTable -> Set.Set Name
-computePureFuns = computePureFunsWith True
-
--- | Stricter purity used by the MAST comptime check ('ComptimeCheck').
--- Unlike 'computePureFuns', memory ops (mload/mstore/mstore8) do NOT count as
--- interpretable, so any function whose asm reads or writes memory is excluded.
---
--- Why the two notions must differ: 'isComptime' classifies expressions
--- *structurally*, with none of the dynamic 'envComptimeMode' / in-context-write
--- gating that makes memory folding sound during PE. A call to an mload-reading
--- function that PE could not fold survives to the comptime check; if it were in
--- pureFuns, 'isComptime' would wrongly label its result comptime even though it
--- depends on runtime memory. Excluding memory-op functions keeps the classifier
--- sound: a legitimately foldable memory chain (e.g. mstore then mload of the
--- same address) is already collapsed to a literal by PE before this check runs,
--- while an unfoldable memory read survives as a call and is correctly rejected.
-computeComptimePureFuns :: FunTable -> Set.Set Name
-computeComptimePureFuns = computePureFunsWith False
-
--- | Fixed-point purity computation. @memOk@ selects whether memory ops
--- (mload/mstore/mstore8) count as interpretable: True for PE
--- ('computePureFuns'), False for the comptime check ('computeComptimePureFuns').
-computePureFunsWith :: Bool -> FunTable -> Set.Set Name
-computePureFunsWith memOk ft = go builtinPureFuns
+computePureFuns ft = go builtinPureFuns
   where
     go pureFuns =
       let pureFuns' =
@@ -1202,7 +1178,7 @@ computePureFunsWith memOk ft = go builtinPureFuns
                     || fname `Set.member` builtinImpureFuns
                     then acc
                     else
-                      if bodyIsPure memOk (Set.insert fname acc) (mastFunBody fd)
+                      if bodyIsPure (Set.insert fname acc) (mastFunBody fd)
                         then Set.insert fname acc
                         else acc
               )
@@ -1212,29 +1188,28 @@ computePureFunsWith memOk ft = go builtinPureFuns
             then pureFuns
             else go pureFuns'
 
-bodyIsPure :: Bool -> Set.Set Name -> [MastStmt] -> Bool
-bodyIsPure memOk pureFuns = all (stmtIsPure memOk pureFuns)
+bodyIsPure :: Set.Set Name -> [MastStmt] -> Bool
+bodyIsPure pureFuns = all (stmtIsPure pureFuns)
 
-stmtIsPure :: Bool -> Set.Set Name -> MastStmt -> Bool
+stmtIsPure :: Set.Set Name -> MastStmt -> Bool
 -- Asm blocks are pure only if every statement uses a statically interpretable
--- operation. This keeps storage reads (sload, …) out of pureFuns entirely;
--- memory reads/writes (mload/mstore/mstore8) count only when @memOk@ is True
--- (PE), never for the comptime check — which is load-bearing for its soundness.
-stmtIsPure memOk _ (MastAsm stmts) = asmIsInterpretableWith memOk stmts
-stmtIsPure _ pureFuns (MastLet _ _ _ mInit) = maybe True (expIsPure pureFuns) mInit
-stmtIsPure _ pureFuns (MastAssign _ e) = expIsPure pureFuns e
-stmtIsPure _ pureFuns (MastStmtExp e) = expIsPure pureFuns e
-stmtIsPure _ pureFuns (MastReturn e) = expIsPure pureFuns e
-stmtIsPure memOk pureFuns (MastMatch e alts) =
-  expIsPure pureFuns e && all (bodyIsPure memOk pureFuns . snd) alts
-stmtIsPure memOk pureFuns (MastFor initStmt cond post body) =
-  stmtIsPure memOk pureFuns initStmt
+-- operation. This keeps storage reads (sload, …) out of pureFuns entirely,
+-- while memory reads/writes (mload/mstore/mstore8) count as interpretable.
+stmtIsPure _ (MastAsm stmts) = asmIsInterpretable stmts
+stmtIsPure pureFuns (MastLet _ _ _ mInit) = maybe True (expIsPure pureFuns) mInit
+stmtIsPure pureFuns (MastAssign _ e) = expIsPure pureFuns e
+stmtIsPure pureFuns (MastStmtExp e) = expIsPure pureFuns e
+stmtIsPure pureFuns (MastReturn e) = expIsPure pureFuns e
+stmtIsPure pureFuns (MastMatch e alts) =
+  expIsPure pureFuns e && all (bodyIsPure pureFuns . snd) alts
+stmtIsPure pureFuns (MastFor initStmt cond post body) =
+  stmtIsPure pureFuns initStmt
     && expIsPure pureFuns cond
-    && stmtIsPure memOk pureFuns post
-    && bodyIsPure memOk pureFuns body
-stmtIsPure _ _ MastBreak = True
-stmtIsPure _ _ MastContinue = True
-stmtIsPure memOk pureFuns (MastSeq stmts) = bodyIsPure memOk pureFuns stmts
+    && stmtIsPure pureFuns post
+    && bodyIsPure pureFuns body
+stmtIsPure _ MastBreak = True
+stmtIsPure _ MastContinue = True
+stmtIsPure pureFuns (MastSeq stmts) = bodyIsPure pureFuns stmts
 
 expIsPure :: Set.Set Name -> MastExp -> Bool
 expIsPure _ (MastLit _) = True
@@ -1248,25 +1223,15 @@ expIsPure pureFuns (MastCond e1 e2 e3) =
 -- | True if an asm block contains only statically interpretable statements.
 -- Such blocks can be evaluated at compile time by the Yul interpreter,
 -- and functions containing only such blocks are eligible for PE inlining.
--- Memory ops (mload/mstore/mstore8) are interpretable here; see
--- 'asmIsInterpretableWith' for the stricter variant used by the comptime check.
+-- Memory ops (mload/mstore/mstore8) are interpretable: the interpreter gates
+-- them on 'envComptimeMode' and only folds in-context writes, so this stays
+-- sound.  Storage ops (sload, …) are never interpretable.
 asmIsInterpretable :: [YulStmt] -> Bool
-asmIsInterpretable = asmIsInterpretableWith True
-
--- | Generalisation of 'asmIsInterpretable'. @memOk@ selects whether memory ops
--- (mload/mstore/mstore8) are treated as interpretable:
---
---   * PE ('computePureFuns') passes True — the interpreter gates memory ops on
---     'envComptimeMode' and only folds in-context writes, so this stays sound.
---   * The comptime check ('computeComptimePureFuns') passes False, so
---     memory-touching asm never counts as pure there. Storage ops (sload, …)
---     are never interpretable, regardless of @memOk@.
-asmIsInterpretableWith :: Bool -> [YulStmt] -> Bool
-asmIsInterpretableWith memOk = all interpretableStmt
+asmIsInterpretable = all interpretableStmt
   where
     interpretableStmt (YAssign [_] e) = interpretableExp e
-    interpretableStmt (YExp (YCall (Name "mstore") [p, v])) = memOk && interpretableExp p && interpretableExp v
-    interpretableStmt (YExp (YCall (Name "mstore8") [p, v])) = memOk && interpretableExp p && interpretableExp v
+    interpretableStmt (YExp (YCall (Name "mstore") [p, v])) = interpretableExp p && interpretableExp v
+    interpretableStmt (YExp (YCall (Name "mstore8") [p, v])) = interpretableExp p && interpretableExp v
     interpretableStmt _ = False
 
     -- mload has its own clause (reads memory); general YCall delegates to interpretableOp
@@ -1274,7 +1239,7 @@ asmIsInterpretableWith memOk = all interpretableStmt
     interpretableExp (YLit (YulNumber _)) = True
     interpretableExp (YLit YulTrue) = True
     interpretableExp (YLit YulFalse) = True
-    interpretableExp (YCall (Name "mload") [p]) = memOk && interpretableExp p
+    interpretableExp (YCall (Name "mload") [p]) = interpretableExp p
     interpretableExp (YCall op args) =
       interpretableOp op (length args) && all interpretableExp args
     interpretableExp _ = False

--- a/src/Solcore/Backend/MastEval.hs
+++ b/src/Solcore/Backend/MastEval.hs
@@ -1118,7 +1118,15 @@ evalFunBody tyReg env (stmt : rest) = case stmt of
             then Map.insert i e' env
             else Map.delete i env
     evalFunBody tyReg env' rest
-  MastStmtExp _ -> evalFunBody tyReg env rest
+  MastStmtExp e -> do
+    -- Inlining puts the body in expression position, where a statement has
+    -- nowhere to leave an effect behind.  Only one that folded away entirely
+    -- can be dropped; anything residual means this body cannot be inlined.
+    -- The comptime builtins depend on it: each is a stub guarded by
+    -- `unimplemented()`, so folding their real meaning is evalPrimitive's job
+    -- and reaching the body at all means it declined.
+    e' <- evalExp env e
+    if isKnownValue e' then evalFunBody tyReg env rest else pure Nothing
   MastReturn e -> do
     e' <- evalExp env e
     pure $ if isKnownValue e' then Just e' else Nothing

--- a/src/Solcore/Backend/MastEval.hs
+++ b/src/Solcore/Backend/MastEval.hs
@@ -1,6 +1,7 @@
 module Solcore.Backend.MastEval
   ( evalCompUnit,
     defaultFuel,
+    fuelExhaustedDiagnostic,
     eliminateDeadCode,
     FunTable,
     buildFunTable,
@@ -54,6 +55,7 @@ import Data.Traversable (mapAccumM)
 import Data.Word (Word8)
 import Language.Yul (YLiteral (..), YulExp (..), YulStmt (..))
 import Solcore.Backend.Mast
+import Solcore.Diagnostics qualified as Diag
 import Solcore.Frontend.Syntax.Name
 import Solcore.Frontend.Syntax.Stmt (Literal (..))
 import Solcore.Primitives.Primitives (integerPrimNames, memStringFromLitName, stringPrimNames)
@@ -82,6 +84,21 @@ type YulState = Map.Map Name Integer
 
 defaultFuel :: Fuel
 defaultFuel = 100
+
+-- | Reported when evaluation stopped because the budget ran out rather than
+-- because there was nothing left to fold.  Carries no label: the evaluator
+-- works on Mast, which has no source locations, and an inferred span would
+-- point at an arbitrary token of an arbitrary file.
+fuelExhaustedDiagnostic :: Diag.Diagnostic
+fuelExhaustedDiagnostic =
+  Diag.Diagnostic
+    { Diag.diagnosticSeverity = Diag.Warning,
+      Diag.diagnosticCode = Just (Diag.DiagnosticCode "SC0401"),
+      Diag.diagnosticMessage = "partial evaluation ran out of fuel",
+      Diag.diagnosticLabels = [],
+      Diag.diagnosticNotes = [],
+      Diag.diagnosticHelp = ["pass --pe-fuel N to raise the budget"]
+    }
 
 -----------------------------------------------------------------------
 -- Evaluation monad

--- a/src/Solcore/Backend/MastEval.hs
+++ b/src/Solcore/Backend/MastEval.hs
@@ -123,9 +123,9 @@ data EvalState = EvalState
     esCloneNames :: !(Map.Map CloneKey Name),
     -- clone definitions, by clone name; kept for clone-of-clone lookups
     esCloneDefs :: !(Map.Map Name MastFunDef),
-    -- clones created but not yet evaluated, with the environment binding their
-    -- erased parameters
-    esPendingClones :: ![(MastFunDef, VEnv)]
+    -- clones created but not yet evaluated; the erased parameters are already
+    -- substituted into their bodies
+    esPendingClones :: ![MastFunDef]
   }
 
 -- Reader for constant environment, State for fuel + memory
@@ -268,13 +268,13 @@ drainClones = go []
           evaluated <- mapM evalCloneDef (reverse pending)
           go (reverse evaluated ++ acc)
 
--- Like `evalFunDef`, but the erased parameters start out bound to their
--- literals, which is what substitutes them into the body.
-evalCloneDef :: (MastFunDef, VEnv) -> EvalM MastFunDef
-evalCloneDef (fd, env0) = do
+-- Like `evalFunDef`, but recording the result so that a clone of a clone can
+-- find its callee's definition.
+evalCloneDef :: MastFunDef -> EvalM MastFunDef
+evalCloneDef fd = do
   modifyMem (const Map.empty)
   let tyReg = buildTypeReg (mastFunParams fd) (mastFunBody fd)
-  (_, body') <- evalStmts tyReg env0 (mastFunBody fd)
+  (_, body') <- evalStmts tyReg Map.empty (mastFunBody fd)
   let fd' = fd {mastFunBody = body'}
   lift $ modify (\s -> s {esCloneDefs = Map.insert (mastFunName fd) fd' (esCloneDefs s)})
   pure fd'
@@ -723,10 +723,10 @@ venvToYulState env =
 -- remain available to the asm code.
 venvToSubst :: VEnv -> Map.Map Name YulExp
 venvToSubst env =
-  Map.fromList
-    [ (mastIdName k, yulLit l)
-    | (k, MastLit l) <- Map.toList env
-    ]
+  yulLitSubst (Map.fromList [(mastIdName k, l) | (k, MastLit l) <- Map.toList env])
+
+yulLitSubst :: LitSubst -> Map.Map Name YulExp
+yulLitSubst = Map.map yulLit
   where
     yulLit (IntLit v) = YLit (YulNumber v)
     yulLit (StrLit s) = YLit (YulString s)
@@ -914,10 +914,16 @@ tryCloneComptime i args = do
         -- what the annotation asks for.  Inlining handles most of the latter,
         -- but not for a callee that cannot be inlined at all.
         erasable p = mastParamComptime p || mastParamType p == mastStringTy
+        -- A parameter the body reassigns has no single value to substitute, so
+        -- it is left alone; the comptime verifier (or EmitHull, for a `string`)
+        -- then reports the function rather than the clone quietly disagreeing
+        -- with itself about what the parameter holds.
+        mutated = mutatedInStmts (mastFunBody fd)
         binds =
           [ (p, l)
           | (p, MastLit l) <- zip (mastFunParams fd) args,
-            erasable p
+            erasable p,
+            mastParamName p `Set.notMember` mutated
           ]
 
 -- Clone definitions are not in the (immutable) function table, so a clone
@@ -931,11 +937,12 @@ lookupFunDef n = do
 -- Create (or reuse) the clone of `fd` in which each listed parameter is bound
 -- to its literal, and build the call to it with those arguments dropped.
 --
--- The substitution itself is left to the evaluator: the clone is queued with a
--- variable environment binding the erased parameters, and evaluating its body
--- under that environment both substitutes the literals and folds whatever they
--- unlock.  This reuses the propagation `evalStmts` already performs rather
--- than adding a second, parallel substitution traversal.
+-- The literals are substituted into the body up front, before the clone is
+-- queued for evaluation.  Relying on the evaluator to propagate them from a
+-- variable environment instead would be unsound: an opaque asm block or a loop
+-- makes `evalStmts` discard the environment, and after erasure that
+-- environment is the parameter's only definition -- the body would keep
+-- reading a parameter the signature no longer has.
 cloneWith :: MastFunDef -> [(MastParam, Literal)] -> [MastExp] -> EvalM (Maybe MastExp)
 cloneWith fd binds args = do
   known <- lift $ gets (Map.lookup key . esCloneNames)
@@ -949,11 +956,7 @@ cloneWith fd binds args = do
     keptParams = filter isKept (mastFunParams fd)
     keptArgs = [a | (p, a) <- zip (mastFunParams fd) args, isKept p]
     cloneTy = foldr (MastArrow . mastParamType) (mastFunReturn fd) keptParams
-    env0 =
-      Map.fromList
-        [ (MastId (mastParamName p) (mastParamType p), MastLit l)
-        | (p, l) <- binds
-        ]
+    subst = Map.fromList [(mastParamName p, l) | (p, l) <- binds]
     -- Each new clone costs fuel, permanently.  A recursive callee that derives
     -- a fresh literal on every step would otherwise queue clones forever;
     -- exhausting the budget stops that and is already reported to the user.
@@ -963,17 +966,105 @@ cloneWith fd binds args = do
         then pure Nothing
         else do
           n <- freshCloneName (mastFunName fd)
-          let clone = fd {mastFunName = n, mastFunParams = keptParams}
+          let clone =
+                fd
+                  { mastFunName = n,
+                    mastFunParams = keptParams,
+                    mastFunBody = substMastStmts subst (mastFunBody fd)
+                  }
           lift $
             modify
               ( \s ->
                   s
                     { esCloneNames = Map.insert key n (esCloneNames s),
                       esCloneDefs = Map.insert n clone (esCloneDefs s),
-                      esPendingClones = (clone, env0) : esPendingClones s
+                      esPendingClones = clone : esPendingClones s
                     }
               )
           pure (Just n)
+
+-- | Names a body may reassign, counting an asm block's escaping assignments.
+-- Unlike 'assignedInStmts', which serves environment invalidation where an
+-- opaque asm block is handled by clearing the environment wholesale, this has
+-- to see through asm: a parameter mutated only there is still mutated.
+mutatedInStmts :: [MastStmt] -> Set.Set Name
+mutatedInStmts = foldMap mutatedInStmt
+
+mutatedInStmt :: MastStmt -> Set.Set Name
+mutatedInStmt (MastAssign i _) = Set.singleton (mastIdName i)
+mutatedInStmt (MastMatch _ alts) = foldMap (mutatedInStmts . snd) alts
+mutatedInStmt (MastFor initStmt _ post body) =
+  mutatedInStmt initStmt
+    `Set.union` mutatedInStmt post
+    `Set.union` mutatedInStmts body
+mutatedInStmt (MastSeq stmts) = mutatedInStmts stmts
+mutatedInStmt (MastAsm yul) = escapingAssignsYulBlock yul
+mutatedInStmt _ = Set.empty
+
+-- | Literals to substitute for the erased parameters, by parameter name.
+type LitSubst = Map.Map Name Literal
+
+-- | Substitute literals for variable references throughout a statement list.
+--
+-- The map is threaded through the sequence so that it stays scope-aware, in the
+-- same way 'substYulBlock' is: a @let@ or a pattern variable of the same name
+-- shadows the parameter, and from there on the name refers to the new binding.
+-- Reassignment needs no such care -- 'tryCloneComptime' refuses to erase a
+-- parameter the body assigns to.
+substMastStmts :: LitSubst -> [MastStmt] -> [MastStmt]
+substMastStmts _ [] = []
+substMastStmts subst (s : ss) =
+  let (s', subst') = substMastStmt subst s
+   in s' : substMastStmts subst' ss
+
+substMastStmt :: LitSubst -> MastStmt -> (MastStmt, LitSubst)
+substMastStmt subst (MastLet ct i ty mInit) =
+  (MastLet ct i ty (fmap (substMastExp subst) mInit), Map.delete (mastIdName i) subst)
+substMastStmt subst (MastAssign i e) =
+  (MastAssign i (substMastExp subst e), subst)
+substMastStmt subst (MastStmtExp e) = (MastStmtExp (substMastExp subst e), subst)
+substMastStmt subst (MastReturn e) = (MastReturn (substMastExp subst e), subst)
+substMastStmt subst (MastMatch e alts) =
+  (MastMatch (substMastExp subst e) (map (substMastAlt subst) alts), subst)
+substMastStmt subst (MastAsm yul) =
+  (MastAsm (substYulBlock (yulLitSubst subst) yul), subst)
+substMastStmt subst (MastSeq stmts) = (MastSeq (substMastStmts subst stmts), subst)
+substMastStmt subst (MastFor initStmt cond post body) =
+  -- Everything the loop declares is local to it, so the map is restored
+  -- afterwards; within the loop, a name declared by the init or post statement
+  -- shadows throughout.
+  let (initStmt', afterInit) = substMastStmt subst initStmt
+      (post', inner) = substMastStmt afterInit post
+   in ( MastFor initStmt' (substMastExp inner cond) post' (substMastStmts inner body),
+        subst
+      )
+substMastStmt subst s = (s, subst) -- MastBreak, MastContinue
+
+substMastAlt :: LitSubst -> MastAlt -> MastAlt
+substMastAlt subst (pat, body) =
+  (substMastPat inner pat, substMastStmts inner body)
+  where
+    inner = foldr Map.delete subst (Set.toList (patVars pat))
+
+-- | Pattern variables bind within the alternative and shadow an outer name.
+patVars :: MastPat -> Set.Set Name
+patVars (MastPVar i) = Set.singleton (mastIdName i)
+patVars (MastPCon _ ps) = foldMap patVars ps
+patVars _ = Set.empty
+
+substMastPat :: LitSubst -> MastPat -> MastPat
+substMastPat subst (MastPCon i ps) = MastPCon i (map (substMastPat subst) ps)
+substMastPat subst (MastPExp e) = MastPExp (substMastExp subst e)
+substMastPat _ p = p -- MastPVar, MastPWildcard, MastPLit
+
+substMastExp :: LitSubst -> MastExp -> MastExp
+substMastExp subst e@(MastVar i) =
+  maybe e MastLit (Map.lookup (mastIdName i) subst)
+substMastExp subst (MastCon i args) = MastCon i (map (substMastExp subst) args)
+substMastExp subst (MastCall i args) = MastCall i (map (substMastExp subst) args)
+substMastExp subst (MastCond c t f) =
+  MastCond (substMastExp subst c) (substMastExp subst t) (substMastExp subst f)
+substMastExp _ e = e -- MastLit
 
 freshCloneName :: Name -> EvalM Name
 freshCloneName base = do

--- a/src/Solcore/Frontend/ComptimeCheck.hs
+++ b/src/Solcore/Frontend/ComptimeCheck.hs
@@ -260,7 +260,7 @@ assignedNames = foldMap inStmt
       For initStmt _ postStmt body ->
         inStmt initStmt <> inStmt postStmt <> assignedNames body
       Block body -> assignedNames body
-      Let{} -> Set.empty
+      Let {} -> Set.empty
       StmtExp _ -> Set.empty
       Return _ -> Set.empty
       Break -> Set.empty

--- a/src/Solcore/Frontend/ComptimeCheck.hs
+++ b/src/Solcore/Frontend/ComptimeCheck.hs
@@ -18,9 +18,17 @@ module Solcore.Frontend.ComptimeCheck (checkComptimeEarly) where
      - A 'let x : comptime T = e' binding where e classifies as CTRuntime.
 
    CTDeferred values are never rejected here; the MAST-level pass handles them.
+
+   Comptime bindings are also immutable.  Partial evaluation discharges such a
+   binding and erases its declaration, so an assignment to it would be left
+   referring to a variable that no longer exists.  Assignment is therefore
+   rejected here, where there is still a source span to point at, whatever the
+   right-hand side is.
 -}
 
 import Data.Map qualified as Map
+import Data.Set qualified as Set
+import Language.Yul
 import Solcore.Frontend.Syntax.Contract
 import Solcore.Frontend.Syntax.Name (Name)
 import Solcore.Frontend.Syntax.Stmt
@@ -54,10 +62,30 @@ buildSigTable (CompUnit _ topDecls) = Map.fromList $ concatMap fromTopDecl topDe
     fromContrDecl _ = []
 
 -----------------------------------------------------------------------
--- Comptime environment: variable name -> Ctness
+-- Comptime environment: variable name -> what is known about it
 -----------------------------------------------------------------------
 
-type CtEnv = Map.Map Name Ctness
+data CtInfo = CtInfo
+  { ctness :: Ctness,
+    -- | True when the binding was written 'comptime' — a comptime let or a
+    -- comptime parameter.  A binding merely /classified/ comptime is not
+    -- declared comptime, and stays assignable.
+    ctDeclared :: Bool
+  }
+
+type CtEnv = Map.Map Name CtInfo
+
+-- | What the checker needs to know about the function it is walking.
+data FunCtx = FunCtx
+  { fcSigs :: SigTable,
+    fcRetComptime :: Bool,
+    -- | Human-readable description of the enclosing definition, for errors.
+    fcWhere :: String,
+    -- | Names assigned anywhere in the body.  What such a variable holds later
+    -- is not what it was initialised with, so its initialiser cannot make it
+    -- comptime.
+    fcAssigned :: Set.Set Name
+  }
 
 -----------------------------------------------------------------------
 -- Entry point
@@ -88,18 +116,29 @@ checkContrDecl _ _ = Right ()
 -----------------------------------------------------------------------
 
 checkFunDef :: SigTable -> String -> FunDef Id -> Either String ()
-checkFunDef st ctx fd = checkBody st (effRetComptime sig) ctx initEnv (funDefBody fd)
+checkFunDef st ctx fd = checkBody fc initEnv body
   where
     sig = funSignature fd
+    body = funDefBody fd
+    fc =
+      FunCtx
+        { fcSigs = st,
+          fcRetComptime = effRetComptime sig,
+          fcWhere = ctx,
+          fcAssigned = assignedNames body
+        }
     -- For '-> comptime' functions, treat ALL params as CTComptime when checking
     -- the body: this verifies "given comptime args, does the body produce comptime?"
     -- A param of comptime-only type (string/integer) is also implicitly comptime,
     -- since such values exist only at compile time.  Other params are CTRuntime.
     initEnv =
       Map.fromList
-        [ (idName (paramName p), if paramComptime p || effRetComptime sig || isComptimeOnlyTy (paramTy p) then CTComptime else CTRuntime)
+        [ (idName (paramName p), CtInfo (paramCtness p) (paramComptime p))
         | p <- sigParams sig
         ]
+    paramCtness p
+      | paramComptime p || effRetComptime sig || isComptimeOnlyTy (paramTy p) = CTComptime
+      | otherwise = CTRuntime
 
 -- | Check an instance method, including the instance head in error context.
 checkFunDefInst :: SigTable -> Instance Id -> FunDef Id -> Either String ()
@@ -119,78 +158,163 @@ tyHeadName :: Ty -> String
 tyHeadName (TyCon n _) = show n
 tyHeadName t = show t
 
-checkBody :: SigTable -> Bool -> String -> CtEnv -> Body Id -> Either String ()
-checkBody _ _ _ _ [] = Right ()
-checkBody st retCt ctx env (s : ss) = do
-  env' <- checkStmt st retCt ctx env s
-  checkBody st retCt ctx env' ss
+checkBody :: FunCtx -> CtEnv -> Body Id -> Either String ()
+checkBody _ _ [] = Right ()
+checkBody fc env (s : ss) = do
+  env' <- checkStmt fc env s
+  checkBody fc env' ss
 
-checkStmt :: SigTable -> Bool -> String -> CtEnv -> Stmt Id -> Either String CtEnv
-checkStmt st retCt ctx env stmt = case stmt of
+checkStmt :: FunCtx -> CtEnv -> Stmt Id -> Either String CtEnv
+checkStmt fc env stmt = case stmt of
   Let ct x _ mInit -> do
     case mInit of
-      Nothing -> return env
+      Nothing ->
+        -- Recorded even without an initialiser, so that assigning to it is
+        -- still recognised as assigning to a comptime binding.
+        return $ bind x (CtInfo (if ct then CTComptime else CTDeferred) ct) env
       Just e -> do
-        checkExp st env e
-        let ct' = classifyExp st env e
+        checkExp fc env e
+        let ct' = classifyExp fc env e
         when_ (ct && ct' == CTRuntime) $
           "comptime let '"
             ++ show (idName x)
             ++ "' is bound to a runtime expression"
-        return $ Map.insert (idName x) (letCtness ct ct') env
-  (_ := e) -> checkExp st env e >> return env
-  StmtExp e -> checkExp st env e >> return env
+        return $ bind x (CtInfo (letCtness fc ct ct' (idName x)) ct) env
+  (lhs := rhs) -> do
+    checkExp fc env lhs
+    checkExp fc env rhs
+    mapM_ (rejectComptimeTarget env) (assignTarget lhs)
+    return env
+  StmtExp e -> checkExp fc env e >> return env
   Return e -> do
-    checkExp st env e
-    when_ (retCt && classifyExp st env e == CTRuntime) $
-      ctx ++ ": function annotated '-> comptime' returns a runtime expression"
+    checkExp fc env e
+    when_ (fcRetComptime fc && classifyExp fc env e == CTRuntime) $
+      fcWhere fc ++ ": function annotated '-> comptime' returns a runtime expression"
     return env
   Match es eqs -> do
-    mapM_ (checkExp st env) es
-    mapM_ (checkEq st retCt ctx env) eqs
+    mapM_ (checkExp fc env) es
+    mapM_ (checkEq fc env) eqs
     return env
   If cond t f -> do
-    checkExp st env cond
-    checkBody st retCt ctx env t
-    checkBody st retCt ctx env f
+    checkExp fc env cond
+    checkBody fc env t
+    checkBody fc env f
     return env
   For initStmt _ postStmt body -> do
-    _ <- checkStmt st retCt ctx env initStmt
-    checkBody st retCt ctx env body
-    _ <- checkStmt st retCt ctx env postStmt
+    _ <- checkStmt fc env initStmt
+    checkBody fc env body
+    _ <- checkStmt fc env postStmt
     return env
-  Asm _ -> return env
-  Block body -> checkBody st retCt ctx env body >> return env
+  Asm blk -> do
+    -- A Yul block assigns to enclosing variables by name, so it can violate
+    -- comptime immutability exactly as a SAIL assignment can.
+    mapM_ (rejectComptimeTarget env) (Set.toList (yulAssignedNames blk))
+    return env
+  Block body -> checkBody fc env body >> return env
   Break -> return env
   Continue -> return env
   EmptyStmt -> return env
+  where
+    bind x = Map.insert (idName x)
+
+-- | Reject an assignment whose target was declared comptime.
+rejectComptimeTarget :: CtEnv -> Name -> Either String ()
+rejectComptimeTarget env n =
+  when_ (maybe False ctDeclared (Map.lookup n env)) $
+    "cannot assign to comptime binding '" ++ show n ++ "'"
+
+-- | The variable an assignment writes to, if it writes to one directly.
+--   Assignments through a field or index have no single target name.
+assignTarget :: Exp Id -> [Name]
+assignTarget (Var x) = [idName x]
+assignTarget (TyExp e _) = assignTarget e
+assignTarget _ = []
 
 -- | Decide the Ctness to assign to a let-bound variable.
---   If declared comptime, treat as CTComptime (Stage 1 verifies the RHS).
---   Otherwise, inherit the classification of the init expression.
-letCtness :: Bool -> Ctness -> Ctness
-letCtness True _ = CTComptime
-letCtness False ct' = ct'
+--   If declared comptime, treat as CTComptime (the RHS check verifies it).
+--   Otherwise inherit the classification of the init expression — unless the
+--   variable is assigned later, in which case defer to the MAST-level check.
+letCtness :: FunCtx -> Bool -> Ctness -> Name -> Ctness
+letCtness _ True _ _ = CTComptime
+letCtness fc False ct' n
+  | n `Set.member` fcAssigned fc = CTDeferred
+  | otherwise = ct'
 
-checkEq :: SigTable -> Bool -> String -> CtEnv -> ([Pat Id], Body Id) -> Either String ()
-checkEq st retCt ctx env (_, body) = checkBody st retCt ctx env body
+checkEq :: FunCtx -> CtEnv -> ([Pat Id], Body Id) -> Either String ()
+checkEq fc env (_, body) = checkBody fc env body
+
+-----------------------------------------------------------------------
+-- Assigned variables
+-----------------------------------------------------------------------
+
+-- | Names assigned anywhere in a body, by a SAIL assignment or inside a Yul
+--   block.  Over-approximating is safe: it only defers a classification.
+assignedNames :: Body Id -> Set.Set Name
+assignedNames = foldMap inStmt
+  where
+    inStmt stmt = case stmt of
+      (lhs := _) -> Set.fromList (assignTarget lhs)
+      Asm blk -> yulAssignedNames blk
+      Match _ eqs -> foldMap (assignedNames . snd) eqs
+      If _ t f -> assignedNames t <> assignedNames f
+      For initStmt _ postStmt body ->
+        inStmt initStmt <> inStmt postStmt <> assignedNames body
+      Block body -> assignedNames body
+      Let{} -> Set.empty
+      StmtExp _ -> Set.empty
+      Return _ -> Set.empty
+      Break -> Set.empty
+      Continue -> Set.empty
+      EmptyStmt -> Set.empty
+
+-- | Names a Yul block assigns to, excluding the ones it declares itself.
+yulAssignedNames :: YulBlock -> Set.Set Name
+yulAssignedNames blk = assigned blk `Set.difference` declared blk
+  where
+    assigned = foldMap stmtAssigned
+    stmtAssigned stmt = case stmt of
+      YAssign ns _ -> Set.fromList ns
+      YBlock b -> assigned b
+      YFun _ _ _ ss -> assigned ss
+      YIf _ b -> assigned b
+      YSwitch _ cases dflt -> foldMap (assigned . snd) cases <> foldMap assigned dflt
+      YFor pre _ post body -> assigned pre <> assigned post <> assigned body
+      _ -> Set.empty
+
+    declared = foldMap stmtDeclared
+    stmtDeclared stmt = case stmt of
+      YLet ns _ -> Set.fromList ns
+      YBlock b -> declared b
+      YFun _ args _ ss -> Set.fromList args <> declared ss
+      YIf _ b -> declared b
+      YSwitch _ cases dflt -> foldMap (declared . snd) cases <> foldMap declared dflt
+      YFor pre _ post body -> declared pre <> declared post <> declared body
+      _ -> Set.empty
 
 -----------------------------------------------------------------------
 -- Expression checking: recurse and enforce comptime-param constraints
 -----------------------------------------------------------------------
 
-checkExp :: SigTable -> CtEnv -> Exp Id -> Either String ()
-checkExp st env (Call _ f args) = do
-  checkCallSite st env f args
-  mapM_ (checkExp st env) args
-checkExp st env (Con _ args) = mapM_ (checkExp st env) args
-checkExp st env (Cond c t e) = mapM_ (checkExp st env) [c, t, e]
-checkExp st env (TyExp e _) = checkExp st env e
-checkExp st env (Lam ps body _) = checkBody st False "lambda" lamEnv body
+checkExp :: FunCtx -> CtEnv -> Exp Id -> Either String ()
+checkExp fc env (Call _ f args) = do
+  checkCallSite fc env f args
+  mapM_ (checkExp fc env) args
+checkExp fc env (Con _ args) = mapM_ (checkExp fc env) args
+checkExp fc env (Cond c t e) = mapM_ (checkExp fc env) [c, t, e]
+checkExp fc env (TyExp e _) = checkExp fc env e
+checkExp fc env (Lam ps body _) = checkBody lamCtx lamEnv body
   where
+    lamCtx =
+      fc
+        { fcRetComptime = False,
+          fcWhere = "lambda",
+          fcAssigned = assignedNames body
+        }
     lamEnv =
       Map.fromList
-        [(idName (paramName p), if paramComptime p then CTComptime else CTRuntime) | p <- ps]
+        [ (idName (paramName p), CtInfo (if paramComptime p then CTComptime else CTRuntime) (paramComptime p))
+        | p <- ps
+        ]
         `Map.union` env
 checkExp _ _ _ = Right ()
 
@@ -198,9 +322,9 @@ checkExp _ _ _ = Right ()
 --   Skips polymorphic signatures (those whose comptime parameter types contain
 --   type variables): the concrete types are only known after specialisation,
 --   so polymorphic calls are deferred to the MAST-level check.
-checkCallSite :: SigTable -> CtEnv -> Id -> [Exp Id] -> Either String ()
-checkCallSite st env f args =
-  case Map.lookup (idName f) st of
+checkCallSite :: FunCtx -> CtEnv -> Id -> [Exp Id] -> Either String ()
+checkCallSite fc env f args =
+  case Map.lookup (idName f) (fcSigs fc) of
     Nothing -> Right ()
     Just sig
       | any (hasTypeVar . paramTy) (filter paramComptime (sigParams sig)) ->
@@ -209,7 +333,7 @@ checkCallSite st env f args =
           mapM_ checkArg (zip (sigParams sig) args)
   where
     checkArg (param, arg) =
-      when_ (paramComptime param && classifyExp st env arg == CTRuntime) $
+      when_ (paramComptime param && classifyExp fc env arg == CTRuntime) $
         "runtime value passed to comptime parameter '"
           ++ show (idName (paramName param))
           ++ "' of '"
@@ -240,13 +364,13 @@ hasTypeVar (TyCon _ ts) = any hasTypeVar ts
 -- Expression classification
 -----------------------------------------------------------------------
 
-classifyExp :: SigTable -> CtEnv -> Exp Id -> Ctness
+classifyExp :: FunCtx -> CtEnv -> Exp Id -> Ctness
 classifyExp _ _ (Lit _) = CTComptime
-classifyExp _ env (Var x) = Map.findWithDefault CTDeferred (idName x) env
-classifyExp st env (TyExp e _) = classifyExp st env e
-classifyExp st env (Call _ f args) = classifyCall st env f args
-classifyExp st env (Con _ args) = combineCt (map (classifyExp st env) args)
-classifyExp st env (Cond c t e) = combineCt (map (classifyExp st env) [c, t, e])
+classifyExp _ env (Var x) = maybe CTDeferred ctness (Map.lookup (idName x) env)
+classifyExp fc env (TyExp e _) = classifyExp fc env e
+classifyExp fc env (Call _ f args) = classifyCall fc env f args
+classifyExp fc env (Con _ args) = combineCt (map (classifyExp fc env) args)
+classifyExp fc env (Cond c t e) = combineCt (map (classifyExp fc env) [c, t, e])
 classifyExp _ _ _ = CTDeferred
 
 -- | Combine a list of Ctness values: all Comptime → Comptime;
@@ -263,9 +387,9 @@ combineCt cts
 --   means "result is comptime when this arg happens to be comptime", so all args
 --   must be checked, not just the comptime-annotated ones.
 --   Never CTRuntime for calls — uncertain cases are deferred to MAST.
-classifyCall :: SigTable -> CtEnv -> Id -> [Exp Id] -> Ctness
-classifyCall st env f args =
-  case Map.lookup (idName f) st of
+classifyCall :: FunCtx -> CtEnv -> Id -> [Exp Id] -> Ctness
+classifyCall fc env f args =
+  case Map.lookup (idName f) (fcSigs fc) of
     Nothing -> CTDeferred
     Just sig
       | effRetComptime sig && allArgsComptime ->
@@ -273,7 +397,7 @@ classifyCall st env f args =
       | otherwise ->
           CTDeferred
   where
-    allArgsComptime = all (\arg -> classifyExp st env arg == CTComptime) args
+    allArgsComptime = all (\arg -> classifyExp fc env arg == CTComptime) args
 
 -----------------------------------------------------------------------
 -- Helper

--- a/src/Solcore/Pipeline/SolcorePipeline.hs
+++ b/src/Solcore/Pipeline/SolcorePipeline.hs
@@ -201,10 +201,10 @@ compileWithDiagnostics opts = runExceptT $ do
 
       evaluated <- liftIO $ timeItNamed "Comptime eval " $ do
         let peFuel = maybe defaultFuel id (optPEFuel opts)
-            (evalResult, remainingFuel) = evalCompUnit peFuel specialized
+            (evalResult, fuelExhausted) = evalCompUnit peFuel specialized
 
         liftIO $
-          when (remainingFuel <= 0) $
+          when fuelExhausted $
             putStrLn "!! Warning: partial evaluation ran out of fuel (use --pe-fuel N to increase)"
 
         liftIO $ when (optDumpSpec opts) $ do

--- a/src/Solcore/Pipeline/SolcorePipeline.hs
+++ b/src/Solcore/Pipeline/SolcorePipeline.hs
@@ -17,7 +17,7 @@ import Language.Hull qualified as Hull
 import Solcore.Backend.ComptimeCheck (checkComptime)
 import Solcore.Backend.EmitHull (emitHull)
 import Solcore.Backend.Mast ()
-import Solcore.Backend.MastEval (defaultFuel, eliminateDeadCode, evalCompUnit)
+import Solcore.Backend.MastEval (defaultFuel, eliminateDeadCode, evalCompUnit, fuelExhaustedDiagnostic)
 import Solcore.Backend.Specialise (specialiseCompUnit)
 import Solcore.Desugarer.ArrayLitDesugar (arrayLitDesugarer)
 import Solcore.Desugarer.ContractDispatch (contractDispatchTopDecls, writeContractAbis)
@@ -199,19 +199,17 @@ compileWithDiagnostics opts = runExceptT $ do
         putStrLn "> Specialised contract:"
         putStrLn (pretty specialized)
 
-      evaluated <- liftIO $ timeItNamed "Comptime eval " $ do
+      (evaluated, fuelExhausted) <- liftIO $ timeItNamed "Comptime eval " $ do
         let peFuel = maybe defaultFuel id (optPEFuel opts)
-            (evalResult, fuelExhausted) = evalCompUnit peFuel specialized
-
-        liftIO $
-          when fuelExhausted $
-            putStrLn "!! Warning: partial evaluation ran out of fuel (use --pe-fuel N to increase)"
+            (evalResult, exhausted) = evalCompUnit peFuel specialized
 
         liftIO $ when (optDumpSpec opts) $ do
           putStrLn "> After partial evaluation:"
           putStrLn (pretty evalResult)
 
-        pure evalResult
+        pure (evalResult, exhausted)
+
+      handleWarningDiagnostics opts sources [fuelExhaustedDiagnostic | fuelExhausted]
 
       -- Dead code elimination: remove functions unreachable from 'start'/'main'
       let optimized = eliminateDeadCode evaluated

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -64,6 +64,7 @@ comptime =
       runTestForFile "string-lit-dedup.solc" comptimeFolder,
       runTestForFile "string-user-instance.solc" comptimeFolder,
       runTestForFile "string-param-erasure.solc" comptimeFolder,
+      runTestForFile "ct_param_erasure_word.solc" comptimeFolder,
       -- comptime verification: negative cases (must be rejected)
       runTestExpectingFailure "ct_param_runtime.solc" comptimeFolder,
       runTestExpectingFailure "ct_param_poly_runtime.solc" comptimeFolder,

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -1,6 +1,7 @@
 module Cases where
 
 import Control.Exception (try)
+import Data.List (isInfixOf)
 import Solcore.Pipeline.Options
 import Solcore.Pipeline.SolcorePipeline
 import System.Exit (ExitCode (..))
@@ -77,14 +78,15 @@ comptime =
       runTestExpectingFailure "ct_overloaded_bad.solc" comptimeFolder,
       runTestExpectingFailure "string-mem-runtime-fail.solc" comptimeFolder,
       -- comptime bindings are immutable, whatever is assigned to them
-      runTestExpectingFailure "ct_assign_fail.solc" comptimeFolder,
-      runTestExpectingFailure "ct_assign_comptime_rhs_fail.solc" comptimeFolder,
-      runTestExpectingFailure "ct_param_assign_fail.solc" comptimeFolder,
+      runTestExpectingError "cannot assign to comptime binding 'x'" "ct_assign_fail.solc" comptimeFolder,
+      runTestExpectingError "cannot assign to comptime binding 'x'" "ct_assign_comptime_rhs_fail.solc" comptimeFolder,
+      runTestExpectingError "cannot assign to comptime binding 'x'" "ct_param_assign_fail.solc" comptimeFolder,
       -- a comptime binding partial evaluation could not discharge is a
       -- runtime binding, however comptime it looks
-      runNamedTestExpectingFailure
+      runNamedTestExpectingError
         "ct_let_ok.solc (starved of fuel)"
         starvedOpt
+        "comptime let 'y' is bound to a runtime expression"
         "ct_let_ok.solc"
         comptimeFolder
     ]
@@ -771,4 +773,26 @@ runNamedTestExpectingFailure testName opts file folder =
       Left (ExitFailure _) -> return () -- Expected failure via exitFailure
       Left ExitSuccess -> assertFailure "Expected compilation to fail, but it exited successfully"
       Right (Left _) -> return () -- Expected failure via Either
+      Right (Right _) -> assertFailure "Expected compilation to fail, but it succeeded"
+
+-- | As 'runTestExpectingFailure', but pinning what the compiler said.  The
+--   expectation is a substring so that it survives changes to the surrounding
+--   diagnostic rendering.
+runTestExpectingError :: String -> FileName -> BaseFolder -> TestTree
+runTestExpectingError expected file folder =
+  runNamedTestExpectingError file (stdOpt {optNoGenDispatch = True}) expected file folder
+
+runNamedTestExpectingError :: String -> Option -> String -> FileName -> BaseFolder -> TestTree
+runNamedTestExpectingError testName opts expected file folder =
+  testCase testName $ do
+    let filePath = folder </> file
+    outcome <- try (compile opts {fileName = filePath, optRootDir = folder})
+    case outcome of
+      Left (code :: ExitCode) ->
+        assertFailure $ "Expected a reported error, but compilation exited with " ++ show code
+      Right (Left err)
+        | expected `isInfixOf` err -> return ()
+        | otherwise ->
+            assertFailure $
+              "Expected an error containing:\n  " ++ expected ++ "\nbut got:\n" ++ err
       Right (Right _) -> assertFailure "Expected compilation to fail, but it succeeded"

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -72,10 +72,19 @@ comptime =
       runTestExpectingFailure "ct_asm_mload_runtime.solc" comptimeFolder,
       runTestExpectingFailure "ct_asm_ret.solc" comptimeFolder,
       runTestExpectingFailure "ct_overloaded_bad.solc" comptimeFolder,
-      runTestExpectingFailure "string-mem-runtime-fail.solc" comptimeFolder
+      runTestExpectingFailure "string-mem-runtime-fail.solc" comptimeFolder,
+      -- a comptime binding partial evaluation could not discharge is a
+      -- runtime binding, however comptime it looks
+      runNamedTestExpectingFailure
+        "ct_let_ok.solc (starved of fuel)"
+        starvedOpt
+        "ct_let_ok.solc"
+        comptimeFolder
     ]
   where
     comptimeFolder = "./test/examples/comptime"
+    -- as runTestForFile compiles it, but with the fuel budget starved
+    starvedOpt = stdOpt {optNoGenDispatch = True, optPEFuel = Just 1}
 
 spec :: TestTree
 spec =

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -65,6 +65,8 @@ comptime =
       runTestForFile "string-user-instance.solc" comptimeFolder,
       runTestForFile "string-param-erasure.solc" comptimeFolder,
       runTestForFile "ct_param_erasure_word.solc" comptimeFolder,
+      -- a binding without the comptime modifier stays assignable
+      runTestForFile "ct_assign_plain_ok.solc" comptimeFolder,
       -- comptime verification: negative cases (must be rejected)
       runTestExpectingFailure "ct_param_runtime.solc" comptimeFolder,
       runTestExpectingFailure "ct_param_poly_runtime.solc" comptimeFolder,
@@ -74,6 +76,10 @@ comptime =
       runTestExpectingFailure "ct_asm_ret.solc" comptimeFolder,
       runTestExpectingFailure "ct_overloaded_bad.solc" comptimeFolder,
       runTestExpectingFailure "string-mem-runtime-fail.solc" comptimeFolder,
+      -- comptime bindings are immutable, whatever is assigned to them
+      runTestExpectingFailure "ct_assign_fail.solc" comptimeFolder,
+      runTestExpectingFailure "ct_assign_comptime_rhs_fail.solc" comptimeFolder,
+      runTestExpectingFailure "ct_param_assign_fail.solc" comptimeFolder,
       -- a comptime binding partial evaluation could not discharge is a
       -- runtime binding, however comptime it looks
       runNamedTestExpectingFailure

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -1,7 +1,10 @@
 module Cases where
 
 import Control.Exception (try)
+import Control.Monad (when)
 import Data.List (isInfixOf)
+import HullCases (checkHullObject)
+import Language.Hull qualified as Hull
 import Solcore.Pipeline.Options
 import Solcore.Pipeline.SolcorePipeline
 import System.Exit (ExitCode (..))
@@ -65,7 +68,10 @@ comptime =
       runTestForFile "string-lit-dedup.solc" comptimeFolder,
       runTestForFile "string-user-instance.solc" comptimeFolder,
       runTestForFile "string-param-erasure.solc" comptimeFolder,
-      runTestForFile "ct_param_erasure_word.solc" comptimeFolder,
+      -- an erased parameter has to be gone from the body, not just the
+      -- signature, so these are checked at the Hull level too
+      runTestCheckingHull "ct_param_erasure_word.solc" comptimeFolder,
+      runTestCheckingHull "string-param-clone-erasure.solc" comptimeFolder,
       -- a binding without the comptime modifier stays assignable
       runTestForFile "ct_assign_plain_ok.solc" comptimeFolder,
       -- comptime verification: negative cases (must be rejected)
@@ -754,6 +760,27 @@ runNamedTestForFile testName opts file folder =
     case result of
       Left err -> assertFailure err
       Right _ -> return ()
+
+-- | As 'runTestForFile', but type-checking the Hull that came out.  The
+--   pipeline never runs the Hull checker on its own output, so an emission bug
+--   -- a reference to a variable that no longer exists, say -- otherwise
+--   surfaces only in `yule`, well after a green test run.
+runTestCheckingHull :: FileName -> BaseFolder -> TestTree
+runTestCheckingHull file folder = testCase (file ++ " (hull type-checked)") $ do
+  let opts = stdOpt {optNoGenDispatch = True, fileName = folder </> file, optRootDir = folder}
+  result <- compile opts
+  case result of
+    Left err -> assertFailure err
+    Right objs -> do
+      when (null objs) $ assertFailure "compilation emitted no hull"
+      mapM_ assertHullTypeChecks objs
+
+assertHullTypeChecks :: Hull.Object -> Assertion
+assertHullTypeChecks obj = do
+  outcome <- checkHullObject obj
+  case outcome of
+    Left err -> assertFailure (show (Hull.objName obj) ++ ": " ++ err)
+    Right () -> return ()
 
 runTestExpectingFailure :: FileName -> BaseFolder -> TestTree
 runTestExpectingFailure file folder = runTestExpectingFailureWith option file folder

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -83,6 +83,12 @@ comptime =
       runTestExpectingFailure "ct_asm_ret.solc" comptimeFolder,
       runTestExpectingFailure "ct_overloaded_bad.solc" comptimeFolder,
       runTestExpectingFailure "string-mem-runtime-fail.solc" comptimeFolder,
+      -- a comptime builtin's stub body must never be inlined: doing so answers
+      -- with its placeholder instead of letting the call be reported
+      runTestExpectingError
+        "runtime value passed to comptime parameter 'a' of 'std_keccakWordLit'"
+        "ct_builtin_runtime_arg_fail.solc"
+        comptimeFolder,
       -- comptime bindings are immutable, whatever is assigned to them
       runTestExpectingError "cannot assign to comptime binding 'x'" "ct_assign_fail.solc" comptimeFolder,
       runTestExpectingError "cannot assign to comptime binding 'x'" "ct_assign_comptime_rhs_fail.solc" comptimeFolder,

--- a/test/ComptimeCheckTests.hs
+++ b/test/ComptimeCheckTests.hs
@@ -1,0 +1,43 @@
+module ComptimeCheckTests (comptimeCheckTests) where
+
+import Data.Either (isLeft, isRight)
+import Solcore.Backend.ComptimeCheck (checkComptime)
+import Solcore.Backend.Mast
+import Solcore.Frontend.Syntax.Name
+import Solcore.Frontend.Syntax.Stmt (Literal (..))
+import Test.Tasty
+import Test.Tasty.HUnit
+
+wordTy :: MastTy
+wordTy = MastTyCon (Name "word") []
+
+param :: Bool -> String -> MastParam
+param ct n = MastParam (Name n) ct wordTy
+
+-- A function returning the value of its first parameter, or 1 if it has none.
+fundef :: String -> [MastParam] -> Bool -> MastFunDef
+fundef n ps retCt = MastFunDef (Name n) ps retCt wordTy [MastReturn body]
+  where
+    body = case ps of
+      [] -> MastLit (IntLit 1)
+      (p : _) -> MastVar (MastId (mastParamName p) wordTy)
+
+unitOf :: [MastFunDef] -> MastCompUnit
+unitOf fds = MastCompUnit [] [MastTContr (MastContract (Name "C") (map MastCFunDecl fds))]
+
+comptimeCheckTests :: TestTree
+comptimeCheckTests =
+  testGroup
+    "Comptime verification"
+    [ testCase "function with no comptime annotation is accepted" $
+        assertBool "expected acceptance" $
+          isRight (checkComptime (unitOf [fundef "f" [param False "x"] False])),
+      -- Partial evaluation substitutes comptime arguments and drops the
+      -- parameters; one still standing means that never happened.
+      testCase "surviving comptime parameter is rejected" $
+        assertBool "expected rejection" $
+          isLeft (checkComptime (unitOf [fundef "f" [param True "n"] False])),
+      testCase "surviving comptime return is rejected" $
+        assertBool "expected rejection" $
+          isLeft (checkComptime (unitOf [fundef "f" [] True]))
+    ]

--- a/test/ComptimeCheckTests.hs
+++ b/test/ComptimeCheckTests.hs
@@ -1,6 +1,5 @@
 module ComptimeCheckTests (comptimeCheckTests) where
 
-import Data.Either (isLeft, isRight)
 import Solcore.Backend.ComptimeCheck (checkComptime)
 import Solcore.Backend.Mast
 import Solcore.Frontend.Syntax.Name
@@ -14,30 +13,96 @@ wordTy = MastTyCon (Name "word") []
 param :: Bool -> String -> MastParam
 param ct n = MastParam (Name n) ct wordTy
 
+var :: String -> MastExp
+var n = MastVar (MastId (Name n) wordTy)
+
 -- A function returning the value of its first parameter, or 1 if it has none.
 fundef :: String -> [MastParam] -> Bool -> MastFunDef
-fundef n ps retCt = MastFunDef (Name n) ps retCt wordTy [MastReturn body]
+fundef n ps retCt = funWithBody n ps retCt [MastReturn body]
   where
     body = case ps of
       [] -> MastLit (IntLit 1)
-      (p : _) -> MastVar (MastId (mastParamName p) wordTy)
+      (p : _) -> var (show (mastParamName p))
+
+funWithBody :: String -> [MastParam] -> Bool -> [MastStmt] -> MastFunDef
+funWithBody n ps retCt = MastFunDef (Name n) ps retCt wordTy
 
 unitOf :: [MastFunDef] -> MastCompUnit
 unitOf fds = MastCompUnit [] [MastTContr (MastContract (Name "C") (map MastCFunDecl fds))]
+
+accepts :: String -> MastCompUnit -> TestTree
+accepts name cu =
+  testCase name $ checkComptime cu @?= Right ()
+
+rejects :: String -> String -> MastCompUnit -> TestTree
+rejects name expected cu =
+  testCase name $ checkComptime cu @?= Left expected
 
 comptimeCheckTests :: TestTree
 comptimeCheckTests =
   testGroup
     "Comptime verification"
-    [ testCase "function with no comptime annotation is accepted" $
-        assertBool "expected acceptance" $
-          isRight (checkComptime (unitOf [fundef "f" [param False "x"] False])),
+    [ accepts "function with no comptime annotation is accepted" $
+        unitOf [fundef "f" [param False "x"] False],
       -- Partial evaluation substitutes comptime arguments and drops the
       -- parameters; one still standing means that never happened.
-      testCase "surviving comptime parameter is rejected" $
-        assertBool "expected rejection" $
-          isLeft (checkComptime (unitOf [fundef "f" [param True "n"] False])),
-      testCase "surviving comptime return is rejected" $
-        assertBool "expected rejection" $
-          isLeft (checkComptime (unitOf [fundef "f" [] True]))
+      rejects
+        "surviving comptime parameter is rejected"
+        "comptime parameter 'n' of 'f' survived partial evaluation"
+        $ unitOf [fundef "f" [param True "n"] False],
+      rejects
+        "surviving comptime return is rejected"
+        "function 'f' annotated '-> comptime' survived partial evaluation"
+        $ unitOf [fundef "f" [] True],
+      -- A parameter reference is not a value, so the comptime promise the
+      -- return annotation makes is unmet.
+      rejects
+        "'-> comptime' returning a non-value is rejected"
+        "function 'f' annotated '-> comptime' returns a runtime expression"
+        $ unitOf [fundef "f" [param False "x"] True],
+      accepts "comptime let bound to a literal is accepted" $
+        unitOf
+          [ funWithBody
+              "f"
+              []
+              False
+              [ MastLet True (MastId (Name "x") wordTy) (Just wordTy) (Just (MastLit (IntLit 7))),
+                MastReturn (var "x")
+              ]
+          ],
+      -- A residual call is a runtime computation whatever it computes:
+      -- evaluation has already had its chance to fold it.
+      rejects
+        "comptime let bound to a residual call is rejected"
+        "comptime let 'x' is bound to a runtime expression"
+        $ unitOf
+          [ fundef "g" [] False,
+            funWithBody
+              "f"
+              []
+              False
+              [ MastLet True (MastId (Name "x") wordTy) (Just wordTy) (Just (MastCall (MastId (Name "g") wordTy) [])),
+                MastReturn (var "x")
+              ]
+          ],
+      rejects
+        "non-value argument to a comptime parameter is rejected"
+        "runtime value passed to comptime parameter 'n' of 'g'"
+        $ unitOf
+          [ fundef "g" [param True "n"] False,
+            funWithBody
+              "f"
+              [param False "x"]
+              False
+              [MastReturn (MastCall (MastId (Name "g") wordTy) [var "x"])]
+          ],
+      accepts "literal argument to a comptime parameter is accepted" $
+        unitOf
+          [ fundef "g" [param False "n"] False,
+            funWithBody
+              "f"
+              []
+              False
+              [MastReturn (MastCall (MastId (Name "g") wordTy) [MastLit (IntLit 3)])]
+          ]
     ]

--- a/test/DiagnosticCliTests.hs
+++ b/test/DiagnosticCliTests.hs
@@ -200,8 +200,48 @@ diagnosticCliTests =
       testCase "warnings deny" $
         expectFailure
           ["--root", "test/examples/cases", "--file", "test/examples/cases/redundant-match.solc", "--no-specialise", "--warnings", "deny"]
-          (map denyWarningLine redundantWarningsSnapshot)
+          (map denyWarningLine redundantWarningsSnapshot),
+      testCase "fuel warning always" $
+        expectSuccess
+          (fuelArgs "always")
+          [ "warning[SC0401]: partial evaluation ran out of fuel",
+            "help: pass --pe-fuel N to raise the budget",
+            "Emitting hull for contract Fuel",
+            "Writing to " ++ fuelOutputDir ++ "/output1.hull"
+          ],
+      testCase "fuel warning never" $
+        expectSuccess
+          (fuelArgs "never")
+          [ "Emitting hull for contract Fuel",
+            "Writing to " ++ fuelOutputDir ++ "/output1.hull"
+          ],
+      testCase "fuel warning deny" $
+        expectFailure
+          (fuelArgs "deny")
+          [ "error[SC0401]: partial evaluation ran out of fuel",
+            "help: pass --pe-fuel N to raise the budget",
+            "help: pass --warnings=default, --warnings=always, or --warnings=never to allow this warning"
+          ]
     ]
+
+-- | Starve partial evaluation of fuel so that compiling a trivial contract
+--   still reports exhaustion, and send the emitted hull somewhere disposable.
+fuelArgs :: String -> [String]
+fuelArgs policy =
+  [ "--root",
+    "test/diagnostics",
+    "--file",
+    "test/diagnostics/fuel-exhausted.solc",
+    "--pe-fuel",
+    "1",
+    "--output-dir",
+    fuelOutputDir,
+    "--warnings",
+    policy
+  ]
+
+fuelOutputDir :: FilePath
+fuelOutputDir = "dist-newstyle/fuel-warning"
 
 expectSuccess :: [String] -> [String] -> Assertion
 expectSuccess args expectedLines = do

--- a/test/HullCases.hs
+++ b/test/HullCases.hs
@@ -1,5 +1,6 @@
-module HullCases (hullTests) where
+module HullCases (hullTests, checkHullFile, checkHullObject) where
 
+import Language.Hull (Object)
 import Language.Hull.Parser (parseObject)
 import Language.Hull.TcEnv (emptyHullTcEnv)
 import Language.Hull.TcMonad (runHullTcM)
@@ -51,5 +52,7 @@ runHullTestExpectingFailure file = testCase file $ do
 checkHullFile :: FilePath -> IO (Either String ())
 checkHullFile path = do
   src <- readFile path
-  let obj = parseObject path src
-  runHullTcM (checkObject obj) emptyHullTcEnv
+  checkHullObject (parseObject path src)
+
+checkHullObject :: Object -> IO (Either String ())
+checkHullObject obj = runHullTcM (checkObject obj) emptyHullTcEnv

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,6 +1,7 @@
 module Main where
 
 import Cases
+import ComptimeCheckTests
 import ContractAbiTests
 import DiagnosticCliTests
 import DiagnosticTests
@@ -39,6 +40,7 @@ tests =
       contractAbiTests,
       matchTests,
       yulEvalTests,
+      comptimeCheckTests,
       hullTests,
       specialiseTests
     ]

--- a/test/YulEvalTests.hs
+++ b/test/YulEvalTests.hs
@@ -4,7 +4,18 @@ import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Word (Word8)
 import Language.Yul (YLiteral (..), YulExp (..), YulStmt (..))
-import Solcore.Backend.Mast (MastExp (..), MastId (..), MastTy (..), mastIdName)
+import Solcore.Backend.Mast
+  ( MastCompUnit (..),
+    MastContract (..),
+    MastContractDecl (..),
+    MastExp (..),
+    MastFunDef (..),
+    MastId (..),
+    MastStmt (..),
+    MastTopDecl (..),
+    MastTy (..),
+    mastIdName,
+  )
 import Solcore.Backend.MastEval
 import Solcore.Frontend.Syntax.Name
 import Solcore.Frontend.Syntax.Stmt (Literal (..))
@@ -66,7 +77,35 @@ yulEvalTests =
       substYulBlockTests,
       memoryHelperTests,
       memoryEvalTests,
-      asmIsInterpretableTests
+      asmIsInterpretableTests,
+      fuelExhaustionTests
+    ]
+
+-----------------------------------------------------------------------
+-- Fuel exhaustion
+-----------------------------------------------------------------------
+
+wordTy :: MastTy
+wordTy = MastTyCon (Name "word") []
+
+-- A unit whose 'main' calls 'callee': evaluating that call needs fuel.
+callUnit :: MastCompUnit
+callUnit = MastCompUnit [] [MastTContr (MastContract (Name "C") decls)]
+  where
+    decls =
+      [ MastCFunDecl (fundef "main" [MastReturn (MastCall (MastId (Name "callee") wordTy) [])]),
+        MastCFunDecl (fundef "callee" [MastReturn (intLit 1)])
+      ]
+    fundef n body = MastFunDef (Name n) [] False wordTy body
+
+fuelExhaustionTests :: TestTree
+fuelExhaustionTests =
+  testGroup
+    "fuel exhaustion"
+    [ testCase "empty budget is reported" $
+        snd (evalCompUnit 0 callUnit) @?= True,
+      testCase "sufficient budget is not reported" $
+        snd (evalCompUnit defaultFuel callUnit) @?= False
     ]
 
 -----------------------------------------------------------------------

--- a/test/YulEvalTests.hs
+++ b/test/YulEvalTests.hs
@@ -599,22 +599,5 @@ asmIsInterpretableTests =
           [ yAssign "a" (yCall "add" [yIdent "x", yIdent "y"]),
             yAssign "b" (yCall "sload" [yNum 0])
           ]
-          @?= False,
-      -- Strict variant (memOk = False), used by the comptime check: memory ops
-      -- are NOT interpretable, but pure arithmetic still is.
-      testCase "strict: mload in assignment → False" $
-        asmIsInterpretableWith False [yAssign "r" (yCall "mload" [yNum 0])]
-          @?= False,
-      testCase "strict: mstore expression stmt → False" $
-        asmIsInterpretableWith False [yExp "mstore" [yNum 0, yIdent "v"]]
-          @?= False,
-      testCase "strict: mstore8 expression stmt → False" $
-        asmIsInterpretableWith False [yExp "mstore8" [yNum 31, yNum 0xff]]
-          @?= False,
-      testCase "strict: add-assign still → True" $
-        asmIsInterpretableWith False [yAssign "rw" (yCall "add" [yIdent "x", yIdent "y"])]
-          @?= True,
-      testCase "strict: nested mload inside arithmetic → False" $
-        asmIsInterpretableWith False [yAssign "r" (yCall "add" [yCall "mload" [yNum 0], yNum 1])]
           @?= False
     ]

--- a/test/diagnostics/fuel-exhausted.solc
+++ b/test/diagnostics/fuel-exhausted.solc
@@ -1,0 +1,5 @@
+contract Fuel {
+  public function main() -> word {
+    return 42;
+  }
+}

--- a/test/examples/comptime/ct_assign_comptime_rhs_fail.solc
+++ b/test/examples/comptime/ct_assign_comptime_rhs_fail.solc
@@ -1,0 +1,13 @@
+/* Negative: assignment to a comptime binding, even from a literal — must fail.
+   The right-hand side being comptime does not help: the binding is erased
+   once discharged, so the assignment loses its target either way.
+*/
+import std;
+
+contract ComptimeAssignLiteral {
+  function main() -> word {
+    let x : comptime word = 5;
+    x = 6;
+    return x;
+  }
+}

--- a/test/examples/comptime/ct_assign_fail.solc
+++ b/test/examples/comptime/ct_assign_fail.solc
@@ -1,0 +1,18 @@
+/* Negative: assignment to a comptime binding — must fail.
+   A comptime binding is immutable.  Partial evaluation discharges the
+   binding and erases the 'let', so an assignment left behind would refer
+   to a variable that is no longer declared.
+*/
+import std;
+
+contract ComptimeAssign {
+  function main() -> word {
+    let x : comptime word = 5;
+    let v : word;
+    assembly {
+      v := sload(0)
+    }
+    x = v;
+    return x;
+  }
+}

--- a/test/examples/comptime/ct_assign_plain_ok.solc
+++ b/test/examples/comptime/ct_assign_plain_ok.solc
@@ -1,0 +1,17 @@
+/* Positive: the same shape without 'comptime' still compiles.
+   Only declared-comptime bindings are immutable; an ordinary local
+   initialised from a literal may still be assigned a runtime value.
+*/
+import std;
+
+contract PlainAssign {
+  function main() -> word {
+    let x : word = 5;
+    let v : word;
+    assembly {
+      v := sload(0)
+    }
+    x = v;
+    return x;
+  }
+}

--- a/test/examples/comptime/ct_builtin_runtime_arg_fail.solc
+++ b/test/examples/comptime/ct_builtin_runtime_arg_fail.solc
@@ -1,0 +1,20 @@
+/* A comptime builtin given a runtime argument is rejected, not folded.
+
+   `keccakWordLit` is a stub -- `unimplemented(); return 0;` -- because folding
+   it is MastEval's job, and reaching its body means folding did not happen.
+   Inlining that body would answer 0, quietly, so inlining has to decline: the
+   call then survives for the comptime verifier to report.
+*/
+
+import std;
+import std.{*};
+
+contract KeccakWordLitRuntime {
+  function main() -> word {
+    let v : word;
+    assembly {
+      v := sload(0)
+    }
+    return std.keccakWordLit(v);
+  }
+}

--- a/test/examples/comptime/ct_param_assign_fail.solc
+++ b/test/examples/comptime/ct_param_assign_fail.solc
@@ -1,0 +1,15 @@
+/* Negative: assignment to a comptime parameter — must fail.
+   A comptime parameter is substituted away by partial evaluation, so it
+   is immutable for the same reason a comptime let is.
+*/
+import std;
+
+contract ComptimeParamAssign {
+  function double(comptime x : word) -> comptime word {
+    x = 7;
+    return x + x;
+  }
+  function main() -> word {
+    return double(21);
+  }
+}

--- a/test/examples/comptime/ct_param_erasure_word.solc
+++ b/test/examples/comptime/ct_param_erasure_word.solc
@@ -1,0 +1,24 @@
+/* A comptime parameter is erased even when the callee cannot be folded away.
+
+   `scaled` reads storage, so it is impure and inlining it is not an option:
+   the call survives into the generated code. Its `comptime n` argument must
+   still be substituted, otherwise the specialisation the annotation asks for
+   never happens and a comptime value is passed at runtime.
+
+   main returns sload(0) * 4.
+*/
+
+import std;
+
+contract ComptimeParamErasureWord {
+  function scaled(comptime n : word) -> word {
+    let v : word;
+    assembly {
+      v := sload(0)
+    }
+    return v * n;
+  }
+  function main() -> word {
+    return scaled(4);
+  }
+}

--- a/test/examples/comptime/string-param-clone-erasure.solc
+++ b/test/examples/comptime/string-param-clone-erasure.solc
@@ -1,0 +1,31 @@
+/* A `string` parameter is erased even when the callee cannot be folded away.
+
+   `tagged` reads storage, so it is impure and inlining it is not an option:
+   the call survives into the generated code. A `string` has no runtime
+   representation, so the parameter must still go -- MastEval clones the
+   callee with the literal substituted and drops the parameter, while the
+   runtime `word` argument is passed to the clone as usual. A surviving
+   string-typed parameter is a hard error at hull emission.
+
+   main returns sload(0) + sload(1) + strlenLit("abcd") = sload(0) + sload(1) + 4.
+*/
+
+import std;
+import std.{*};
+
+contract StringParamCloneErasure {
+  function tagged(s : string, x : word) -> word {
+    let v : word;
+    assembly {
+      v := sload(0)
+    }
+    return v + x + std.strlenLit(s);
+  }
+  function main() -> word {
+    let r : word;
+    assembly {
+      r := sload(1)
+    }
+    return tagged("abcd", r);
+  }
+}


### PR DESCRIPTION
Three comptime failures were silent. This branch turns each into a rejection
with a message, and pins the messages so they cannot quietly stop working.

**Assigning to a comptime binding emitted structurally invalid Hull** 

`MastEval` drops the `let` when a comptime binding is discharged
but always re-emits the assignment, so the body referenced an undeclared
variable. Neither comptime checker looked at an assignment target, and the
pipeline never runs `Language.Hull.TypeCheck` on its own output, so only `yule`
caught it — well after a green build. The rule now lives in
`Solcore.Frontend.ComptimeCheck`, where source spans exist: a *declared*
comptime binding (`let x : comptime word`, or a `comptime` parameter) is
immutable, including against assignment from inside an `assembly` block, which
reaches enclosing variables by name. Parameters merely treated as comptime
because the result is comptime are unaffected — those are assumptions, not
declarations.

Fixing that exposed a flow-insensitivity hole: `if` / `for` / `match` discard
the environment their bodies produce, so `let x = 5; x = <runtime>; f(x)`
classified `x` as comptime. An unannotated `let` whose name is assigned
anywhere in the function now yields `CTDeferred`.

**Fuel exhaustion was a bare `putStrLn`**, so `--warnings never` did not
silence it, `--warnings deny` did not escalate it, and nothing could assert it.
It is now `warning[SC0401]` through the normal diagnostics path, reported from
a sticky flag rather than inferred from the remaining budget.

**The Mast-level checker's open/closed function split was decorative.**
`fcOpen` was true exactly when `checkNothingLeftToSubstitute` rejects
unconditionally, so the split only chose which message a doomed program got.
Collapsed to `isValue`; the module header now states the one rule the pass
enforces.

Two correctness bugs turned up while writing the fixture for the `string`
clone relaxation, both worse than anything above:

- `tryCloneComptime` erased a parameter from the clone's signature but left its
  value only in the partial evaluator's variable environment. That environment
  is cleared at every opaque `assembly` block and at every `for` loop, so one
  `sload` in the body and the clone referenced a parameter that no longer
  existed — again exit 0, again caught only by `yule` (`Undefined variable:
  n`). The literals are now substituted into the body at clone creation, and a
  parameter the body assigns to is not erased at all.
- `evalFunBody` walked past every statement-expression while extracting a
  callee's return value, so inlining silently dropped any statement whose
  result was discarded but whose *effect* was not. `encodeNone` in
  `test/examples/dispatch/generic_sum.solc` lost its entire ABI encoding —
  allocate a zeroed buffer, never write to it, read it back — and passed its
  contract test only because `None` encodes as zeros. The same hole let a
  comptime builtin's stub body (`unimplemented(); return 0;`) inline to its
  placeholder, so `keccakWordLit(<runtime word>)` compiled to `return 0`
  instead of being reported.

**A residual call no longer counts as comptime.** The Mast-level checker
classified an expression structurally: comptime if it was a literal, a
comptime-bound variable, or a call to a *pure* function with comptime
arguments. But this pass runs after partial evaluation has already had its
chance at every function, so a call that is still there is one the evaluator
declined to fold — a runtime computation whatever its shape. The obligation
is now discharged only by a value: a literal, or a constructor applied to
values. That is also what makes exhausted fuel a rejection rather than
silently worse code.

This subsumes #566. That PR excluded memory-op functions from the purity
notion feeding the classifier, so an unfoldable `mload` read would stop being
classified comptime; under the value rule *any* residual call is rejected,
memory or not, so `computeComptimePureFuns` and the `memOk` flag it needed
are gone (its fixture, `ct_asm_mload_runtime.solc`, still passes — the five
`asmIsInterpretableWith False` unit tests went with the function).

A second pass then rejects any comptime annotation that survives to emission
at all: every function reaching this point is about to be emitted, so a
comptime parameter means the argument was never substituted, and a comptime
return means no call to it was ever folded.

Assisted-By: Claude Opus 5