### PR TITLE
Implementing implicit coercions

### DIFF
--- a/run_contests.sh
+++ b/run_contests.sh
@@ -61,3 +61,7 @@ bash ./contest.sh test/examples/dispatch/weth9.json
 bash ./contest.sh test/examples/dispatch/derive_ord.json
 bash ./contest.sh test/examples/dispatch/derive_contract_local.json
 bash ./contest.sh test/examples/dispatch/deposit.json
+bash ./contest.sh test/examples/dispatch/coerce.json
+bash ./contest.sh test/examples/dispatch/coerce_implicit.json
+bash ./contest.sh test/examples/dispatch/coerce_sites.json
+bash ./contest.sh test/examples/dispatch/coerce_keyword.json

--- a/sol-core.cabal
+++ b/sol-core.cabal
@@ -103,6 +103,7 @@ library
       Solcore.Frontend.Syntax.NameResolution
       Solcore.Frontend.Syntax.Stmt
       Solcore.Frontend.Syntax.SyntaxTree
+      Solcore.Frontend.TypeInference.CoercionGraph
       Solcore.Frontend.TypeInference.Erase
       Solcore.Frontend.TypeInference.Id
       Solcore.Frontend.TypeInference.InvokeGen
@@ -191,6 +192,7 @@ test-suite sol-core-tests
   -- cabal-fmt: expand test -Main
   other-modules:
     Cases
+    CoercionGraphTests
     ContractAbiTests
     DiagnosticCliTests
     DiagnosticTests

--- a/src/Solcore/Frontend/Parser/Decl.hs
+++ b/src/Solcore/Frontend/Parser/Decl.hs
@@ -372,6 +372,69 @@ instanceAfterPrefix vars ctx = do
   funs <- braces (many funDefP)
   return (Instance isDefault vars ctx iname params mty funs)
 
+-- forall vs . coercion S -> T by f; the surface syntax for an implicit
+-- coercion. It desugars to the internal Coerce instance encoding, so
+-- the rest of the pipeline treats it exactly like a hand-written instance.
+-- S and T are parsed as atomic types so the -> separator is not mistaken
+-- for a function-type arrow.
+coercionAfterPrefix :: [Ty] -> [Pred] -> Parser Instance
+coercionAfterPrefix vars ctx = do
+  keyword "coercion"
+  src <- atomTypeP
+  _ <- symbol "->"
+  tgt <- atomTypeP
+  keyword "by"
+  witness <- qualifiedName
+  _ <- semicolon
+  return (coercionInstance vars ctx src tgt witness)
+
+-- Build the Coerce instance a coercion S -> T by f declaration desugars to:
+--
+-- > instance [vs .] Pair(S, Proxy(T)) : Coerce(T) {
+-- >   function coerce(p : Pair(S, Proxy(T))) -> T {
+-- >     match p { | Pair(x, _) => return f(x); }
+-- >   }
+-- > }
+--
+-- The @Pair(S, Proxy(T))@ head lets several targets share one source without
+-- tripping the instance-overlap check; coherence is enforced separately by the
+-- coercion graph.
+coercionInstance :: [Ty] -> [Pred] -> Ty -> Ty -> Name -> Instance
+coercionInstance vars ctx src tgt witness =
+  Instance
+    { instDefault = False,
+      instVars = vars,
+      instContext = ctx,
+      instName = Name "Coerce",
+      paramsTy = [tgt],
+      mainTy = headTy,
+      instFunctions = [coerceFun]
+    }
+  where
+    headTy = TyCon (Name "Pair") [src, TyCon (Name "Proxy") [tgt]]
+    coerceFun =
+      FunDef
+        { funIsPublic = False,
+          funSignature =
+            Signature
+              { sigVars = [],
+                sigContext = [],
+                sigName = Name "coerce",
+                sigParams = [Typed False (Name "p") headTy],
+                sigRetComptime = False,
+                sigReturn = Just tgt,
+                sigPayable = False
+              },
+          funDefBody =
+            [ Match
+                [ExpVar Nothing (Name "p")]
+                [ ( [Pat (Name "Pair") [Pat (Name "x") [], PWildcard]],
+                    [Return (ExpName Nothing witness [ExpVar Nothing (Name "x")])]
+                  )
+                ]
+            ]
+        }
+
 contractP :: Parser Contract
 contractP = do
   keyword "contract"
@@ -438,7 +501,8 @@ topDeclP =
             choice
               [ TFunDef <$> funDefAfterPrefix False vars ctx,
                 TClassDef <$> classAfterPrefix vars ctx,
-                TInstDef <$> instanceAfterPrefix vars ctx
+                TInstDef <$> instanceAfterPrefix vars ctx,
+                TInstDef <$> coercionAfterPrefix vars ctx
               ]
         )
     ]

--- a/src/Solcore/Frontend/TypeInference/CoercionGraph.hs
+++ b/src/Solcore/Frontend/TypeInference/CoercionGraph.hs
@@ -1,0 +1,123 @@
+-- The coercion graph: the mechanism behind implicit coercions 
+-- Coercions are declared as Coerce instances whose head encodes the edge as
+-- Pair(S, Proxy(T)) : Coerce(T). This module reads those
+-- edges, builds a directed graph over coercion-endpoint types, and resolves a
+-- needed coercion S -> T to a single, deterministic canonical path.
+module Solcore.Frontend.TypeInference.CoercionGraph
+  ( CoercionEdge (..),
+    CoercionGraph,
+    emptyCoercionGraph,
+    coercionEdgeOf,
+    buildCoercionGraph,
+    canonicalCoercionPath,
+    coercionNodes,
+  )
+where
+
+import Data.List (intercalate, nub, sortOn)
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Solcore.Frontend.Syntax.Name
+import Solcore.Frontend.Syntax.Ty
+
+-- A declared coercion edge S -> T with its witness function/constructor.
+data CoercionEdge = CoercionEdge
+  { ceSrc :: Ty,
+    ceTgt :: Ty,
+    ceWitness :: Name
+  }
+  deriving (Eq, Show)
+
+-- A location-insensitive structural key for a (ground) coercion endpoint.
+tyKey :: Ty -> String
+tyKey (TyVar v) = "#" ++ show (tyvarName v)
+tyKey (Meta m) = "?" ++ show (metaName m)
+tyKey (TyCon n ts) = show n ++ "(" ++ intercalate "," (map tyKey ts) ++ ")"
+
+-- The graph: adjacency keyed by source-node key, plus a representative Ty
+-- per node key so callers can recover the endpoint types.
+data CoercionGraph = CoercionGraph
+  { cgAdj :: Map String [(String, Name)],
+    cgRep :: Map String Ty
+  }
+  deriving (Show)
+
+emptyCoercionGraph :: CoercionGraph
+emptyCoercionGraph = CoercionGraph Map.empty Map.empty
+
+-- Recognize a Coerce instance head and read off its edge. The head is
+-- Pair(S, Proxy(T)) : Coerce(T); return (S, T).
+coercionEdgeOf :: Name -> Ty -> Maybe (Ty, Ty)
+coercionEdgeOf cls main
+  | cls == Name "Coerce",
+    TyCon pair [s, TyCon proxy [t]] <- main,
+    pair == Name "Pair",
+    proxy == Name "Proxy" =
+      Just (s, t)
+  | otherwise = Nothing
+
+-- Build the graph from all declared coercion edges, running the decidable
+-- coherence check (no two edges with the same (src,tgt) but different
+-- witnesses). Returns a diagnostic on failure.
+buildCoercionGraph :: [CoercionEdge] -> Either String CoercionGraph
+buildCoercionGraph edges =
+  do
+    checkDuplicateEdges edges
+    let adj =
+          Map.fromListWith
+            (++)
+            [(tyKey (ceSrc e), [(tyKey (ceTgt e), ceWitness e)]) | e <- edges]
+        rep =
+          Map.fromList $
+            concat [[(tyKey (ceSrc e), ceSrc e), (tyKey (ceTgt e), ceTgt e)] | e <- edges]
+    pure (CoercionGraph adj rep)
+
+-- Reject a source/target pair declared with more than one distinct witness.
+checkDuplicateEdges :: [CoercionEdge] -> Either String ()
+checkDuplicateEdges edges =
+  let byPair =
+        Map.fromListWith
+          (++)
+          [((tyKey (ceSrc e), tyKey (ceTgt e)), [ceWitness e]) | e <- edges]
+      clash = [(s, t, nub ws) | ((s, t), ws) <- Map.toList byPair, length (nub ws) > 1]
+   in case clash of
+        [] -> Right ()
+        ((s, t, ws) : _) ->
+          Left $
+            "coercion "
+              ++ s
+              ++ " -> "
+              ++ t
+              ++ " declared with multiple different witnesses: "
+              ++ intercalate ", " (map show ws)
+
+-- The node keys present in the graph.
+coercionNodes :: CoercionGraph -> [String]
+coercionNodes = Map.keys . cgRep
+
+-- The canonical coercion path S -> T
+canonicalCoercionPath :: CoercionGraph -> Ty -> Ty -> Maybe [Name]
+canonicalCoercionPath g s t
+  | sk == tk = Just []
+  | otherwise = bfs (cgAdj g) sk tk
+  where
+    sk = tyKey s
+    tk = tyKey t
+
+-- Deterministic breadth-first search. Neighbors are explored in sorted key
+-- order and nodes are marked visited on enqueue, so the first path reaching the
+-- goal is the shortest one under a fixed tie-break: the canonical path.
+bfs :: Map String [(String, Name)] -> String -> String -> Maybe [Name]
+bfs adj start goal = go [(start, [])] (Set.singleton start)
+  where
+    go :: [(String, [Name])] -> Set String -> Maybe [Name]
+    go [] _ = Nothing
+    go ((cur, revWits) : queue) visited
+      | cur == goal = Just (reverse revWits)
+      | otherwise =
+          let neighbors = sortOn fst (Map.findWithDefault [] cur adj)
+              fresh = [(n, w : revWits) | (n, w) <- neighbors, not (Set.member n visited)]
+              visited' = foldr (Set.insert . fst) visited fresh
+           in go (queue ++ fresh) visited'

--- a/src/Solcore/Frontend/TypeInference/CoercionGraph.hs
+++ b/src/Solcore/Frontend/TypeInference/CoercionGraph.hs
@@ -1,4 +1,4 @@
--- The coercion graph: the mechanism behind implicit coercions 
+-- The coercion graph: the mechanism behind implicit coercions
 -- Coercions are declared as Coerce instances whose head encodes the edge as
 -- Pair(S, Proxy(T)) : Coerce(T). This module reads those
 -- edges, builds a directed graph over coercion-endpoint types, and resolves a

--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -12,15 +12,15 @@ import Data.Set qualified as Set
 import GHC.Stack
 import Language.Yul
 import Solcore.Desugarer.StructProjection (fieldProjName)
-import Solcore.Diagnostics (CompilerError, compilerErrorText, SourceSpan)
+import Solcore.Diagnostics (CompilerError, SourceSpan, compilerErrorText)
 import Solcore.Frontend.Pretty.ShortName
 import Solcore.Frontend.Pretty.SolcorePretty
 import Solcore.Frontend.Syntax
 import Solcore.Frontend.Syntax.Traversal (everythingButSpans, everywhereButSpans)
+import Solcore.Frontend.TypeInference.CoercionGraph
 import Solcore.Frontend.TypeInference.Id
 import Solcore.Frontend.TypeInference.InvokeGen
 import Solcore.Frontend.TypeInference.NameSupply
-import Solcore.Frontend.TypeInference.CoercionGraph
 import Solcore.Frontend.TypeInference.TcEnv
 import Solcore.Frontend.TypeInference.TcMonad
 import Solcore.Frontend.TypeInference.TcResolution
@@ -1573,9 +1573,9 @@ coercionEdgesInScope =
     itbl <- gets instEnv
     pure
       [ CoercionEdge srcTy tgtTy (Name "")
-        | instList <- Map.elems itbl,
-          (_ :=> InCls cls headTy _) <- instList,
-          Just (srcTy, tgtTy) <- [coercionEdgeOf cls headTy]
+      | instList <- Map.elems itbl,
+        (_ :=> InCls cls headTy _) <- instList,
+        Just (srcTy, tgtTy) <- [coercionEdgeOf cls headTy]
       ]
 
 -- Whether the coercion graph has a path from src to tgt.
@@ -1632,7 +1632,7 @@ tcCheckOrCoerceWith reconcile e expected =
                     (_, _, ti) <- tcExp e
                     ti' <- ((`apply` ti) <$> getSubst) >>= maybeExpandSynonym
                     hasCoercionPath ti' expected'
-                  )
+                )
                   `catchError` \_ -> pure False
               putSubst saved
               if probe
@@ -1685,7 +1685,7 @@ tcReturnOrCoerce (Just rt) e =
                       (_, _, ti) <- tcExp e
                       ti' <- zonkTy ti
                       hasCoercionPath ti' rt'
-                    )
+                  )
                     `catchError` \_ -> pure False
                 putSubst saved
                 if probe
@@ -1807,7 +1807,7 @@ tcCall mExpected Nothing n args =
     (es', pss', ts') <-
       plainArgs `catchError` coerceArgsFallback saved paramTys (\ts'' -> unify t (funtype ts'' t')) args
     -- Resolve any overload from the arguments before the expected result: this
-    -- keeps the expected type from leaking into argument positions 
+    -- keeps the expected type from leaking into argument positions
     -- fixed by its arguments and only its result is reconciled with the context.
     unifyExpectedResult mExpected t'
     let ps' = foldr union [] (ps : pss')

--- a/src/Solcore/Frontend/TypeInference/TcStmt.hs
+++ b/src/Solcore/Frontend/TypeInference/TcStmt.hs
@@ -12,7 +12,7 @@ import Data.Set qualified as Set
 import GHC.Stack
 import Language.Yul
 import Solcore.Desugarer.StructProjection (fieldProjName)
-import Solcore.Diagnostics (SourceSpan)
+import Solcore.Diagnostics (CompilerError, compilerErrorText, SourceSpan)
 import Solcore.Frontend.Pretty.ShortName
 import Solcore.Frontend.Pretty.SolcorePretty
 import Solcore.Frontend.Syntax
@@ -20,6 +20,7 @@ import Solcore.Frontend.Syntax.Traversal (everythingButSpans, everywhereButSpans
 import Solcore.Frontend.TypeInference.Id
 import Solcore.Frontend.TypeInference.InvokeGen
 import Solcore.Frontend.TypeInference.NameSupply
+import Solcore.Frontend.TypeInference.CoercionGraph
 import Solcore.Frontend.TypeInference.TcEnv
 import Solcore.Frontend.TypeInference.TcMonad
 import Solcore.Frontend.TypeInference.TcResolution
@@ -66,10 +67,11 @@ tcStmtWithExpectedReturn' _ e@(lhs := rhs) =
     (lhs1, ps1, t1) <- tcExp lhs
     s0 <- getSubst
     let expectedRhsTy = apply s0 t1
-    (rhs1, ps2, t2) <- tcExpWithExpected (Just expectedRhsTy) rhs
-    s <- unify t1 t2 `wrapError` e
-    _ <- extSubst s
-    pure (lhs1 := rhs1, apply s $ ps1 ++ ps2, unit)
+    -- Reconcile the rhs with the lhs type via bidirectional unify (the lhs type
+    -- may still be a metavariable), inserting an implicit coercion as a last
+    -- resort when the rhs does not fit a concrete lhs type directly.
+    (rhs1, ps2, _) <- tcCheckOrCoerceWith unify rhs expectedRhsTy `wrapError` e
+    withCurrentSubst (lhs1 := rhs1, ps1 ++ ps2, unit)
 tcStmtWithExpectedReturn' _ e@(Let ct n mt me) =
   do
     (me', psf, tf) <- case (mt, me) of
@@ -78,9 +80,7 @@ tcStmtWithExpectedReturn' _ e@(Let ct n mt me) =
         let bvs = bv t2
         sks <- mapM (const freshTyVar) bvs
         let t' = insts (zip bvs sks) t2
-        (e', ps1, t1) <- tcExpWithExpected (Just t') e1
-        s <- tcmMatch t1 t' `wrapError` e
-        _ <- extSubst s
+        (e', ps1) <- tcCheckOrCoerce e1 t' `wrapError` e
         withCurrentSubst (Just e', ps1, t')
       (Just t, Nothing) -> do
         return (Nothing, [], t)
@@ -102,7 +102,7 @@ tcStmtWithExpectedReturn' _ (StmtExp e) =
     pure (StmtExp e', ps', unit)
 tcStmtWithExpectedReturn' mExpectedReturn (Return e) =
   do
-    (e', ps, t) <- tcExpWithExpected mExpectedReturn e
+    (e', ps, t) <- tcReturnOrCoerce mExpectedReturn e
     pure (Return e', ps, t)
 tcStmtWithExpectedReturn' mExpectedReturn (Match es eqns) =
   do
@@ -389,17 +389,23 @@ tcExpWithExpected' mExpected e@(Con n es) =
         pure ()
     expectedArgTys' <- withCurrentSubst expectedArgTys
     -- typing parameters with expected constructor argument types
-    (es', pss, ts) <-
-      unzip3
-        <$> zipWithM
-          (\arg expectedTy -> tcExpWithExpected (Just expectedTy) arg)
-          es
-          expectedArgTys'
-    -- unifying inferred parameter types
-    s <- unify (funtype ts t') t `wrapError` e
-    _ <- extSubst s
+    saved <- getSubst
+    let plainArgs =
+          do
+            (es', pss, ts) <-
+              unzip3
+                <$> zipWithM
+                  (\arg expectedTy -> tcExpWithExpected (Just expectedTy) arg)
+                  es
+                  expectedArgTys'
+            -- unifying inferred parameter types
+            s <- unify (funtype ts t') t `wrapError` e
+            _ <- extSubst s
+            pure (es', pss, ts)
+    (es', pss, _) <-
+      plainArgs `catchError` coerceArgsFallback saved expectedArgTys' (\ts'' -> unify (funtype ts'' t') t) es
     -- expand synonyms before extracting type name
-    t'' <- maybeExpandSynonym (apply s t')
+    t'' <- maybeExpandSynonym =<< withCurrentSubst t'
     tn <- typeName t''
     -- checking if the constructor belongs to type tn
     checkConstr tn n'
@@ -466,9 +472,10 @@ tcExpWithExpected' mExpected (Lam args bd _) =
 tcExpWithExpected' _ e1@(TyExp e ty) =
   do
     ty1 <- kindCheck ty `wrapError` e1
-    (e', ps, ty') <- tcExpWithExpected (Just ty1) e
-    s <- tcmMatch ty' ty1
-    _ <- extSubst s
+    -- A type ascription is a checking-mode position against a fixed annotation
+    -- (one-way match reconcile); coerce as a last resort when @e@ does not have
+    -- the annotated type directly.
+    (e', ps, _) <- tcCheckOrCoerceWith tcmMatch e ty1 `wrapError` e1
     withCurrentSubst (TyExp e' ty1, ps, ty1)
 tcExpWithExpected' mExpected e@(Cond e1 e2 e3) =
   do
@@ -1549,6 +1556,236 @@ unifyExpectedResult (Just expectedTy) resultTy =
     s <- unify resultTy expectedTy'
     void $ extSubst s
 
+-- Implicit coercions: checking-mode insertion.
+-- In a checking position, where the expected type is fully known and concrete,
+-- if an expression's type does not match the expected type but the coercion
+-- graph (built from the Coerce instances in scope) has a path between them, the
+-- expression is wrapped in the library coercion
+-- Coerce.coerce(Pair(e, Proxy : Proxy(T))) and re-checked. Firing only against
+-- a concrete target and only after the plain check has failed keeps this a last
+-- resort that cannot change an already well-typed program.
+
+-- The coercion edges currently in scope, read off the Coerce instances in the
+-- instance environment.
+coercionEdgesInScope :: TcM [CoercionEdge]
+coercionEdgesInScope =
+  do
+    itbl <- gets instEnv
+    pure
+      [ CoercionEdge srcTy tgtTy (Name "")
+        | instList <- Map.elems itbl,
+          (_ :=> InCls cls headTy _) <- instList,
+          Just (srcTy, tgtTy) <- [coercionEdgeOf cls headTy]
+      ]
+
+-- Whether the coercion graph has a path from src to tgt.
+hasCoercionPath :: Ty -> Ty -> TcM Bool
+hasCoercionPath src tgt =
+  do
+    edges <- coercionEdgesInScope
+    pure $ case buildCoercionGraph edges of
+      Left _ -> False
+      Right g -> isJust (canonicalCoercionPath g src tgt)
+
+-- Apply the current substitution and expand any synonym, i.e. the fully
+-- resolved form of a type as currently known.
+zonkTy :: Ty -> TcM Ty
+zonkTy ty = ((`apply` ty) <$> getSubst) >>= maybeExpandSynonym
+
+-- The source-level coercion wrapper Coerce.coerce(Pair(e, Proxy : Proxy(tgt))).
+mkCoerceExp :: Exp Name -> Ty -> Exp Name
+mkCoerceExp e tgt =
+  Call
+    Nothing
+    (QualName (Name "Coerce") "coerce")
+    [Con (Name "Pair") [e, TyExp (Con (Name "Proxy") []) (TyCon (Name "Proxy") [tgt])]]
+
+-- Check e against expected; if the plain check fails but expected is a
+-- fully-determined concrete type reachable from e's inferred type in the
+-- coercion graph, wrap e in the coercion and re-check instead of failing.
+--
+-- The reconcile strategy decides how the plainly-checked type is tied to
+-- expected: an annotated let uses the one-way tcmMatch (the annotation is
+-- fixed), whereas an argument position uses bidirectional unify (the parameter
+-- type may still be a metavariable). Both share the same coercion fallback.
+tcCheckOrCoerceWith ::
+  (Ty -> Ty -> TcM Subst) -> Exp Name -> Ty -> TcM (Exp Id, [Pred], Ty)
+tcCheckOrCoerceWith reconcile e expected =
+  do
+    saved <- getSubst
+    let plain =
+          do
+            (e', ps, t1) <- tcExpWithExpected (Just expected) e
+            s <- reconcile t1 expected
+            _ <- extSubst s
+            pure (e', ps, t1)
+    plain
+      `catchError` \err ->
+        do
+          putSubst saved
+          expected' <- ((`apply` expected) <$> getSubst) >>= maybeExpandSynonym
+          if not (isTyCon expected')
+            then throwError err
+            else do
+              probe <-
+                ( do
+                    (_, _, ti) <- tcExp e
+                    ti' <- ((`apply` ti) <$> getSubst) >>= maybeExpandSynonym
+                    hasCoercionPath ti' expected'
+                  )
+                  `catchError` \_ -> pure False
+              putSubst saved
+              if probe
+                then do
+                  checkCoercionAmbiguity e expected'
+                  tcExpWithExpected (Just expected') (mkCoerceExp e expected')
+                else throwError err
+
+-- Checking-mode coercion for an annotated @let@ (one-way match reconcile).
+tcCheckOrCoerce :: Exp Name -> Ty -> TcM (Exp Id, [Pred])
+tcCheckOrCoerce e expected =
+  do
+    (e', ps, _) <- tcCheckOrCoerceWith tcmMatch e expected
+    pure (e', ps)
+
+-- Checking-mode coercion for a function-argument position (bidirectional
+-- unify reconcile, since the parameter type may still be a metavariable).
+tcArgCoerce :: Exp Name -> Ty -> TcM (Exp Id, [Pred], Ty)
+tcArgCoerce = tcCheckOrCoerceWith unify
+
+-- Type-check a return expression against the function's declared result
+-- type, inserting an implicit coercion when the returned value does not fit that
+-- (concrete) type directly.
+-- A return is delicate because its type is normally reconciled with the declared
+-- return type LATER, by the function-level unification, which is unique-type /
+-- closure aware (a defunctionalized lambda gets a fresh unique type that must not
+-- be unified with its arrow type here). So this does NOT eagerly reconcile in the
+-- common case. Two situations lead to a coercion, both last resorts:
+--   * the plain check throws outright, an overloaded call resolved at a type
+--     other than a concrete return type, caught and retried through the graph;
+--   * the plain check succeeds but the value's (non-unique) type would not
+--     reconcile with a concrete return type and a coercion path exists.
+-- Otherwise the value is returned unchanged and the later function-level
+-- unification does its usual (unique-type-aware) job, so well-typed and
+-- higher-order returns are unaffected.
+tcReturnOrCoerce :: Maybe Ty -> Exp Name -> TcM (Exp Id, [Pred], Ty)
+tcReturnOrCoerce Nothing e = tcExp e
+tcReturnOrCoerce (Just rt) e =
+  do
+    saved <- getSubst
+    let coerceFrom err =
+          do
+            putSubst saved
+            rt' <- zonkTy rt
+            if not (isTyCon rt')
+              then throwError err
+              else do
+                probe <-
+                  ( do
+                      (_, _, ti) <- tcExp e
+                      ti' <- zonkTy ti
+                      hasCoercionPath ti' rt'
+                    )
+                    `catchError` \_ -> pure False
+                putSubst saved
+                if probe
+                  then do
+                    checkCoercionAmbiguity e rt'
+                    tcExpWithExpected (Just rt') (mkCoerceExp e rt')
+                  else throwError err
+    mplain <- (Right <$> tcExpWithExpected (Just rt) e) `catchError` (pure . Left)
+    case mplain of
+      Left err -> coerceFrom err
+      Right (e', ps, t) ->
+        do
+          rt' <- zonkTy rt
+          afterPlain <- getSubst
+          reconciles <-
+            (True <$ (unify t rt' >>= extSubst)) `catchError` \_ -> pure False
+          putSubst afterPlain
+          t' <- zonkTy t
+          unique <- or <$> mapM isUniqueTyName (tyconNames t')
+          if reconciles || unique || not (isTyCon rt')
+            then pure (e', ps, t)
+            else do
+              hasPath <- hasCoercionPath t' rt' `catchError` \_ -> pure False
+              if not hasPath
+                then pure (e', ps, t)
+                else do
+                  putSubst saved
+                  checkCoercionAmbiguity e rt'
+                  tcExpWithExpected (Just rt') (mkCoerceExp e rt')
+
+-- Last-resort argument coercion for a call whose plain argument elaboration
+-- failed. Restores the saved substitution, then re-checks each argument against
+-- its parameter type with a coercion fallback (tcArgCoerce). If every argument
+-- checks and the resulting argument types still reconcile with the function type
+-- (via reconcile), returns the (possibly coerced) arguments; otherwise
+-- re-raises the ORIGINAL type error, so enabling coercions never degrades an
+-- existing diagnostic. Because it engages only after the plain elaboration has
+-- already failed, a well-typed call is elaborated exactly as before.
+coerceArgsFallback ::
+  Subst ->
+  [Ty] ->
+  ([Ty] -> TcM Subst) ->
+  [Exp Name] ->
+  CompilerError ->
+  TcM ([Exp Id], [[Pred]], [Ty])
+coerceArgsFallback saved paramTys reconcile args err =
+  do
+    putSubst saved
+    let attempt =
+          do
+            rs <- zipWithM tcArgCoerce args paramTys
+            let (es', pss', ts') = unzip3 rs
+            s <- reconcile ts'
+            _ <- extSubst s
+            pure (es', pss', ts')
+    attempt
+      `catchError` \err2 ->
+        do
+          putSubst saved
+          -- A deliberate coercion-coherence rejection (the ambivalence error) must
+          -- surface; only a genuine "no coercion applies" failure falls back to the
+          -- original type error so an existing diagnostic is never degraded.
+          if coercionAmbiguityMarker `isInfixOf` compilerErrorText err2
+            then throwError err2
+            else throwError err
+
+-- Reject the coercion/overload ambivalence. We are
+-- about to coerce the RESULT of e to tgt. If e is a call whose ARGUMENTS
+-- could instead be coerced to tgt so the call resolves (possibly at a
+-- different overload) directly at tgt, then coercing the result and coercing
+-- the arguments are two competing elaborations with potentially different
+-- meaning, an ambiguity we reject rather than silently pick, asking for an
+-- explicit conversion. The check is speculative and state-isolated, and only
+-- runs when a coercion is already being inserted, so well-typed programs are
+-- unaffected.
+-- A stable phrase identifying the coercion-ambivalence rejection, so that the
+-- argument-coercion fallback can tell a deliberate coherence rejection apart from
+-- an ordinary "no coercion applies" failure and let the former surface.
+coercionAmbiguityMarker :: String
+coercionAmbiguityMarker = "ambiguous implicit coercion around an overloaded call"
+
+checkCoercionAmbiguity :: Exp Name -> Ty -> TcM ()
+checkCoercionAmbiguity e tgt =
+  case e of
+    Call me op args@(_ : _) ->
+      do
+        saved <- getSubst
+        let alt = Call me op (map (`mkCoerceExp` tgt) args)
+        altOk <-
+          (True <$ tcExpWithExpected (Just tgt) alt) `catchError` \_ -> pure False
+        putSubst saved
+        when altOk $
+          tcmError $
+            unlines
+              [ coercionAmbiguityMarker ++ ":",
+                "coercing its result and coercing its arguments select different overloads;",
+                "write the conversion explicitly."
+              ]
+    _ -> pure ()
+
 tcCall :: Maybe Ty -> Maybe (Exp Name) -> Name -> [Exp Name] -> TcM (Exp Id, [Pred], Ty)
 tcCall mExpected Nothing n args =
   do
@@ -1558,11 +1795,21 @@ tcCall mExpected Nothing n args =
     expectedArgTys <- mapM (const freshTyVar) args
     s0 <- unify t (funtype expectedArgTys t')
     _ <- extSubst s0
-    unifyExpectedResult mExpected t'
+    saved <- getSubst
+    let paramTys = apply s0 expectedArgTys
+        plainArgs =
+          do
+            (es', pss', ts') <-
+              unzip3 <$> zipWithM (\e expectedTy -> tcExpWithExpected (Just expectedTy) e) args paramTys
+            s1 <- unify t (funtype ts' t')
+            _ <- extSubst s1
+            pure (es', pss', ts')
     (es', pss', ts') <-
-      unzip3 <$> zipWithM (\e expectedTy -> tcExpWithExpected (Just expectedTy) e) args (apply s0 expectedArgTys)
-    s1 <- unify t (funtype ts' t')
-    _ <- extSubst s1
+      plainArgs `catchError` coerceArgsFallback saved paramTys (\ts'' -> unify t (funtype ts'' t')) args
+    -- Resolve any overload from the arguments before the expected result: this
+    -- keeps the expected type from leaking into argument positions 
+    -- fixed by its arguments and only its result is reconciled with the context.
+    unifyExpectedResult mExpected t'
     let ps' = foldr union [] (ps : pss')
         t1 = funtype ts' t'
     withCurrentSubst (Call Nothing (Id n t1) es', ps', t')
@@ -1575,11 +1822,20 @@ tcCall mExpected (Just e) n args =
     expectedArgTys <- mapM (const freshTyVar) args
     s0 <- unify (foldr (:->) t' expectedArgTys) t
     _ <- extSubst s0
+    saved <- getSubst
+    let paramTys = apply s0 expectedArgTys
+        plainArgs =
+          do
+            (es', pss', ts') <-
+              unzip3 <$> zipWithM (\arg expectedTy -> tcExpWithExpected (Just expectedTy) arg) args paramTys
+            s' <- unify (foldr (:->) t' ts') t
+            _ <- extSubst s'
+            pure (es', pss', ts')
+    (es', pss', _) <-
+      plainArgs `catchError` coerceArgsFallback saved paramTys (\ts'' -> unify (foldr (:->) t' ts'') t) args
+    -- See the unqualified branch: resolve the overload from the arguments before
+    -- reconciling the result with the expected type.
     unifyExpectedResult mExpected t'
-    (es', pss', ts') <-
-      unzip3 <$> zipWithM (\arg expectedTy -> tcExpWithExpected (Just expectedTy) arg) args (apply s0 expectedArgTys)
-    s' <- unify (foldr (:->) t' ts') t
-    _ <- extSubst s'
     let ps' = foldr union [] ((ps ++ ps1) : pss')
     withCurrentSubst (Call (Just e') (Id n t') es', ps', t')
 

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -309,7 +309,12 @@ cases :: TestTree
 cases =
   testGroup
     "Files for folder cases"
-    [ runTestForFile "abigeneric.solc" caseFolder,
+    [ runTestForFile "coerce_ok.solc" caseFolder,
+      runTestForFile "coerce_sites_ok.solc" caseFolder,
+      runTestExpectingFailure "coerce_ambiguous.solc" caseFolder,
+      runTestExpectingFailure "coerce_ambiguous_arg.solc" caseFolder,
+      runTestExpectingFailure "coerce_ambiguous_ret.solc" caseFolder,
+      runTestForFile "abigeneric.solc" caseFolder,
       runTestForFile "Ackermann.solc" caseFolder,
       runTestForFile "Add1.solc" caseFolder,
       runTestExpectingFailure "add-moritz.solc" caseFolder,

--- a/test/CoercionGraphTests.hs
+++ b/test/CoercionGraphTests.hs
@@ -1,0 +1,59 @@
+module CoercionGraphTests (coercionGraphTests) where
+
+import Solcore.Frontend.Syntax.Name
+import Solcore.Frontend.Syntax.Ty
+import Solcore.Frontend.TypeInference.CoercionGraph
+import Test.Tasty
+import Test.Tasty.HUnit
+
+-- A ground nullary type constructor, e.g. `uint8`.
+tc :: String -> Ty
+tc n = TyCon (Name n) []
+
+edge :: String -> String -> String -> CoercionEdge
+edge s t w = CoercionEdge (tc s) (tc t) (Name w)
+
+-- Build the graph and resolve the canonical path, collapsing a build failure to
+-- Nothing (the build-failure cases are tested directly below).
+path :: [CoercionEdge] -> String -> String -> Maybe [Name]
+path es s t =
+  case buildCoercionGraph es of
+    Left _ -> Nothing
+    Right g -> canonicalCoercionPath g (tc s) (tc t)
+
+coercionGraphTests :: TestTree
+coercionGraphTests =
+  testGroup
+    "CoercionGraph"
+    [ testCase "edge read off a Coerce head" $
+        coercionEdgeOf
+          (Name "Coerce")
+          (TyCon (Name "Pair") [tc "uint8", TyCon (Name "Proxy") [tc "uint16"]])
+          @?= Just (tc "uint8", tc "uint16"),
+      testCase "a non-Coerce head is not an edge" $
+        coercionEdgeOf (Name "Eq") (tc "uint8") @?= Nothing,
+      testCase "a direct edge is a length-1 path" $
+        path [edge "a" "b" "f"] "a" "b" @?= Just [Name "f"],
+      testCase "two covering edges compose to a 2-step path" $
+        path [edge "a" "b" "f", edge "b" "c" "g"] "a" "c" @?= Just [Name "f", Name "g"],
+      testCase "identity needs no coercion" $
+        path [edge "a" "b" "f"] "a" "a" @?= Just [],
+      testCase "no path yields Nothing" $
+        path [edge "a" "b" "f"] "a" "c" @?= Nothing,
+      testCase "canonical path is the shortest (a direct edge beats a composed one)" $
+        path [edge "a" "b" "f", edge "b" "c" "g", edge "a" "c" "h"] "a" "c" @?= Just [Name "h"],
+      testCase "a diamond resolves deterministically (shortest, tie-broken by node key)" $
+        path
+          [edge "a" "x" "f1", edge "x" "d" "f2", edge "a" "y" "g1", edge "y" "d" "g2"]
+          "a"
+          "d"
+          @?= Just [Name "f1", Name "f2"],
+      testCase "a duplicate edge with different witnesses is rejected (coherence)" $
+        case buildCoercionGraph [edge "a" "b" "f", edge "a" "b" "g"] of
+          Left _ -> pure ()
+          Right _ -> assertFailure "expected duplicate-witness rejection",
+      testCase "a duplicate edge with the same witness is accepted" $
+        case buildCoercionGraph [edge "a" "b" "f", edge "a" "b" "f"] of
+          Right _ -> pure ()
+          Left e -> assertFailure ("unexpected rejection: " ++ e)
+    ]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,6 +1,7 @@
 module Main where
 
 import Cases
+import CoercionGraphTests
 import ContractAbiTests
 import DiagnosticCliTests
 import DiagnosticTests
@@ -22,6 +23,7 @@ tests =
   testGroup
     "Tests"
     [ parserTests,
+      coercionGraphTests,
       yulParserTests,
       cases,
       tabledResolution,

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -633,6 +633,72 @@ declTests =
                   ]
               )
           ),
+      testCase "coercion keyword desugars to a Coerce instance" $
+        parsesAs
+          topDeclP
+          "coercion small -> big by conv;"
+          ( TInstDef
+              ( Instance
+                  False
+                  []
+                  []
+                  "Coerce"
+                  [TyCon "big" []]
+                  (TyCon "Pair" [TyCon "small" [], TyCon "Proxy" [TyCon "big" []]])
+                  [ FunDef
+                      False
+                      ( Signature
+                          []
+                          []
+                          "coerce"
+                          [Typed False "p" (TyCon "Pair" [TyCon "small" [], TyCon "Proxy" [TyCon "big" []]])]
+                          False
+                          (Just (TyCon "big" []))
+                          False
+                      )
+                      [ Match
+                          [var "p"]
+                          [ ( [Pat "Pair" [Pat "x" [], PWildcard]],
+                              [Return (ExpName Nothing "conv" [var "x"])]
+                            )
+                          ]
+                      ]
+                  ]
+              )
+          ),
+      testCase "coercion keyword with a forall prefix and context" $
+        parsesAs
+          topDeclP
+          "forall a. a:Eq => coercion box(a) -> a by unbox;"
+          ( TInstDef
+              ( Instance
+                  False
+                  [TyCon "a" []]
+                  [InCls "Eq" (TyCon "a" []) []]
+                  "Coerce"
+                  [TyCon "a" []]
+                  (TyCon "Pair" [TyCon "box" [TyCon "a" []], TyCon "Proxy" [TyCon "a" []]])
+                  [ FunDef
+                      False
+                      ( Signature
+                          []
+                          []
+                          "coerce"
+                          [Typed False "p" (TyCon "Pair" [TyCon "box" [TyCon "a" []], TyCon "Proxy" [TyCon "a" []]])]
+                          False
+                          (Just (TyCon "a" []))
+                          False
+                      )
+                      [ Match
+                          [var "p"]
+                          [ ( [Pat "Pair" [Pat "x" [], PWildcard]],
+                              [Return (ExpName Nothing "unbox" [var "x"])]
+                            )
+                          ]
+                      ]
+                  ]
+              )
+          ),
       testCase "empty contract" $
         parsesAs
           topDeclP

--- a/test/examples/cases/coerce_ambiguous.solc
+++ b/test/examples/cases/coerce_ambiguous.solc
@@ -1,0 +1,47 @@
+import std.{*};
+import std.dispatch.{*};
+import std.coerce.{*};
+
+data A = A1 | A2;
+data B = B1 | B2 | B3;
+
+function cAB(x : A) -> B {
+  match x {
+    | A.A1 => return B.B1;
+    | A.A2 => return B.B2;
+  }
+}
+
+// Declared with the surface `coercion` keyword (desugars to the Coerce instance).
+coercion A -> B by cAB;
+
+forall t . class t : Op {
+  function op(x : t, y : t) -> t;
+}
+
+instance A : Op {
+  function op(x : A, y : A) -> A {
+    match x {
+      | A.A1 => return A.A1;
+      | A.A2 => return A.A2;
+    }
+  }
+}
+
+instance B : Op {
+  function op(x : B, y : B) -> B {
+    match x {
+      | B.B1 => return B.B3;
+      | B.B2 => return B.B2;
+      | B.B3 => return B.B1;
+    }
+  }
+}
+
+contract C {
+  constructor() {}
+  public function test() -> B {
+    let r : B = Op.op(A.A1, A.A2);
+    return r;
+  }
+}

--- a/test/examples/cases/coerce_ambiguous_arg.solc
+++ b/test/examples/cases/coerce_ambiguous_arg.solc
@@ -1,0 +1,56 @@
+import std.{*};
+import std.dispatch.{*};
+import std.coerce.{*};
+
+data A = A1 | A2;
+data B = B1 | B2 | B3;
+
+function cAB(x : A) -> B {
+  match x {
+    | A.A1 => return B.B1;
+    | A.A2 => return B.B2;
+  }
+}
+
+instance Pair(A, Proxy(B)) : Coerce(B) {
+  function coerce(p : Pair(A, Proxy(B))) -> B {
+    match p {
+      | Pair(x, _) => return cAB(x);
+    }
+  }
+}
+
+forall t . class t : Op {
+  function op(x : t, y : t) -> t;
+}
+
+instance A : Op {
+  function op(x : A, y : A) -> A {
+    match x {
+      | A.A1 => return A.A1;
+      | A.A2 => return A.A2;
+    }
+  }
+}
+
+instance B : Op {
+  function op(x : B, y : B) -> B {
+    match x {
+      | B.B1 => return B.B3;
+      | B.B2 => return B.B2;
+      | B.B3 => return B.B1;
+    }
+  }
+}
+
+function sink(x : B) -> B {
+  return x;
+}
+
+contract C {
+  constructor() {}
+  public function test() -> B {
+    // Argument-position ambivalence: sink expects B, Op.op(A1,A2) is an A.
+    return sink(Op.op(A.A1, A.A2));
+  }
+}

--- a/test/examples/cases/coerce_ambiguous_ret.solc
+++ b/test/examples/cases/coerce_ambiguous_ret.solc
@@ -1,0 +1,57 @@
+import std.{*};
+import std.dispatch.{*};
+import std.coerce.{*};
+
+data A = A1 | A2;
+data B = B1 | B2 | B3;
+
+function cAB(x : A) -> B {
+  match x {
+    | A.A1 => return B.B1;
+    | A.A2 => return B.B2;
+  }
+}
+
+instance Pair(A, Proxy(B)) : Coerce(B) {
+  function coerce(p : Pair(A, Proxy(B))) -> B {
+    match p {
+      | Pair(x, _) => return cAB(x);
+    }
+  }
+}
+
+forall t . class t : Op {
+  function op(x : t, y : t) -> t;
+}
+
+instance A : Op {
+  function op(x : A, y : A) -> A {
+    match x {
+      | A.A1 => return A.A1;
+      | A.A2 => return A.A2;
+    }
+  }
+}
+
+instance B : Op {
+  function op(x : B, y : B) -> B {
+    match x {
+      | B.B1 => return B.B3;
+      | B.B2 => return B.B2;
+      | B.B3 => return B.B1;
+    }
+  }
+}
+
+// Return-position ambivalence: coercing the RESULT of Op.op to B, or coercing
+// its ARGUMENTS to B and resolving Op@B, select different overloads. Rejected.
+function retAmb() -> B {
+  return Op.op(A.A1, A.A2);
+}
+
+contract C {
+  constructor() {}
+  public function test() -> B {
+    return retAmb();
+  }
+}

--- a/test/examples/cases/coerce_ok.solc
+++ b/test/examples/cases/coerce_ok.solc
@@ -1,0 +1,16 @@
+import std.{*};
+import std.dispatch.{*};
+import std.coerce.{*};
+
+// Implicit coercions in checking positions (annotated let). These previously
+// were type errors; the compiler now inserts the library coercion.
+contract C {
+    constructor() {}
+
+    public function widen() -> uint256 {
+        let a : uint8 = uint8(200);
+        let r : uint16 = a;         // implicit uint8 -> uint16
+        let s : uint256 = a;        // implicit uint8 -> uint256 (across the ladder)
+        return uint256(Typedef.rep(r)) + uint256(Typedef.rep(s));
+    }
+}

--- a/test/examples/cases/coerce_sites_ok.solc
+++ b/test/examples/cases/coerce_sites_ok.solc
@@ -1,0 +1,27 @@
+import std.{*};
+import std.dispatch.{*};
+import std.coerce.{*};
+
+data Box = MkBox(uint256);
+
+// return-position: uint8 returned where uint256 is declared.
+function retSite(a : uint8) -> uint256 {
+  return a;
+}
+
+// type-ascription: (a : uint256) where a : uint8.
+function ascriptionSite(a : uint8) -> uint256 {
+  return (a : uint256);
+}
+
+// assignment: r : uint256 assigned a uint8.
+function assignSite(a : uint8) -> uint256 {
+  let r : uint256 = uint256(0);
+  r = a;
+  return r;
+}
+
+// constructor argument: MkBox expects uint256, given a uint8.
+function conSite(a : uint8) -> Box {
+  return Box.MkBox(a);
+}

--- a/test/examples/dispatch/coerce_implicit.json
+++ b/test/examples/dispatch/coerce_implicit.json
@@ -1,0 +1,64 @@
+{
+  "coerce_implicit": {
+    "bytecode": "",
+    "contract": "C",
+    "tests": [
+      {
+        "input": {
+          "comment": "ctor",
+          "calldata": "",
+          "value": "0"
+        },
+        "kind": "constructor"
+      },
+      {
+        "input": {
+          "comment": "u8->u16 let",
+          "calldata": "3b54f0b2",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "status": "success",
+          "returndata": "00000000000000000000000000000000000000000000000000000000000000c8"
+        }
+      },
+      {
+        "input": {
+          "comment": "u8->u256 let",
+          "calldata": "1118781f",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "status": "success",
+          "returndata": "00000000000000000000000000000000000000000000000000000000000000c8"
+        }
+      },
+      {
+        "input": {
+          "comment": "same",
+          "calldata": "9146a4d5",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "status": "success",
+          "returndata": "0000000000000000000000000000000000000000000000000000000000000007"
+        }
+      },
+      {
+        "input": {
+          "comment": "u8->u256 at a function-argument position",
+          "calldata": "904fa02a",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "status": "success",
+          "returndata": "00000000000000000000000000000000000000000000000000000000000000c8"
+        }
+      }
+    ]
+  }
+}

--- a/test/examples/dispatch/coerce_implicit.solc
+++ b/test/examples/dispatch/coerce_implicit.solc
@@ -1,0 +1,40 @@
+import std.{*};
+import std.dispatch.{*};
+import std.coerce.{*};
+
+contract C {
+    constructor() {}
+
+    // IMPLICIT coercion at an annotated let: a : uint8 used where uint16 is expected.
+    public function u8_to_u16() -> uint256 {
+        let a : uint8 = uint8(200);
+        let r : uint16 = a;                 // <-- should insert coerce(a)
+        return uint256(Typedef.rep(r));
+    }
+
+    // IMPLICIT across the ladder: uint8 -> uint256 (direct instance in the closure).
+    public function u8_to_u256() -> uint256 {
+        let a : uint8 = uint8(200);
+        let r : uint256 = a;                // <-- should insert coerce(a)
+        return uint256(Typedef.rep(r));
+    }
+
+    // control: no coercion needed (types already agree) must be unchanged.
+    public function same() -> uint256 {
+        let a : uint256 = uint256(7);
+        let r : uint256 = a;
+        return uint256(Typedef.rep(r));
+    }
+
+    // A helper that expects a uint256 argument.
+    function widen(x : uint256) -> uint256 {
+        return x;
+    }
+
+    // IMPLICIT coercion at a function-ARGUMENT position: a : uint8 passed where
+    // widen expects uint256. The argument should be coerced automatically.
+    public function arg_coerce() -> uint256 {
+        let a : uint8 = uint8(200);
+        return uint256(Typedef.rep(widen(a)));
+    }
+}

--- a/test/examples/dispatch/coerce_keyword.json
+++ b/test/examples/dispatch/coerce_keyword.json
@@ -1,0 +1,28 @@
+{
+  "coerce_keyword": {
+    "bytecode": "",
+    "contract": "C",
+    "tests": [
+      {
+        "input": {
+          "comment": "ctor",
+          "calldata": "",
+          "value": "0"
+        },
+        "kind": "constructor"
+      },
+      {
+        "input": {
+          "comment": "coercion Small -> Big declared with the surface keyword, inserted at a let",
+          "calldata": "0f59f83a",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "status": "success",
+          "returndata": "000000000000000000000000000000000000000000000000000000000000002a"
+        }
+      }
+    ]
+  }
+}

--- a/test/examples/dispatch/coerce_keyword.solc
+++ b/test/examples/dispatch/coerce_keyword.solc
@@ -1,0 +1,27 @@
+import std.{*};
+import std.dispatch.{*};
+import std.coerce.{*};
+
+data Small = S(uint256);
+data Big = B(uint256);
+
+function smallToBig(x : Small) -> Big {
+  match x {
+    | Small.S(v) => return Big.B(v);
+  }
+}
+
+// Surface syntax for an implicit coercion, desugared to a Coerce instance.
+coercion Small -> Big by smallToBig;
+
+contract C {
+  constructor() {}
+
+  public function go() -> uint256 {
+    let s : Small = Small.S(42);
+    let b : Big = s;                 // implicit coercion via the declared `coercion`
+    match b {
+      | Big.B(v) => return uint256(Typedef.rep(v));
+    }
+  }
+}

--- a/test/examples/dispatch/coerce_sites.json
+++ b/test/examples/dispatch/coerce_sites.json
@@ -1,0 +1,64 @@
+{
+  "coerce_sites": {
+    "bytecode": "",
+    "contract": "C",
+    "tests": [
+      {
+        "input": {
+          "comment": "ctor",
+          "calldata": "",
+          "value": "0"
+        },
+        "kind": "constructor"
+      },
+      {
+        "input": {
+          "comment": "return-position coercion uint8 -> uint256",
+          "calldata": "a84255c1",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "status": "success",
+          "returndata": "00000000000000000000000000000000000000000000000000000000000000c8"
+        }
+      },
+      {
+        "input": {
+          "comment": "type-ascription coercion uint8 -> uint256",
+          "calldata": "926d1923",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "status": "success",
+          "returndata": "00000000000000000000000000000000000000000000000000000000000000c8"
+        }
+      },
+      {
+        "input": {
+          "comment": "assignment coercion uint8 -> uint256",
+          "calldata": "05cf3cbf",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "status": "success",
+          "returndata": "00000000000000000000000000000000000000000000000000000000000000c8"
+        }
+      },
+      {
+        "input": {
+          "comment": "constructor-argument coercion uint8 -> uint256",
+          "calldata": "6708827b",
+          "value": "0"
+        },
+        "kind": "call",
+        "output": {
+          "status": "success",
+          "returndata": "00000000000000000000000000000000000000000000000000000000000000c8"
+        }
+      }
+    ]
+  }
+}

--- a/test/examples/dispatch/coerce_sites.solc
+++ b/test/examples/dispatch/coerce_sites.solc
@@ -1,0 +1,46 @@
+import std.{*};
+import std.dispatch.{*};
+import std.coerce.{*};
+
+data Box = MkBox(uint256);
+
+function unbox(b : Box) -> uint256 {
+    match b {
+      | Box.MkBox(x) => return x;
+    }
+}
+
+contract C {
+    constructor() {}
+
+    // return-position coercion: a : uint8 returned where uint256 is expected.
+    public function ret_coerce() -> uint256 {
+        let a : uint8 = uint8(200);
+        return uint256(Typedef.rep(a_to_u256(a)));
+    }
+
+    function a_to_u256(a : uint8) -> uint256 {
+        return a;                              // <-- return-site coercion uint8 -> uint256
+    }
+
+    // type-ascription coercion: (a : uint256) where a : uint8.
+    public function ascription_coerce() -> uint256 {
+        let a : uint8 = uint8(200);
+        return uint256(Typedef.rep((a : uint256)));   // <-- TyExp-site coercion
+    }
+
+    // assignment coercion: r starts uint256, assigned a uint8.
+    public function assign_coerce() -> uint256 {
+        let a : uint8 = uint8(200);
+        let r : uint256 = uint256(0);
+        r = a;                                 // <-- assignment-site coercion uint8 -> uint256
+        return uint256(Typedef.rep(r));
+    }
+
+    // constructor-argument coercion: MkBox expects uint256, given a uint8.
+    public function con_coerce() -> uint256 {
+        let a : uint8 = uint8(200);
+        let b : Box = Box.MkBox(a);            // <-- Con-arg-site coercion uint8 -> uint256
+        return uint256(Typedef.rep(unbox(b)));
+    }
+}


### PR DESCRIPTION
* Initial implementation of implicit coercions mechanism. Now, only one coercion path is accepted. Ambiguous coercions in overloaded symbols are rejected.